### PR TITLE
[Improve] Responsiveness of edit profile pages

### DIFF
--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -10,117 +10,115 @@ const { backendAddress } = config;
  *  Controller for the EmploymentDataFormView.
  *  It gathers the required data for rendering the component
  */
-function EmploymentDataForm(props) {
+const EmploymentDataForm = (props) => {
   const [substantiveOptions, setSubstantiveOptions] = useState(null);
   const [classificationOptions, setClassificationOptions] = useState(null);
   const [securityOptions, setSecurityOptions] = useState(null);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
 
-  // get current language code
+  // Get current language code
   let locale = props.intl.formatMessage({
     id: "language.code",
     defaultMessage: "en",
   });
 
-  /* useEffect to run once component is mounted */
+  // Get substantive level options
+  const getSubstantiveOptions = async () => {
+    try {
+      let result = await axios.get(backendAddress + "api/option/getTenure");
+
+      let options = [];
+      // Generate the data for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var option = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        options.push(option);
+      }
+      setSubstantiveOptions(options);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // Get classification options
+  const getClassificationOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getGroupLevel";
+      let result = await axios.get(url);
+      let options = [];
+
+      // Generate the data for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var option = {
+          title: result.data[i].description,
+          key: result.data[i].id,
+        };
+        options.push(option);
+      }
+      setClassificationOptions(options);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // Get security options
+  const getSecurityOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getSecurityClearance";
+      let result = await axios.get(url);
+      let options = [];
+
+      // Generate the data for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var option = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        options.push(option);
+      }
+      setSecurityOptions(options);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // Get user profile for form drop down
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // useEffect to run once component is mounted
   useEffect(() => {
-    /* get substantive level options */
-    const getSubstantiveOptions = async () => {
-      try {
-        let result = await axios.get(backendAddress + "api/option/getTenure");
-
-        let options = [];
-        // Generate the data for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var option = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          options.push(option);
-        }
-        await setSubstantiveOptions(options);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get classification options */
-    const getClassificationOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getGroupLevel";
-        let result = await axios.get(url);
-        let options = [];
-
-        // Generate the data for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var option = {
-            title: result.data[i].description,
-            key: result.data[i].id,
-          };
-          options.push(option);
-        }
-        await setClassificationOptions(options);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get security options */
-    const getSecurityOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getSecurityClearance";
-        let result = await axios.get(url);
-        let options = [];
-
-        // Generate the data for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var option = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          options.push(option);
-        }
-        return await setSecurityOptions(options);
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get user profile for form drop down */
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get all required data component */
-    const getAllData = async () => {
-      try {
-        await getClassificationOptions();
-        await getSubstantiveOptions();
-        await getSecurityOptions();
-        await getProfileInfo();
+    // Get all required data component
+    Promise.all([
+      getClassificationOptions(),
+      getSubstantiveOptions(),
+      getSecurityOptions(),
+      getProfileInfo(),
+    ])
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         setLoad(false);
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, [locale]);
 
   return (
@@ -134,6 +132,6 @@ function EmploymentDataForm(props) {
       load={load}
     />
   );
-}
+};
 
 export default injectIntl(EmploymentDataForm);

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -9,73 +9,61 @@ const { backendAddress } = config;
  *  Controller for the EmploymentDataFormView.
  *  It gathers the required data for rendering the component
  */
-function LangProficiencyForm(props) {
+const LangProficiencyForm = (props) => {
   const [languageOptions, setLanguageOptions] = useState(null);
   const [proficiencyOptions, setProficiencyOptions] = useState(null);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
 
-  /* useEffect to run once component is mounted */
+  // Get user profile for form drop down
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // useEffect to run once component is mounted
   useEffect(() => {
-    /* get substantive level options */
-    const getLanguageOptions = () => {
-      const languages = [
-        {
-          key: "en",
-          value: "en",
-          text: "English",
-        },
-        {
-          key: "fr",
-          value: "fr",
-          text: "Français",
-        },
-      ];
-      setLanguageOptions(languages);
-    };
+    // Set proficiency options
+    setProficiencyOptions([
+      { key: "A", value: "A", text: "A" },
+      { key: "B", value: "B", text: "B" },
+      { key: "C", value: "C", text: "C" },
+      { key: "E", value: "E", text: "E" },
+      { key: "X", value: "X", text: "X" },
+    ]);
 
-    const getProficiencyOptions = () => {
-      const proficiency = [
-        { key: "A", value: "A", text: "A" },
-        { key: "B", value: "B", text: "B" },
-        { key: "C", value: "C", text: "C" },
-        { key: "E", value: "E", text: "E" },
-        { key: "X", value: "X", text: "X" },
-      ];
-      setProficiencyOptions(proficiency);
-    };
+    // Set substantive level options
+    setLanguageOptions([
+      {
+        key: "en",
+        value: "en",
+        text: "English",
+      },
+      {
+        key: "fr",
+        value: "fr",
+        text: "Français",
+      },
+    ]);
 
-    /* get user profile for form drop down */
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get all required data component */
-    const getAllData = async () => {
-      try {
-        await getLanguageOptions();
-        await getProficiencyOptions();
-        await getProfileInfo();
+    // Get all required data component
+    getProfileInfo()
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         setLoad(false);
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, []);
 
   return (
@@ -87,6 +75,6 @@ function LangProficiencyForm(props) {
       load={load}
     />
   );
-}
+};
 
 export default LangProficiencyForm;

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -19,7 +19,6 @@ import axios from "axios";
 import moment from "moment";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
-
 const { backendAddress } = config;
 const { Option } = Select;
 const { Title } = Typography;
@@ -163,7 +162,7 @@ const LangProficiencyFormView = (props) => {
 
   /* toggle temporary role form */
   const toggleSecLangForm = () => {
-    setDisplayMentorshipForm(!displayMentorshipForm);
+    setDisplayMentorshipForm(prev => !prev);
   };
 
   /* Save data */
@@ -466,7 +465,7 @@ const LangProficiencyFormView = (props) => {
   useEffect(() => {
     /* check if user has a second language */
     setDisplayMentorshipForm(
-      props.profileInfo ? Boolean(props.profileInfo.secondLanguage) : false
+      props.profileInfo ? !!props.profileInfo.secondaryOralProficiency : false
     );
   }, [props.profileInfo]);
 

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -10,7 +10,7 @@ const { backendAddress } = config;
  *  Controller for the PersonalGrowthFormView.
  *  It gathers the required data for rendering the component
  */
-function PersonalGrowthForm(props) {
+const PersonalGrowthForm = (props) => {
   // Define States
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
@@ -27,13 +27,13 @@ function PersonalGrowthForm(props) {
   const [savedTalentMatrixResult, setSavedTalentMatrixResult] = useState();
   const [savedExFeederBool, setSavedExFeederBool] = useState();
 
-  // get current language code
+  // Get current language code
   let locale = props.intl.formatMessage({
     id: "language.code",
     defaultMessage: "en",
   });
 
-  /*
+  /**
    * Get saved Developmental Goals
    *
    * get saved Developmental Goals from profile
@@ -41,7 +41,7 @@ function PersonalGrowthForm(props) {
   const getSavedDevelopmentalGoals = () => {
     let selected = [];
 
-    // generate and array of ID's of save locations
+    // Generate and array of ID's of save locations
     for (let i = 0; i < profileInfo.developmentalGoals.length; i++) {
       selected.push(profileInfo.developmentalGoals[i].id);
     }
@@ -49,7 +49,7 @@ function PersonalGrowthForm(props) {
     setSavedDevelopmentalGoals(selected);
   };
 
-  /*
+  /**
    * Get Saved Relocation Locations
    *
    * get saved Relocation Locations from profile
@@ -57,7 +57,7 @@ function PersonalGrowthForm(props) {
   const getSavedRelocationLocations = () => {
     let selected = [];
 
-    // generate and array of ID's of save locations
+    // Generate and array of ID's of save locations
     for (let i = 0; i < profileInfo.relocationLocations.length; i++) {
       selected.push(profileInfo.relocationLocations[i].locationId);
     }
@@ -65,9 +65,8 @@ function PersonalGrowthForm(props) {
     setSavedRelocationLocations(selected);
   };
 
-  /*
+  /**
    * Get User Profile
-   *
    */
   const getProfileInfo = async () => {
     try {
@@ -83,7 +82,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /*
+  /**
    * Get Developmental Goal Options
    *
    * get a list of developmental goal options for treeSelect dropdown
@@ -109,7 +108,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /*
+  /**
    * Get Interested In Remote Options
    *
    * get Interested In Remote Options
@@ -129,7 +128,7 @@ function PersonalGrowthForm(props) {
     setInterestedInRemoteOptions(options);
   };
 
-  /*
+  /**
    * Get Relocation Options
    *
    * get a list of Relocation Options for dropdown treeSelect
@@ -156,7 +155,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /*
+  /**
    * Get Saved Looking For New Job
    *
    * get Saved Looking For New Job from user profile
@@ -183,7 +182,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /*
+  /**
    * Get Career Mobility Options
    *
    * get all dropdown options for Career Mobility
@@ -210,7 +209,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /*
+  /**
    * Get Talent Matrix Result Options
    *
    * get all dropdown options for Talent Matrix Results
@@ -237,7 +236,7 @@ function PersonalGrowthForm(props) {
     }
   };
 
-  /* useEffect when profileInfo changes */
+  // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
     if (profileInfo) {
       const {
@@ -260,11 +259,11 @@ function PersonalGrowthForm(props) {
     }
   }, [profileInfo]);
 
-  /* useEffect when locale changes */
+  // useEffect when locale changes
   useEffect(() => {
     getInterestedInRemoteOptions();
 
-    /* Get all required data component */
+    // Get all required data component
     Promise.all([
       getProfileInfo(),
       getDevelopmentalGoalOptions(),

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -66,57 +66,6 @@ function PersonalGrowthForm(props) {
   };
 
   /*
-   * Get Saved Looking For New Job
-   *
-   * get Saved Looking For New Job from user profile
-   */
-  const getSavedLookingForNewJob = () => {
-    // if id is not found set to "undefined" so dropdown defaults to placeholder
-    let savedValue = profileInfo.lookingForNewJob
-      ? profileInfo.lookingForNewJob.id
-      : undefined;
-
-    setSavedLookingForNewJob(savedValue);
-  };
-
-  /*
-   * Get Saved Career Mobility
-   *
-   * get saved Saved Career Mobility from user profile
-   */
-  const getSavedCareerMobility = () => {
-    // if id is not found set to "undefined" so dropdown defaults to placeholder
-    let savedValue = profileInfo.careerMobility
-      ? profileInfo.careerMobility.id
-      : undefined;
-
-    setSavedCareerMobility(savedValue);
-  };
-
-  /*
-   * Get Saved Talent Matrix Result
-   *
-   * get saved Talent Matrix Result from user profile
-   */
-  const getSavedTalentMatrixResult = () => {
-    // if id is not found set to "undefined" so dropdown defaults to placeholder
-    let savedValue = profileInfo.talentMatrixResult
-      ? profileInfo.talentMatrixResult.id
-      : undefined;
-
-    setSavedTalentMatrixResult(savedValue);
-  };
-
-  /*
-   * Get Ex Feeder Bool
-   *
-   * get EX-feeder nomination boolean from user profile
-   */
-  const getExFeederBool = () => {
-    setSavedExFeederBool(result.data.exFeeder);
-  };
-
-  /*
    * Get User Profile
    *
    */
@@ -291,12 +240,23 @@ function PersonalGrowthForm(props) {
   /* useEffect when profileInfo changes */
   useEffect(() => {
     if (profileInfo) {
+      const {
+        lookingForNewJob,
+        talentMatrixResult,
+        careerMobility,
+        exFeeder,
+      } = profileInfo;
+
       getSavedDevelopmentalGoals();
       getSavedRelocationLocations();
-      getSavedLookingForNewJob();
-      getSavedCareerMobility();
-      getSavedTalentMatrixResult();
-      getExFeederBool();
+      setSavedLookingForNewJob(
+        lookingForNewJob ? lookingForNewJob.id : undefined
+      );
+      setSavedTalentMatrixResult(
+        talentMatrixResult ? talentMatrixResult.id : undefined
+      );
+      setSavedCareerMobility(careerMobility ? careerMobility.id : undefined);
+      setSavedExFeederBool(exFeeder);
     }
   }, [profileInfo]);
 

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -33,352 +33,293 @@ function PersonalGrowthForm(props) {
     defaultMessage: "en",
   });
 
-  /* useEffect to run once component is mounted */
+  /*
+   * Get saved Developmental Goals
+   *
+   * get saved Developmental Goals from profile
+   */
+  const getSavedDevelopmentalGoals = () => {
+    let selected = [];
+
+    // generate and array of ID's of save locations
+    for (let i = 0; i < profileInfo.developmentalGoals.length; i++) {
+      selected.push(profileInfo.developmentalGoals[i].id);
+    }
+
+    setSavedDevelopmentalGoals(selected);
+  };
+
+  /*
+   * Get Saved Relocation Locations
+   *
+   * get saved Relocation Locations from profile
+   */
+  const getSavedRelocationLocations = () => {
+    let selected = [];
+
+    // generate and array of ID's of save locations
+    for (let i = 0; i < profileInfo.relocationLocations.length; i++) {
+      selected.push(profileInfo.relocationLocations[i].locationId);
+    }
+
+    setSavedRelocationLocations(selected);
+  };
+
+  /*
+   * Get Saved Looking For New Job
+   *
+   * get Saved Looking For New Job from user profile
+   */
+  const getSavedLookingForNewJob = () => {
+    // if id is not found set to "undefined" so dropdown defaults to placeholder
+    let savedValue = profileInfo.lookingForNewJob
+      ? profileInfo.lookingForNewJob.id
+      : undefined;
+
+    setSavedLookingForNewJob(savedValue);
+  };
+
+  /*
+   * Get Saved Career Mobility
+   *
+   * get saved Saved Career Mobility from user profile
+   */
+  const getSavedCareerMobility = () => {
+    // if id is not found set to "undefined" so dropdown defaults to placeholder
+    let savedValue = profileInfo.careerMobility
+      ? profileInfo.careerMobility.id
+      : undefined;
+
+    setSavedCareerMobility(savedValue);
+  };
+
+  /*
+   * Get Saved Talent Matrix Result
+   *
+   * get saved Talent Matrix Result from user profile
+   */
+  const getSavedTalentMatrixResult = () => {
+    // if id is not found set to "undefined" so dropdown defaults to placeholder
+    let savedValue = profileInfo.talentMatrixResult
+      ? profileInfo.talentMatrixResult.id
+      : undefined;
+
+    setSavedTalentMatrixResult(savedValue);
+  };
+
+  /*
+   * Get Ex Feeder Bool
+   *
+   * get EX-feeder nomination boolean from user profile
+   */
+  const getExFeederBool = () => {
+    setSavedExFeederBool(result.data.exFeeder);
+  };
+
+  /*
+   * Get User Profile
+   *
+   */
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /*
+   * Get Developmental Goal Options
+   *
+   * get a list of developmental goal options for treeSelect dropdown
+   */
+  const getDevelopmentalGoalOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getDevelopmentalGoals";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for treeSelect
+      for (var i = 0; i < result.data.length; i++) {
+        var goal = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        dataTree.push(goal);
+      }
+      setDevelopmentalGoalOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /*
+   * Get Interested In Remote Options
+   *
+   * get Interested In Remote Options
+   * TODO: Generate this list from API call to back end
+   */
+  const getInterestedInRemoteOptions = () => {
+    const options = [
+      {
+        key: true,
+        text: locale === "fr" ? "Oui" : "Yes",
+      },
+      {
+        key: false,
+        text: locale === "fr" ? "Non" : "No",
+      },
+    ];
+    setInterestedInRemoteOptions(options);
+  };
+
+  /*
+   * Get Relocation Options
+   *
+   * get a list of Relocation Options for dropdown treeSelect
+   */
+  const getRelocationOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getWillingToRelocateTo";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for treeSelect
+      for (var i = 0; i < result.data.length; i++) {
+        var location = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        dataTree.push(location);
+      }
+
+      setRelocationOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /*
+   * Get Saved Looking For New Job
+   *
+   * get Saved Looking For New Job from user profile
+   */
+  const getLookingForNewJobOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getLookingForANewJob";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var goal = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        dataTree.push(goal);
+      }
+
+      setLookingForNewJobOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /*
+   * Get Career Mobility Options
+   *
+   * get all dropdown options for Career Mobility
+   */
+  const getCareerMobilityOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getCareerMobility";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var goal = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        dataTree.push(goal);
+      }
+
+      setCareerMobilityOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /*
+   * Get Talent Matrix Result Options
+   *
+   * get all dropdown options for Talent Matrix Results
+   */
+  const getTalentMatrixResultOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getTalentMatrixResult";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var goal = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        dataTree.push(goal);
+      }
+
+      setTalentMatrixResultOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /* useEffect when profileInfo changes */
   useEffect(() => {
-    /*
-     * Get User Profile
-     *
-     */
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
+    if (profileInfo) {
+      getSavedDevelopmentalGoals();
+      getSavedRelocationLocations();
+      getSavedLookingForNewJob();
+      getSavedCareerMobility();
+      getSavedTalentMatrixResult();
+      getExFeederBool();
+    }
+  }, [profileInfo]);
 
-    /*
-     * Get Developmental Goal Options
-     *
-     * get a list of developmental goal options for treeSelect dropdown
-     */
-    const getDevelopmentalGoalOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getDevelopmentalGoals";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for treeSelect
-        for (var i = 0; i < result.data.length; i++) {
-          var goal = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          dataTree.push(goal);
-        }
-        await setDevelopmentalGoalOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get saved Developmental Goals
-     *
-     * get saved Developmental Goals from profile
-     */
-    const getSavedDevelopmentalGoals = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-
-        // generate and array of ID's of save locations
-        for (let i = 0; i < result.data.developmentalGoals.length; i++) {
-          selected.push(result.data.developmentalGoals[i].id);
-        }
-
-        await setSavedDevelopmentalGoals(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Interested In Remote Options
-     *
-     * get Interested In Remote Options
-     * TODO: Generate this list from API call to back end
-     */
-    const getInterestedInRemoteOptions = () => {
-      const options = [
-        {
-          key: true,
-          text: locale === "fr" ? "Oui" : "Yes",
-        },
-        {
-          key: false,
-          text: locale === "fr" ? "Non" : "No",
-        },
-      ];
-      setInterestedInRemoteOptions(options);
-    };
-
-    /*
-     * Get Relocation Options
-     *
-     * get a list of Relocation Options for dropdown treeSelect
-     */
-    const getRelocationOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getWillingToRelocateTo";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for treeSelect
-        for (var i = 0; i < result.data.length; i++) {
-          var location = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          dataTree.push(location);
-        }
-
-        await setRelocationOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Relocation Locations
-     *
-     * get saved Relocation Locations from profile
-     */
-    const getSavedRelocationLocations = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-
-        // generate and array of ID's of save locations
-        for (let i = 0; i < result.data.relocationLocations.length; i++) {
-          selected.push(result.data.relocationLocations[i].locationId);
-        }
-
-        await setSavedRelocationLocations(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Looking For New Job
-     *
-     * get Saved Looking For New Job from user profile
-     */
-    const getLookingForNewJobOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getLookingForANewJob";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var goal = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          dataTree.push(goal);
-        }
-
-        await setLookingForNewJobOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Looking For New Job
-     *
-     * get Saved Looking For New Job from user profile
-     */
-    const getSavedLookingForNewJob = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-
-        // if id is not found set to "undefined" so dropdown defaults to placeholder
-        let savedValue = result.data.lookingForNewJob
-          ? result.data.lookingForNewJob.id
-          : undefined;
-
-        await setSavedLookingForNewJob(savedValue);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Career Mobility Options
-     *
-     * get all dropdown options for Career Mobility
-     */
-    const getCareerMobilityOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getCareerMobility";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var goal = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          dataTree.push(goal);
-        }
-
-        await setCareerMobilityOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Career Mobility
-     *
-     * get saved Saved Career Mobility from user profile
-     */
-    const getSavedCareerMobility = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-
-        // if id is not found set to "undefined" so dropdown defaults to placeholder
-        let savedValue = result.data.careerMobility.id
-          ? result.data.careerMobility.id
-          : undefined;
-
-        await setSavedCareerMobility(savedValue);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Talent Matrix Result Options
-     *
-     * get all dropdown options for Talent Matrix Results
-     */
-    const getTalentMatrixResultOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getTalentMatrixResult";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var goal = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          dataTree.push(goal);
-        }
-
-        await setTalentMatrixResultOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Talent Matrix Result
-     *
-     * get saved Talent Matrix Result from user profile
-     */
-    const getSavedTalentMatrixResult = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-
-        // if id is not found set to "undefined" so dropdown defaults to placeholder
-        let savedValue = result.data.talentMatrixResult.id
-          ? result.data.talentMatrixResult.id
-          : undefined;
-
-        await setSavedTalentMatrixResult(savedValue);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Ex Feeder Bool
-     *
-     * get EX-feeder nomination boolean from user profile
-     */
-    const getExFeederBool = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setSavedExFeederBool(result.data.exFeeder);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
+  /* useEffect when locale changes */
+  useEffect(() => {
+    getInterestedInRemoteOptions();
 
     /* Get all required data component */
-    const getAllData = async () => {
-      try {
-        await getProfileInfo();
-        await getDevelopmentalGoalOptions();
-        await getSavedDevelopmentalGoals();
-        await getInterestedInRemoteOptions();
-        await getRelocationOptions();
-        await getSavedRelocationLocations();
-        await getLookingForNewJobOptions();
-        await getSavedLookingForNewJob();
-        await getCareerMobilityOptions();
-        await getSavedCareerMobility();
-        await getTalentMatrixResultOptions();
-        await getSavedTalentMatrixResult();
-        await getExFeederBool();
+    Promise.all([
+      getProfileInfo(),
+      getDevelopmentalGoalOptions(),
+      getRelocationOptions(),
+      getLookingForNewJobOptions(),
+      getCareerMobilityOptions(),
+      getTalentMatrixResultOptions(),
+    ])
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         setLoad(false);
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, [locale]);
 
   return (

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -4,53 +4,47 @@ import axios from "axios";
 import config from "../../../config";
 const { backendAddress } = config;
 
-function PrimaryInfoForm(props) {
+const PrimaryInfoForm = (props) => {
   const [locationOptions, setLocationOptions] = useState(null);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
 
+  // Get possible locations for form drop down
+  const getLocations = async () => {
+    try {
+      let result = await axios.get(backendAddress + "api/option/getLocation");
+      setLocationOptions(result.data);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // Get user profile for form drop down
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      return 1;
+    } catch (error) {
+      return 0;
+    }
+  };
+
   // useEffect to run once component is mounted
   useEffect(() => {
-    // get possible locations for form drop down
-    const getLocations = async () => {
-      try {
-        let result = await axios.get(backendAddress + "api/option/getLocation");
-        await setLocationOptions(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    // get user profile for form drop down
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        return 0;
-      }
-    };
-
-    // get all required data component
-    const getAllData = async () => {
-      try {
-        await getProfileInfo();
-        await getLocations();
+    // Get all required data component
+    Promise.all([getProfileInfo(), getLocations()])
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, []);
 
   return (
@@ -61,6 +55,6 @@ function PrimaryInfoForm(props) {
       formType={props.formType}
     />
   );
-}
+};
 
 export default PrimaryInfoForm;

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -10,7 +10,7 @@ const { backendAddress } = config;
  *  Controller for the QualificationsFormView.
  *  It gathers the required data for rendering the component
  */
-function QualificationsForm(props) {
+const QualificationsForm = (props) => {
   // Define States
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
@@ -18,135 +18,101 @@ function QualificationsForm(props) {
   const [savedExperience, setSavedExperience] = useState();
   const [savedProjects, setSavedProjects] = useState();
 
-  /* useEffect to run once component is mounted */
+  /**
+   * Get User Profile
+   */
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      setLoad(true);
+      return 1;
+    } catch (error) {
+      setLoad(false);
+      throw new Error(error);
+    }
+  };
+
+  /**
+   * Get Saved Education Information
+   *
+   * get saved education items
+   */
+  const getSavedEducation = () => {
+    let selected = [];
+
+    // Generate an array of education items
+    for (let i = 0; i < profileInfo.education.length; i++) {
+      let child = {
+        school: profileInfo.education[i].school.id,
+        diploma: profileInfo.education[i].diploma.id,
+        startDate: moment(profileInfo.education[i].startDate.en),
+        endDate: profileInfo.education[i].endDate.en
+          ? moment(profileInfo.education[i].endDate.en)
+          : null,
+      };
+      selected.push(child);
+    }
+
+    setSavedEducation(selected);
+  };
+
+  /**
+   * Get Saved Experience Information
+   *
+   * get saved experience items
+   */
+  const getSavedExperience = () => {
+    let selected = [];
+
+    // Generate an array of education items
+    for (let i = 0; i < profileInfo. careerSummary.length; i++) {
+      let child = {
+        header: profileInfo.careerSummary[i].header,
+        subheader: profileInfo.careerSummary[i].subheader,
+        content: profileInfo.careerSummary[i].content,
+        startDate: moment(profileInfo.careerSummary[i].startDate),
+        endDate: profileInfo.careerSummary[i].endDate
+          ? moment(profileInfo.careerSummary[i].endDate)
+          : null,
+      };
+      selected.push(child);
+    }
+
+    setSavedExperience(selected);
+  };
+
+  /**
+   * Get Saved Projects
+   *
+   * get saved projects
+   */
+  const getSavedProjects = () => {
+    const selected = [];
+
+    for (let i = 0; i < profileInfo.projects.length; i++) {
+      selected.push(profileInfo.projects[i].text);
+    }
+    setSavedProjects(selected);
+  };
+
+  // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
-    /*
-     * Get User Profile
-     *
-     */
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
+    if (profileInfo) {
+      getSavedEducation();
+      getSavedExperience();
+      getSavedProjects();
+    }
+  }, [profileInfo]);
 
-    /*
-     * Get Saved Education Information
-     *
-     * get saved education items
-     */
-    const getSavedEducation = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-
-        // generate an array of education items
-        for (let i = 0; i < result.data.education.length; i++) {
-          let child = {
-            school: result.data.education[i].school.id,
-            diploma: result.data.education[i].diploma.id,
-            startDate: moment(result.data.education[i].startDate.en),
-            endDate: result.data.education[i].endDate.en
-              ? moment(result.data.education[i].endDate.en)
-              : null,
-          };
-          selected.push(child);
-        }
-        await setSavedEducation(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Experience Information
-     *
-     * get saved experience items
-     */
-    const getSavedExperience = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-
-        // generate an array of education items
-        for (let i = 0; i < result.data.careerSummary.length; i++) {
-          let child = {
-            header: result.data.careerSummary[i].header,
-            subheader: result.data.careerSummary[i].subheader,
-            content: result.data.careerSummary[i].content,
-            startDate: moment(result.data.careerSummary[i].startDate),
-            endDate: result.data.careerSummary[i].endDate
-              ? moment(result.data.careerSummary[i].endDate)
-              : null,
-          };
-          selected.push(child);
-        }
-
-        await setSavedExperience(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get Saved Projects
-     *
-     * get saved projects
-     */
-    const getSavedProjects = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        const selected = [];
-
-        for (let i = 0; i < result.data.projects.length; i++) {
-          selected.push(result.data.projects[i].text);
-        }
-        await setSavedProjects(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
+  // useEffect to run once component is mounted
+  useEffect(() => {
     /* Get all required data component */
-    const getAllData = async () => {
-      try {
-        await getProfileInfo();
-        await getSavedEducation();
-        await getSavedExperience();
-        await getSavedProjects();
-        setLoad(true);
-        return 1;
-      } catch (error) {
-        setLoad(false);
-        console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+    getProfileInfo();
   }, []);
 
   return (
@@ -159,6 +125,6 @@ function QualificationsForm(props) {
       load={load}
     />
   );
-}
+};
 
 export default QualificationsForm;

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
@@ -11,7 +11,7 @@ const { backendAddress } = config;
  *  This component is strongly linked ot Qualifications Form.
  *  It generated the form fields for each education item the user creates in the qualifications form.
  */
-function EducationForm(props) {
+const EducationForm = (props) => {
   // Define States
   const [load, setLoad] = useState(false);
   const [diplomaOptions, setDiplomaOptions] = useState();
@@ -23,75 +23,69 @@ function EducationForm(props) {
     defaultMessage: "en",
   });
 
-  /* useEffect to run once component is mounted */
+  /**
+   * Get Diploma Options
+   *
+   * get a list of diploma options for dropdown
+   */
+  const getDiplomaOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getDiploma";
+      let result = await axios.get(url);
+      let options = [];
+
+      // Generate the data format required for treeSelect
+      for (var i = 0; i < result.data.length; i++) {
+        var option = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        options.push(option);
+      }
+      setDiplomaOptions(options);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /**
+   * Get School Options
+   *
+   * get a list of diploma options for dropdown
+   */
+  const getSchoolOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getSchool";
+      let result = await axios.get(url);
+      let dataTree = [];
+
+      // Generate the data format required for treeSelect
+      for (var i = 0; i < result.data.length; i++) {
+        var goal = {
+          title: result.data[i].description,
+          key: result.data[i].id,
+        };
+        dataTree.push(goal);
+      }
+      setSchoolOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  // useEffect to run once component is mounted
   useEffect(() => {
-    /*
-     * Get Diploma Options
-     *
-     * get a list of diploma options for dropdown
-     */
-    const getDiplomaOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getDiploma";
-        let result = await axios.get(url);
-        let options = [];
-
-        // Generate the data format required for treeSelect
-        for (var i = 0; i < result.data.length; i++) {
-          var option = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          options.push(option);
-        }
-        await setDiplomaOptions(options);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * Get School Options
-     *
-     * get a list of diploma options for dropdown
-     */
-    const getSchoolOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getSchool";
-        let result = await axios.get(url);
-        let dataTree = [];
-
-        // Generate the data format required for treeSelect
-        for (var i = 0; i < result.data.length; i++) {
-          var goal = {
-            title: result.data[i].description,
-            key: result.data[i].id,
-          };
-          dataTree.push(goal);
-        }
-        await setSchoolOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* Get all required data component */
-    const getAllData = async () => {
-      try {
-        await getDiplomaOptions();
-        await getSchoolOptions();
+    // Get all required data component
+    Promise.all([getDiplomaOptions(), getSchoolOptions()])
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         setLoad(false);
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, [locale]);
 
   return (
@@ -106,6 +100,6 @@ function EducationForm(props) {
       load={load}
     />
   );
-}
+};
 
 export default injectIntl(EducationForm);

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceForm.jsx
@@ -7,7 +7,7 @@ import ExperienceFormView from "./ExperienceFormView";
  *  This component is strongly linked ot Qualifications Form.
  *  It generated the form fields for each experience item the user creates in the qualifications form.
  */
-function ExperienceForm(props) {
+const ExperienceForm = (props) => {
   return (
     <ExperienceFormView
       form={props.form}
@@ -17,6 +17,6 @@ function ExperienceForm(props) {
       style={props.style}
     />
   );
-}
+};
 
 export default ExperienceForm;

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -10,7 +10,7 @@ const { backendAddress } = config;
  *  Controller for the EmploymentDataFormView.
  *  It gathers the required data for rendering the component
  */
-function TalentForm(props) {
+const TalentForm = (props) => {
   const [profileInfo, setProfileInfo] = useState(null);
   const [skillOptions, setSkillOptions] = useState(null);
   const [competencyOptions, setCompetencyOptions] = useState(null);
@@ -25,185 +25,152 @@ function TalentForm(props) {
     defaultMessage: "en",
   });
 
-  /* useEffect to run once component is mounted */
+  /**
+   * Get user profile
+   */
+  const getProfileInfo = async () => {
+    try {
+      let url =
+        backendAddress +
+        "api/private/profile/" +
+        localStorage.getItem("userId");
+      let result = await axios.get(url);
+      setProfileInfo(result.data);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /**
+   * Get all competency options
+   *
+   * competency options for drop down
+   */
+  const getCompetencyOptions = async () => {
+    try {
+      let url = backendAddress + "api/option/getCompetency";
+      let result = await axios.get(url);
+      let options = [];
+
+      // Generate the data for dropdown
+      for (var i = 0; i < result.data.length; i++) {
+        var option = {
+          title: result.data[i].description[locale],
+          key: result.data[i].id,
+        };
+        options.push(option);
+      }
+
+      setCompetencyOptions(options);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /**
+   * Get all skill options
+   *
+   * generate the dataTree of skills and skill categories for the TreeSelect
+   */
+  const getSkillOptions = async () => {
+    try {
+      let dataTree = [];
+
+      // Get user profile
+      let url = backendAddress + "api/option/getCategory";
+      let result = await axios.get(url);
+
+      // Loop through all skill categories
+      for (var i = 0; i < result.data.length; i++) {
+        var parent = {
+          title: result.data[i].description[locale],
+          value: result.data[i].id,
+          children: [],
+        };
+
+        dataTree.push(parent);
+        // Loop through skills in each category
+        for (var w = 0; w < result.data[i].skills.length; w++) {
+          var child = {
+            title:
+              result.data[i].description[locale] +
+              ": " +
+              result.data[i].skills[w].description[locale],
+            value: result.data[i].skills[w].id,
+            key: result.data[i].skills[w].id,
+          };
+          dataTree[i].children.push(child);
+        }
+      }
+
+      setSkillOptions(dataTree);
+      return 1;
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  /**
+   * Get saved competencies
+   *
+   * get saved competencies from profile
+   */
+  const getSavedCompetencies = () => {
+    let selected = [];
+    for (let i = 0; i < profileInfo.competencies.length; i++) {
+      selected.push(profileInfo.competencies[i].id);
+    }
+    setSavedCompetencies(selected);
+  };
+
+  /**
+   * Get saved skills from profile
+   *
+   * generate an array of skill ids saved in profile
+   */
+  const getSavedSkills = () => {
+    let selected = [];
+    for (let i = 0; i < profileInfo.skills.length; i++) {
+      selected.push(profileInfo.skills[i].id);
+    }
+    setSavedSkills(selected);
+  };
+
+  /**
+   * Get saved mentorship from profile
+   *
+   * generate an array of mentorship skill ids saved in profile
+   */
+  const getSavedMentorshipSkill = () => {
+    let selected = [];
+    for (let i = 0; i < profileInfo.mentorshipSkills.length; i++) {
+      selected.push(profileInfo.mentorshipSkills[i].id);
+    }
+    setSavedMentorshipSkills(selected);
+  };
+
+  // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
-    /*
-     * get user profile
-     *
-     */
-    const getProfileInfo = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        await setProfileInfo(result.data);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
+    if (profileInfo) {
+      getSavedCompetencies();
+      getSavedSkills();
+      getSavedMentorshipSkill();
+    }
+  }, [profileInfo]);
 
-    /*
-     * get all competency options
-     *
-     * competency options for drop down
-     */
-    const getCompetencyOptions = async () => {
-      try {
-        let url = backendAddress + "api/option/getCompetency";
-        let result = await axios.get(url);
-        let options = [];
-
-        // Generate the data for dropdown
-        for (var i = 0; i < result.data.length; i++) {
-          var option = {
-            title: result.data[i].description[locale],
-            key: result.data[i].id,
-          };
-          options.push(option);
-        }
-
-        await setCompetencyOptions(options);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*  */
-    /*
-     * get saved competencies
-     *
-     * get saved competencies from profile
-     */
-    const getSavedCompetencies = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-        for (let i = 0; i < result.data.competencies.length; i++) {
-          selected.push(result.data.competencies[i].id);
-        }
-        await setSavedCompetencies(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * get all skill options
-     *
-     * generate the dataTree of skills and skill categories for the TreeSelect
-     */
-    const getSkillOptions = async () => {
-      try {
-        let dataTree = [];
-
-        // get user profile
-        let url = backendAddress + "api/option/getCategory";
-        let result = await axios.get(url);
-
-        // loop through all skill categories
-        for (var i = 0; i < result.data.length; i++) {
-          var parent = {
-            title: result.data[i].description[locale],
-            value: result.data[i].id,
-            children: [],
-          };
-
-          dataTree.push(parent);
-          // loop through skills in each category
-          for (var w = 0; w < result.data[i].skills.length; w++) {
-            var child = {
-              title:
-                result.data[i].description[locale] +
-                ": " +
-                result.data[i].skills[w].description[locale],
-              value: result.data[i].skills[w].id,
-              key: result.data[i].skills[w].id,
-            };
-            dataTree[i].children.push(child);
-          }
-        }
-
-        await setSkillOptions(dataTree);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * get saved skills from profile
-     *
-     * generate an array of skill ids saved in profile
-     */
-    const getSavedSkills = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-        for (let i = 0; i < result.data.skills.length; i++) {
-          selected.push(result.data.skills[i].id);
-        }
-        await setSavedSkills(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /*
-     * get saved mentorship from profile
-     *
-     * generate an array of mentorship skill ids saved in profile
-     */
-    const getSavedMentorshipSkill = async () => {
-      try {
-        let url =
-          backendAddress +
-          "api/private/profile/" +
-          localStorage.getItem("userId");
-        let result = await axios.get(url);
-        let selected = [];
-        for (let i = 0; i < result.data.mentorshipSkills.length; i++) {
-          selected.push(result.data.mentorshipSkills[i].id);
-        }
-        await setSavedMentorshipSkills(selected);
-        return 1;
-      } catch (error) {
-        throw new Error(error);
-      }
-    };
-
-    /* get all required data component */
-    const getAllData = async () => {
-      try {
-        await getProfileInfo();
-        await getSkillOptions();
-        await getCompetencyOptions();
-        await getSavedCompetencies();
-        await getSavedSkills();
-        await getSavedMentorshipSkill();
+  // useEffect to run once component is mounted
+  useEffect(() => {
+    // get all required data component
+    Promise.all([getProfileInfo(), getSkillOptions(), getCompetencyOptions()])
+      .then(() => {
         setLoad(true);
-        return 1;
-      } catch (error) {
+      })
+      .catch((error) => {
         setLoad(false);
         console.log(error);
-        return 0;
-      }
-    };
-
-    getAllData();
+      });
   }, [locale]);
 
   return (
@@ -219,6 +186,6 @@ function TalentForm(props) {
       load={load}
     />
   );
-}
+};
 
 export default injectIntl(TalentForm);


### PR DESCRIPTION
This is now getting info asynchronously and only calling the same API (the profile one) once instead of multiple times. It also fixes an issue for the switch (where it would always be unchecked, it seems that the values of `secondLanguage` is always null from the API) the Edit profile of Language proficiency

**Example for loading the edit page for Personal growth interests**

before:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/22248828/81341265-3dc83a00-907f-11ea-824d-201dabb26c3d.png)

after:
![MicrosoftTeams-image](https://user-images.githubusercontent.com/22248828/81341268-3ef96700-907f-11ea-97eb-d351acb62b86.png)


closes #204 