### PR TITLE
[FIX] Limiting duplicate values in skills and categories tables

### DIFF
--- a/services/backend/migrations/20191030200718-create-category.js
+++ b/services/backend/migrations/20191030200718-create-category.js
@@ -1,31 +1,47 @@
-'use strict';
+"use strict";
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable('categories', {
-      id: {
-        type: Sequelize.INTEGER,
-        allowNull: false,
-        primaryKey: true,
-        autoIncrement: true // initial value 0.. skills id is set to the associated number
-        // need to figure out if 1) important to have 
-      },
-      descriptionEn: {
-        type: Sequelize.STRING
-      },
-      descriptionFr: {
-        type: Sequelize.STRING
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      }
+  up: async (queryInterface, Sequelize) => {
+    return await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.createTable(
+        "categories",
+        {
+          id: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            autoIncrement: true, // initial value 0.. skills id is set to the associated number
+            // need to figure out if 1) important to have
+          },
+          descriptionEn: {
+            type: Sequelize.STRING,
+          },
+          descriptionFr: {
+            type: Sequelize.STRING,
+          },
+          createdAt: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+          updatedAt: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+        },
+        transaction
+      );
+      // admin user cannot enter a category description if the combination of french and english text already exists in the table
+      await queryInterface.addConstraint(
+        "categories",
+        ["descriptionEn", "descriptionFr"],
+        {
+          type: "unique",
+          name: "categories_unique_definition",
+          transaction,
+        }
+      );
     });
   },
   down: (queryInterface, Sequelize) => {
-    return queryInterface.dropTable('categories');
-  }
+    return queryInterface.dropTable("categories");
+  },
 };

--- a/services/backend/migrations/20191030200719-create-skill.js
+++ b/services/backend/migrations/20191030200719-create-skill.js
@@ -1,41 +1,58 @@
 "use strict";
 module.exports = {
-  up: (queryInterface, Sequelize) => {
-    return queryInterface.createTable("skills", {
-      id: {
-        allowNull: false,
-        primaryKey: true,
-        type: Sequelize.UUID,
-        defaultValue: Sequelize.literal("uuid_generate_v1()")
-      },
-      descriptionEn: {
-        type: Sequelize.STRING
-      },
-      descriptionFr: {
-        type: Sequelize.STRING
-      },
-      type: {
-        type: Sequelize.STRING
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE
-      },
-      categoryId:{ // addition of category foreign key
-        type: Sequelize.INTEGER,
-        allowNull: false, // a skill must belong to a category
-        references:{
-          model: "categories",
-          key: "id"
+  up: async (queryInterface, Sequelize) => {
+    return await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.createTable(
+        "skills",
+        {
+          id: {
+            allowNull: false,
+            primaryKey: true,
+            type: Sequelize.UUID,
+            defaultValue: Sequelize.literal("uuid_generate_v1()"),
+          },
+          descriptionEn: {
+            type: Sequelize.STRING,
+          },
+          descriptionFr: {
+            type: Sequelize.STRING,
+          },
+          type: {
+            type: Sequelize.STRING,
+          },
+          createdAt: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+          updatedAt: {
+            allowNull: false,
+            type: Sequelize.DATE,
+          },
+          categoryId: {
+            // addition of category foreign key
+            type: Sequelize.INTEGER,
+            allowNull: false, // a skill must belong to a category
+            references: {
+              model: "categories",
+              key: "id",
+            },
+          },
+        },
+        transaction
+      );
+      // admin user cannot enter a skill description if the combination of french and english text already exists in the table
+      await queryInterface.addConstraint(
+        "skills",
+        ["descriptionEn", "descriptionFr"],
+        {
+          type: "unique",
+          name: "skills_unique_definition",
+          transaction,
         }
-      }
+      );
     });
   },
   down: (queryInterface, Sequelize) => {
     return queryInterface.dropTable("skills");
-  }
+  },
 };


### PR DESCRIPTION
Adding constraint on english and french description so that users cannot enter values that are already present in the table

Changes were only made to migration files for these tables

_NOTE: Frontend changes related to these constraints need to be made in admin view_