### PR TITLE
[fix] correct some /profile/edit Select filters

### DIFF
--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -356,8 +356,9 @@ const PersonalGrowthFormView = (props) => {
               >
                 <Select
                   mode="multiple"
-                  style={{ width: "100%" }}
+                  optionFilterProp="children"
                   placeholder={<FormattedMessage id="setup.select" />}
+                  style={{ width: "100%" }}
                 >
                   {props.developmentalGoalOptions.map((value, index) => {
                     return <Option key={value.key}>{value.title}</Option>;
@@ -412,6 +413,7 @@ const PersonalGrowthFormView = (props) => {
                   mode="multiple"
                   style={{ width: "100%" }}
                   placeholder={<FormattedMessage id="setup.select" />}
+                  optionFilterProp={"children"}
                 >
                   {props.relocationOptions.map((value, index) => {
                     return <Option key={value.key}>{value.title}</Option>;

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -520,8 +520,9 @@ const TalentFormView = (props) => {
                 <Select
                   className="custom-bubble-select-style"
                   mode="multiple"
-                  style={{ width: "100%" }}
+                  optionFilterProp="children"
                   placeholder={<FormattedMessage id="setup.select" />}
+                  style={{ width: "100%" }}
                 >
                   {props.competencyOptions.map((value) => {
                     return <Option key={value.key}>{value.title}</Option>;


### PR DESCRIPTION
- added optionFilterProp={"children"} for "competencies", "developmental goals" and "willing to relocate to" Select elements to make them filter using children (option text) instead of guid key
