### PR TITLE
[Fix] Fixed issue related to visible cards on the profile page

### DIFF
--- a/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import ProfileCardsView from "./ProfileCardsView";
 import axios from "axios";
 import config from "../../config";
@@ -9,11 +10,14 @@ function ProfileCards(props) {
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
 
+  //useParams returns an object of key/value pairs from URL parameters
+  const { id } = useParams();
+  const urlID = id;
+
   // get user profile for hidden cards value
   const getProfileInfo = async () => {
     try {
-      let url =
-        backendAddress + "api/profile/" + localStorage.getItem("userId");
+      let url = backendAddress + "api/profile/" + urlID;
       let result = await axios.get(url);
       return await setProfileInfo(result.data);
     } catch (error) {

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -30,8 +30,7 @@ function ProfileCardsView(props) {
     // Update visibleCards state in profile
     try {
       // Get current card visibility status from db
-      let url =
-        backendAddress + "api/profile/" + localStorage.getItem("userId");
+      let url = backendAddress + "api/profile/" + urlID;
       let result = await axios.get(url);
       let visibleCards = result.data.visibleCards;
 
@@ -41,10 +40,9 @@ function ProfileCardsView(props) {
       setDisabled(visibleCards[cardNameToBeModified]);
 
       // save toggle value in db
-      await axios.put(
-        backendAddress + "api/profile/" + localStorage.getItem("userId"),
-        { visibleCards }
-      );
+      await axios.put(backendAddress + "api/profile/" + urlID, {
+        visibleCards,
+      });
     } catch (error) {
       console.log(error);
     }
@@ -131,6 +129,7 @@ function ProfileCardsView(props) {
       },
     };
   }
+
   return (
     <div>
       <Card


### PR DESCRIPTION
- Problem: whether you are on your own profile or not, we are using current user data to display the cards.
- Solution: fixed it by using the urlID (which changes dynamically depending on whose profile is being look at) instead of always using the same locolstorageId.