### PR TITLE
Add expandable description for job experience items

### DIFF
--- a/services/frontend-v3/src/App.css
+++ b/services/frontend-v3/src/App.css
@@ -60,13 +60,14 @@
   color: rgb(0, 30, 30) !important;
 }
 
-.ant-divider.ant-divider-horizontal.ant-divider-with-text-left::before {
+.results-card-divider.ant-divider.ant-divider-horizontal.ant-divider-with-text-left::before {
   border-top-color: #001c1a !important;
 }
 
-.ant-divider.ant-divider-horizontal.ant-divider-with-text-left::after {
+.results-card-divider.ant-divider.ant-divider-horizontal.ant-divider-with-text-left::after {
   border-top-color: #001c1a !important;
 }
+
 .ant-form-item {
   margin-bottom: 13px !important;
 }

--- a/services/frontend-v3/src/components/experience/Experience.jsx
+++ b/services/frontend-v3/src/components/experience/Experience.jsx
@@ -34,10 +34,11 @@ function Experience(props) {
         const endDate = expElement.endDate;
 
         const experience = {
+          description: expElement.content,
+          duration: getExperienceDuration(startDate, endDate),
           icon: "solution",
           jobTitle: expElement.header,
           organizationName: expElement.subheader,
-          duration: getExperienceDuration(startDate, endDate),
         };
 
         experienceInfo.push(experience);

--- a/services/frontend-v3/src/components/experience/ExperienceView.jsx
+++ b/services/frontend-v3/src/components/experience/ExperienceView.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Row, Col, Avatar, List } from "antd";
-import { ContainerOutlined } from "@ant-design/icons";
+import { Row, Col, List } from "antd";
+import ExperienceItem from "./experienceItem/ExperienceItem";
 
 function ExperienceView(props) {
   /* Component Styles */
@@ -8,30 +8,14 @@ function ExperienceView(props) {
     card: {
       height: "100%",
     },
-    avatar: {
-      backgroundColor: "#007471",
-    },
   };
   const generateExperienceInfoList = (dataSource) => {
     return (
       <List
-        itemLayout="horizontal"
+        itemLayout="vertical"
         dataSource={dataSource}
         renderItem={(item) => (
-          <List.Item extra={item.duration}>
-            <List.Item.Meta
-              avatar={
-                <Avatar
-                  style={styles.avatar}
-                  size="large"
-                  icon={<ContainerOutlined />}
-                  shape="square"
-                />
-              }
-              title={item.jobTitle}
-              description={item.organizationName}
-            />
-          </List.Item>
+          <ExperienceItem item={item}/>
         )}
       />
     );

--- a/services/frontend-v3/src/components/experience/experienceItem/ExperienceItem.jsx
+++ b/services/frontend-v3/src/components/experience/experienceItem/ExperienceItem.jsx
@@ -1,0 +1,14 @@
+import React, { useState, useEffect } from "react"
+import ExperienceItemView from "./ExperienceItemView"
+
+function ExperienceItem(props){
+    const [expand, setExpand] = useState(false);
+
+    const toggleExpand = ()=>{
+        setExpand(!expand);
+    }
+    
+    return (<ExperienceItemView expand={expand} toggleExpand={toggleExpand} {...props}/>);
+}
+
+export default ExperienceItem;

--- a/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
+++ b/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
@@ -10,7 +10,8 @@ function ExperienceItem(props){
         },
         experienceDescription: {
             color: "rgba(0, 0, 0, 0.85)",
-            maxWidth:"525px"
+            maxWidth:"525px",
+            paddingTop:"6px"
         },
         experienceDescriptionToggleTag: {
             color: "rgba(0, 0, 0, 0.85)",
@@ -19,9 +20,6 @@ function ExperienceItem(props){
         expandDescriptionToggleTagText:{
             paddingLeft:"5px"
         },
-        experienceDescriptionDivider:{
-            fontSize:"14px"
-        }
       };
     const {expand, item, toggleExpand} = props;
     
@@ -29,12 +27,6 @@ function ExperienceItem(props){
             if (expand) {
                 return (
                     <Row>
-                        <Divider plain style={styles.experienceDescriptionDivider} className="experienceDescriptionDivider" orientation="left">
-                        {props.intl.formatMessage({
-                                id: "profile.career.content.title",
-                                    defaultMessage: "Job Description",
-                                })}
-                        </Divider>
                         <p style={styles.experienceDescription}>{item.description}</p>
                     </Row>);
             } else {

--- a/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
+++ b/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
@@ -33,9 +33,7 @@ function ExperienceItem(props){
                 return null;
             }
     }
-
-
-
+    
     const generateDescription = () => {
         return <>
                 <Row>{item.organizationName}</Row>

--- a/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
+++ b/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { injectIntl } from "react-intl";
+import { Row, Col, Divider, Avatar, List } from "antd";
+import { ContainerOutlined, DownOutlined, UpOutlined } from "@ant-design/icons";
+
+function ExperienceItem(props){
+    const styles = {
+        avatar: {
+          backgroundColor: "#007471",
+        },
+        experienceDescription: {
+            color: "rgba(0, 0, 0, 0.85)",
+            maxWidth:"525px"
+        },
+        experienceDescriptionToggleTag: {
+            color: "rgba(0, 0, 0, 0.85)",
+            paddingTop:"8px"
+        },
+        expandDescriptionToggleTagText:{
+            paddingLeft:"5px"
+        },
+        experienceDescriptionDivider:{
+            fontSize:"14px"
+        }
+      };
+    const {expand, item, toggleExpand} = props;
+    
+    const generateDescriptionContent = () => {
+            if (expand) {
+                return (
+                    <Row>
+                        <Divider plain style={styles.experienceDescriptionDivider} className="experienceDescriptionDivider" orientation="left">
+                        {props.intl.formatMessage({
+                                id: "profile.career.content.title",
+                                    defaultMessage: "Job Description",
+                                })}
+                        </Divider>
+                        <p style={styles.experienceDescription}>{item.description}</p>
+                    </Row>);
+            } else {
+                return null;
+            }
+    }
+
+
+
+    const generateDescription = () => {
+        return <>
+                <Row>{item.organizationName}</Row>
+                {generateDescriptionContent()}
+                <Row>
+                    <a onClick={toggleExpand} style={styles.experienceDescriptionToggleTag}>
+                        {expand ? <UpOutlined /> : <DownOutlined />}
+                        <span style={styles.expandDescriptionToggleTagText}>
+                            {props.intl.formatMessage({
+                                id: "profile.career.content.name",
+                                    defaultMessage: "Description",
+                                })}
+                        </span>
+                    </a>
+                </Row>
+            </>;
+    }
+
+    return (
+        <List.Item extra={item.duration}>
+            <List.Item.Meta
+                avatar={
+                    <Avatar
+                        style={styles.avatar}
+                        size="large"
+                        icon={<ContainerOutlined />}
+                        shape="square"
+                    />
+                }
+                title={item.jobTitle}
+                description={generateDescription()}
+            />
+            
+
+        </List.Item>
+    );
+}
+
+export default injectIntl(ExperienceItem);

--- a/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
+++ b/services/frontend-v3/src/components/experience/experienceItem/ExperienceItemView.jsx
@@ -33,9 +33,10 @@ function ExperienceItem(props){
                 return null;
             }
     }
-    
+
     const generateDescription = () => {
-        return <>
+        return (
+            <>
                 <Row>{item.organizationName}</Row>
                 {generateDescriptionContent()}
                 <Row>
@@ -49,7 +50,7 @@ function ExperienceItem(props){
                         </span>
                     </a>
                 </Row>
-            </>;
+            </>);
     }
 
     return (
@@ -66,8 +67,6 @@ function ExperienceItem(props){
                 title={item.jobTitle}
                 description={generateDescription()}
             />
-            
-
         </List.Item>
     );
 }

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
@@ -70,7 +70,7 @@ function ResultsCardView(props) {
             <p></p>
           )}
 
-          <Divider style={styles.divider} orientation="left">
+          <Divider className="results-card-divider" style={styles.divider} orientation="left">
             {props.intl.formatMessage({
               id: "advanced.search.form.skills",
               defaultMessage: "Skills",

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -198,7 +198,6 @@
   "profile.diploma": "Diploma",
   "profile.projects": "Projects",
   "profile.school": "School",
-  "profile.career.content.title": "Job Description",
   "profile.career.content.name": "Description",
   "profile.career.content.rule": "Max 250 characters",
   "profile.career.header.name": "Job Title",

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -198,6 +198,7 @@
   "profile.diploma": "Diploma",
   "profile.projects": "Projects",
   "profile.school": "School",
+  "profile.career.content.title": "Job Description",
   "profile.career.content.name": "Description",
   "profile.career.content.rule": "Max 250 characters",
   "profile.career.header.name": "Job Title",


### PR DESCRIPTION
 -changed resultsCard's left orientated divider changing theme of all left orientated dividers in the app
- added expandable job description to profile
- closes #134 
note: I added a class name for resultsCard dividers to use and altered the CSS changes in app.css to only affect left orientated dividers that also have that class name instead of all left orientated dividers

![description dividerless real](https://user-images.githubusercontent.com/30152653/81337063-66990100-9078-11ea-84f0-463cb7992c75.png)
