### PR TITLE
Show Ex-Feeder nomination on profile

### DIFF
--- a/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
@@ -1,34 +1,13 @@
 import React from "react";
 import TalentManagementView from "./TalentManagementView";
-import { FormattedMessage } from "react-intl";
 
 function TalentManagement(props) {
   const data = props.data;
-
-  const getTalentManagementInfo = dataSource => {
-    const locale = localStorage.getItem("lang");
-    const careerMobility = {
-      title: <FormattedMessage id="profile.career.mobility" />,
-      description: dataSource.careerMobility.description[locale] || (
-        <FormattedMessage id="profile.not.specified" />
-      )
-    };
-
-    const talentMatrixResult = {
-      title: <FormattedMessage id="profile.talent.matrix.result" />,
-      description: dataSource.talentMatrixResult.description[locale] || (
-        <FormattedMessage id="profile.not.specified" />
-      )
-    };
-
-    return [careerMobility, talentMatrixResult];
-  };
 
   return (
     <TalentManagementView
       data={data}
       locale={localStorage.getItem("lang")}
-      info={getTalentManagementInfo(data)}
     />
   );
 }

--- a/services/frontend-v3/src/components/talentManagement/TalentManagementView.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagementView.jsx
@@ -1,8 +1,41 @@
 import React from "react";
-
+import { FormattedMessage } from "react-intl";
+import { CheckOutlined } from '@ant-design/icons';
 import { Row, Col, List } from "antd";
 
 function TalentManagementView(props) {
+  const styles = {
+    exFeederTitleSpan:{
+      paddingLeft:"8px"
+    }
+  }
+
+  const getTalentManagementDatasource = data => {
+    const locale = localStorage.getItem("lang");
+    const careerMobility = {
+      title: <FormattedMessage id="profile.career.mobility" />,
+      description: data.careerMobility.description[locale] || (
+        <FormattedMessage id="profile.not.specified" />
+      )
+    };
+
+    const talentMatrixResult = {
+      title: <FormattedMessage id="profile.talent.matrix.result" />,
+      description: data.talentMatrixResult.description[locale] || (
+        <FormattedMessage id="profile.not.specified" />
+      )
+    };
+
+    if (data.exFeeder == true){
+      const exFeederResult = {
+        title: <React.Fragment><CheckOutlined/><span style={styles.exFeederTitleSpan}><FormattedMessage id="profile.ex.feeder" /></span></React.Fragment>
+      }
+      return [careerMobility, talentMatrixResult, exFeederResult];
+    } else {
+      return [careerMobility, talentMatrixResult];
+    }
+  };
+  
   const generateTalentManagementInfoList = dataSource => {
     return (
       <List
@@ -17,12 +50,12 @@ function TalentManagementView(props) {
     );
   };
 
-  const info = props.info;
-
   return (
     <Row>
       <Col xs={24} lg={24}>
-        {generateTalentManagementInfoList(info)}
+        {generateTalentManagementInfoList(
+          getTalentManagementDatasource(props.data)
+        )}
       </Col>
     </Row>
   );

--- a/services/frontend-v3/src/components/talentManagement/TalentManagementView.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagementView.jsx
@@ -11,7 +11,7 @@ function TalentManagementView(props) {
   }
 
   const getTalentManagementDatasource = data => {
-    const locale = localStorage.getItem("lang");
+    const locale = props.locale;
     const careerMobility = {
       title: <FormattedMessage id="profile.career.mobility" />,
       description: data.careerMobility.description[locale] || (


### PR DESCRIPTION
- display additional message in talent management card if user is nominated in exFeeder program
- moved generation of titles and descriptions for talent management list items into view. I needed to do this to avoid importing ant design into the controller as the ex feeder item includes a check mark symbol

![exFeederDisplay](https://user-images.githubusercontent.com/30152653/81314995-bf0bd680-9057-11ea-8962-9fc6ec17f0d0.png)
