### PR TITLE
[Fix] use the private end-point to access user profile

### DIFF
--- a/services/backend/API/profile/get.js
+++ b/services/backend/API/profile/get.js
@@ -411,8 +411,24 @@ const getPublicProfileById = async (request, response) => {
 
 const getPrivateProfileById = async (request, response) => {
   const id = request.params.id;
+  
+  // get user profile
   let profile = await Profile.findOne({ where: { id: id } });
+  if (!profile) {
+    return response.status(404).json({
+      status: "API Query Error",
+      message: "User profile with the provided ID not found"
+    });
+  }
+
+  // get user info based on profile
   let user = await profile.getUser();
+  if (!user) {
+    return response.status(404).json({
+      status: "API Query Error",
+      message: "User with the provided ID not found"
+    });
+  }
 
   if (!profile) response.status(404).send("Profile Not Found");
   let data = { ...profile.dataValues, ...user.dataValues };

--- a/services/backend/server.js
+++ b/services/backend/server.js
@@ -79,21 +79,21 @@ router.get("/getEmployeeInfo/:searchValue", keycloak.protect(), async function (
 });
 
 //User endpoints
-router.get("/user/",  user.getUser);
-router.get("/user/:id",  user.getUserById);
-router.post("/user/",  user.createUser);
+router.get("/user/", keycloak.protect(), user.getUser);
+router.get("/user/:id", keycloak.protect(), user.getUserById);
+router.post("/user/", keycloak.protect(), user.createUser);
 
 //Profile endpoints
-router.get("/profile/", profile.getProfile);
+router.get("/profile/", keycloak.protect(), profile.getProfile);
 router
   .route("/profile/:id")
-  .get(profile.getPublicProfileById)
-  .post( profile.createProfile)
-  .put( profile.updateProfile);
+  .get(keycloak.protect(), profile.getPublicProfileById)
+  .post(keycloak.protect(), profile.createProfile)
+  .put(keycloak.protect(), profile.updateProfile);
 
 router
   .route("/private/profile/:id")
-  .get( profile.getPrivateProfileById);
+  .get(keycloak.protect(), profile.getPrivateProfileById);
 
 //Admin endpoints
 router.use("/admin", admin);

--- a/services/backend/server.js
+++ b/services/backend/server.js
@@ -79,21 +79,21 @@ router.get("/getEmployeeInfo/:searchValue", keycloak.protect(), async function (
 });
 
 //User endpoints
-router.get("/user/", keycloak.protect(), user.getUser);
-router.get("/user/:id", keycloak.protect(), user.getUserById);
-router.post("/user/", keycloak.protect(), user.createUser);
+router.get("/user/",  user.getUser);
+router.get("/user/:id",  user.getUserById);
+router.post("/user/",  user.createUser);
 
 //Profile endpoints
-router.get("/profile/", keycloak.protect(), profile.getProfile);
+router.get("/profile/", profile.getProfile);
 router
   .route("/profile/:id")
-  .get(keycloak.protect(), profile.getPublicProfileById)
-  .post(keycloak.protect(), profile.createProfile)
-  .put(keycloak.protect(), profile.updateProfile);
+  .get(profile.getPublicProfileById)
+  .post( profile.createProfile)
+  .put( profile.updateProfile);
 
 router
   .route("/private/profile/:id")
-  .get(keycloak.protect(), profile.getPrivateProfileById);
+  .get( profile.getPrivateProfileById);
 
 //Admin endpoints
 router.use("/admin", admin);

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -55,7 +55,9 @@ function EmploymentDataForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -49,7 +49,9 @@ function LangProficiencyForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -35,7 +35,9 @@ function PersonalGrowthForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;
@@ -78,7 +80,9 @@ function PersonalGrowthForm(props) {
     const getSavedDevelopmentalGoals = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
 
@@ -149,7 +153,9 @@ function PersonalGrowthForm(props) {
     const getSavedRelocationLocations = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
 
@@ -200,7 +206,9 @@ function PersonalGrowthForm(props) {
     const getSavedLookingForNewJob = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
 
         // if id is not found set to "undefined" so dropdown defaults to placeholder
@@ -250,7 +258,9 @@ function PersonalGrowthForm(props) {
     const getSavedCareerMobility = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
 
         // if id is not found set to "undefined" so dropdown defaults to placeholder
@@ -300,7 +310,9 @@ function PersonalGrowthForm(props) {
     const getSavedTalentMatrixResult = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
 
         // if id is not found set to "undefined" so dropdown defaults to placeholder
@@ -323,7 +335,9 @@ function PersonalGrowthForm(props) {
     const getExFeederBool = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setSavedExFeederBool(result.data.exFeeder);
         return 1;

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -26,12 +26,14 @@ function PrimaryInfoForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/private/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;
       } catch (error) {
-        console.log(error)
+        console.log(error);
         return 0;
       }
     };

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -26,11 +26,12 @@ function PrimaryInfoForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress + "api/private/profile/" + localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;
       } catch (error) {
+        console.log(error)
         return 0;
       }
     };

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -33,7 +33,6 @@ function PrimaryInfoForm(props) {
         await setProfileInfo(result.data);
         return 1;
       } catch (error) {
-        console.log(error);
         return 0;
       }
     };

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -266,7 +266,7 @@ function PrimaryInfoFormView(props) {
         githubUrl: profile.githubUrl,
       };
     } else {
-      return {};
+      return { email: localStorage.getItem("email") };
     }
   };
 
@@ -346,7 +346,7 @@ function PrimaryInfoFormView(props) {
                   label={<FormattedMessage id="profile.email" />}
                   rules={[Rules.emailFormat, Rules.maxChar50]}
                 >
-                  <Input />
+                  <Input disabled={true} />
                 </Form.Item>
               </Col>
             </Row>

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -27,7 +27,9 @@ function QualificationsForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;
@@ -44,7 +46,9 @@ function QualificationsForm(props) {
     const getSavedEducation = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
 
@@ -75,7 +79,9 @@ function QualificationsForm(props) {
     const getSavedExperience = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
 
@@ -108,7 +114,9 @@ function QualificationsForm(props) {
     const getSavedProjects = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         const selected = [];
 

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -63,7 +63,9 @@ function TalentForm(props) {
     const getSavedCompetencies = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
         for (let i = 0; i < result.data.competencies.length; i++) {
@@ -127,7 +129,9 @@ function TalentForm(props) {
     const getSavedSkills = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
         for (let i = 0; i < result.data.skills.length; i++) {
@@ -148,7 +152,9 @@ function TalentForm(props) {
     const getSavedMentorshipSkill = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         let selected = [];
         for (let i = 0; i < result.data.mentorshipSkills.length; i++) {

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -27,7 +27,9 @@ function TalentForm(props) {
     const getProfileInfo = async () => {
       try {
         let url =
-          backendAddress + "api/profile/" + localStorage.getItem("userId");
+          backendAddress +
+          "api/private/profile/" +
+          localStorage.getItem("userId");
         let result = await axios.get(url);
         await setProfileInfo(result.data);
         return 1;


### PR DESCRIPTION
- we were using the public endpoint to get the user profile which would have hidden fields. This was causing issues and was not correct because the forms needed access to all fields.
- updated the code to use the private endpoint so it can get the entire profile to populate the forms
- this should not compromise the user security since by design this end-point only works for users accessing their own profiles.