### PR TITLE
[Fix] Admin path backend error

### DIFF
--- a/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
+++ b/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
@@ -8,18 +8,21 @@ import DashboardGraphsView from "./DashboardGraphsView";
  *  Controller for the DashboardGraphsView.
  *  It setups the data (bridge) for rendering the component in the view.
  */
-function DashboardGraphs({ data }) {
+const DashboardGraphs = ({ data }) => {
   /* only access data for graphes that uses corresponding language on page */
   const changeEnFr = (dataSource) => {
-    const locale = localStorage.getItem("lang") || "en";
-    const data = dataSource.map((skill) => {
-      return {
-        name: skill.description[locale],
-        count: skill.count,
-      };
-    });
+    if (dataSource) {
+      const locale = localStorage.getItem("lang") || "en";
+      const data = dataSource.map((skill) => {
+        return {
+          name: skill.description[locale],
+          count: skill.count,
+        };
+      });
 
-    return data;
+      return data;
+    }
+    return [];
   };
 
   return (
@@ -30,10 +33,9 @@ function DashboardGraphs({ data }) {
       monthlyGrowth={data.graphicalData}
     />
   );
-}
+};
 
 DashboardGraphs.propTypes = {
-  // data: PropTypes.isRequired,
   data: PropTypes.shape({
     skillCount: PropTypes.isRequired,
     compCount: PropTypes.isRequired,

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
@@ -38,7 +38,7 @@ const SkillTable = ({ intl, type }) => {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return [];
     }
   }, [type]);
 
@@ -52,7 +52,7 @@ const SkillTable = ({ intl, type }) => {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return [];
     }
   }, [type]);
 

--- a/services/frontend-v3/src/components/admin/statCards/StatCards.jsx
+++ b/services/frontend-v3/src/components/admin/statCards/StatCards.jsx
@@ -1,31 +1,38 @@
 import React from "react";
 import PropTypes from "prop-types";
 import StatCardsView from "./StatCardsView";
+
 /**
  *  StatCards(props)
  *  Controller for the StatCardsView.
  *  It setups the data (bridge) for rendering the component in the view.
  */
-function StatCards({ data }) {
+const StatCards = ({ data }) => {
   /* gets data for the stat cards on dashboard */
   // Gets data for Total users, Inactive users, Hidden profiles, and Total Ex Feeders
-  const dashboardCount = dashboardCountData => {
-    const totalUsers = dashboardCountData.user;
-    const inactiveUsers = dashboardCountData.inactive;
-    const hiddenProfiles = dashboardCountData.flagged;
-    const exFeeders = dashboardCountData.exFeeder;
-    return { totalUsers, inactiveUsers, hiddenProfiles, exFeeders };
+  const dashboardCount = (dashboardCountData) => {
+    if (dashboardCountData) {
+      const totalUsers = dashboardCountData.user;
+      const inactiveUsers = dashboardCountData.inactive;
+      const hiddenProfiles = dashboardCountData.flagged;
+      const exFeeders = dashboardCountData.exFeeder;
+      return { totalUsers, inactiveUsers, hiddenProfiles, exFeeders };
+    }
+    return {};
   };
 
   /* gets monthly data for the stat cards on dashboard */
   // New users in month, and Growth rate in month
-  const monthGrowthRate = growthRateByMonthData => {
-    const growthRate = growthRateByMonthData.growthRateFromPreviousMonth;
+  const monthGrowthRate = (growthRateByMonthData) => {
+    if (growthRateByMonthData) {
+      const growthRate = growthRateByMonthData.growthRateFromPreviousMonth;
 
-    const currentMonthAdditions =
-      growthRateByMonthData.current_month_additions.count;
+      const currentMonthAdditions =
+        growthRateByMonthData.current_month_additions.count;
 
-    return { growthRate, currentMonthAdditions };
+      return { growthRate, currentMonthAdditions };
+    }
+    return {};
   };
 
   return (
@@ -34,7 +41,7 @@ function StatCards({ data }) {
       monthGrowthRate={monthGrowthRate(data.growthRateByMonth)}
     />
   );
-}
+};
 
 StatCards.propTypes = {
   data: PropTypes.shape({

--- a/services/frontend-v3/src/components/admin/statCards/StatCardsView.jsx
+++ b/services/frontend-v3/src/components/admin/statCards/StatCardsView.jsx
@@ -18,7 +18,11 @@ import { IntlPropType } from "../../../customPropTypes";
  *  This component renders the statistic cards for the Admin Dashboard page.
  */
 
-function StatCardsView({ dashboardCount, intl, monthGrowthRate }) {
+const StatCardsView = ({ dashboardCount, intl, monthGrowthRate }) => {
+  if (!dashboardCount || !monthGrowthRate) {
+    return null;
+  }
+
   return (
     <Row gutter={[8, 8]} type="flex">
       <Col span={4}>

--- a/services/frontend-v3/src/pages/admin/Dashboard.jsx
+++ b/services/frontend-v3/src/pages/admin/Dashboard.jsx
@@ -33,7 +33,7 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error);
-      return 0;
+      return [];
     }
   };
 


### PR DESCRIPTION
If the backend is down, the app will crash. This fixes the admin/ routes, instead of returning 0 when the components expect an array, we just provide an empty array and add additional checks to see if data is defined or not.

Related to #246