### PR TITLE
[Fix] Increased navbar zIndex

### DIFF
--- a/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
@@ -22,7 +22,7 @@ function TopNavView(props) {
       padding: 0,
       boxShadow: "0 0.125rem 0.25rem rgba(0, 0, 0, 0.075)",
       position: "fixed",
-      zIndex: 1,
+      zIndex: 2,
       width: "100%",
     },
     navBrand: {


### PR DESCRIPTION
Increased navbar zIndex so that the content underneath won't go over it, aka the underline of the `EmployeeSummaryView`

closes #195 