### PR TITLE
[Fix] Potential fix for initial login

### DIFF
--- a/services/frontend-v3/src/routes/Secured.js
+++ b/services/frontend-v3/src/routes/Secured.js
@@ -64,7 +64,10 @@ function Secured(props) {
       })
       .then((authenticated) => {
         // check if user is admin
-        if (keycloak.tokenParsed.resource_access["upskill-client"]) {
+        if (
+          keycloak.tokenParsed.resource_access &&
+          keycloak.tokenParsed.resource_access["upskill-client"]
+        ) {
           sessionStorage.setItem(
             "admin",
             keycloak.tokenParsed.resource_access[


### PR DESCRIPTION
If the user logs in for the first time, there will be an undefined error in the front-end. A simple check to see if the variable has the `resource_access` key fixes it.