### PR TITLE
Handle get request errors

### DIFF
--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContent.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContent.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import AdminErrorContentView from "./AdminErrorContentView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const AdminErrorContent = ({ networkError }) => {
-  return <AdminErrorContentView networkError={networkError} />;
+const AdminErrorContent = ({ networkErrors }) => {
+  return <AdminErrorContentView networkErrors={networkErrors} />;
+};
+
+AdminErrorContent.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default AdminErrorContent;

--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContent.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContent.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import AdminErrorContentView from "./AdminErrorContentView";
+
+const AdminErrorContent = ({ networkError }) => {
+  return <AdminErrorContentView networkError={networkError} />;
+};
+
+export default AdminErrorContent;

--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
@@ -2,10 +2,16 @@ import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
 import { PageHeader } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { List } from "antd";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const AdminErrorContentView = ({ networkError }) => {
+const AdminErrorContentView = ({ networkErrors }) => {
   const styles = {
-    errorTitle: { paddingLeft: "8px" },
+    errorTitleText: { paddingLeft: "8px" },
+    itemTitleText: {
+      fontSize: "14px",
+      fontWeight: "normal",
+    },
   };
   return (
     <>
@@ -13,27 +19,48 @@ const AdminErrorContentView = ({ networkError }) => {
         title={
           <>
             <WarningOutlined />
-            <span style={styles.errorTitle}>
+            <span style={styles.errorTitleText}>
               <FormattedMessage id="error.network" />
             </span>
           </>
         }
       />
-      <div>
-        <p>
-          {networkError.config.method.toUpperCase()} {networkError.config.url}
-        </p>
-        {networkError && networkError.response && networkError.response.data ? (
-          <>
-            <p>{networkError.response.data.status}</p>
-            <p>{networkError.response.data.message}</p>
-          </>
-        ) : (
-          <p>no response from backend server</p>
+      <List
+        size="small"
+        dataSource={networkErrors}
+        renderItem={item => (
+          <List.Item>
+            <List.Item.Meta
+              title={
+                <span style={styles.itemTitleText}>
+                  {item.config.method.toUpperCase()} {item.config.url}
+                </span>
+              }
+              description={
+                item.response && item.response.data ? (
+                  <>
+                    <div style={styles.itemDescription}>
+                      {item.response.status}
+                    </div>
+                    <div style={styles.itemDescription}>
+                      {item.response.statusText}
+                    </div>
+                  </>
+                ) : (
+                  <div style={styles.itemDescription}>
+                    No response from backend
+                  </div>
+                )
+              }
+            />
+          </List.Item>
         )}
-      </div>
+      />
     </>
   );
+};
+AdminErrorContentView.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(AdminErrorContentView);

--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
@@ -47,7 +47,7 @@ const AdminErrorContentView = ({ networkErrors }) => {
                   </>
                 ) : (
                   <div style={styles.itemDescription}>
-                    No response from backend
+                    <FormattedMessage id="error.no.backend.response" />
                   </div>
                 )
               }

--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { PageHeader } from "antd";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const AdminErrorContentView = ({ networkError }) => {
+  const styles = {
+    errorTitle: { paddingLeft: "8px" },
+  };
+  return (
+    <>
+      <PageHeader
+        title={
+          <>
+            <WarningOutlined />
+            <span style={styles.errorTitle}>
+              <FormattedMessage id="error.network" />
+            </span>
+          </>
+        }
+      />
+      <div>
+        <p>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </p>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <p>{networkError.response.data.status}</p>
+            <p>{networkError.response.data.message}</p>
+          </>
+        ) : (
+          <p>no response from backend server</p>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(AdminErrorContentView);

--- a/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
+++ b/services/frontend-v3/src/components/admin/adminErrorContent/AdminErrorContentView.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
-import { PageHeader } from "antd";
+import { PageHeader, List } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
-import { List } from "antd";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
 const AdminErrorContentView = ({ networkErrors }) => {

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTable.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTable.jsx
@@ -23,7 +23,7 @@ function CategoryTable({ intl, type }) {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const size = "large";
 
@@ -38,7 +38,7 @@ function CategoryTable({ intl, type }) {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -201,7 +201,7 @@ function CategoryTable({ intl, type }) {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
-      networkError={networkError}
+      networkErrors={networkErrors}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTable.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTable.jsx
@@ -23,6 +23,7 @@ function CategoryTable({ intl, type }) {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -37,6 +38,7 @@ function CategoryTable({ intl, type }) {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -89,7 +91,7 @@ function CategoryTable({ intl, type }) {
 
   /* handles addition of a category */
   // eslint-disable-next-line consistent-return
-  const handleSubmitAdd = async (values) => {
+  const handleSubmitAdd = async values => {
     try {
       const url = `${backendAddress}api/admin/options/${type}`;
 
@@ -126,7 +128,7 @@ function CategoryTable({ intl, type }) {
   };
 
   /* get part of the title for the page */
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -149,14 +151,14 @@ function CategoryTable({ intl, type }) {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
 
   /* helper function to rowSelection */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const onSelectChange = (selectedRowKeys) => {
+  const onSelectChange = selectedRowKeys => {
     // Can access the keys of each category selected in the table
     setSelectedRowKeys(selectedRowKeys);
   };
@@ -164,7 +166,7 @@ function CategoryTable({ intl, type }) {
   /* handles row selection in the table */
   // Consult: function taken from Ant Design table components (updated to functional)
   const rowSelection = {
-    onChange: (selectedRowKeys) => {
+    onChange: selectedRowKeys => {
       onSelectChange(selectedRowKeys);
     },
   };
@@ -199,6 +201,7 @@ function CategoryTable({ intl, type }) {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
+      networkError={networkError}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -21,7 +21,7 @@ import {
 } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
@@ -35,7 +35,7 @@ const CategoryTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
-  networkError,
+  networkErrors,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -507,8 +507,8 @@ const CategoryTableView = ({
     return categoryTableColumns;
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -565,6 +565,7 @@ CategoryTableView.propTypes = {
   size: PropTypes.string.isRequired,
   rowSelection: PropTypes.objectOf(PropTypes.any),
   data: PropTypes.arrayOf(PropTypes.any).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
   // data: PropTypes.shape({
   //   getCategoryInformation: PropTypes.shape({
   //     description: PropTypes.string,

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -22,6 +22,7 @@ import {
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import { IntlPropType } from "../../../customPropTypes";
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
  *  CategoryTableView(props)
@@ -34,6 +35,7 @@ const CategoryTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
+  networkError,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -66,7 +68,7 @@ const CategoryTableView = ({
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -74,7 +76,7 @@ const CategoryTableView = ({
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -104,17 +106,17 @@ const CategoryTableView = ({
         </Button>
       </div>
     ),
-    filterIcon: (filtered) => (
+    filterIcon: filtered => (
       <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visible) => {
+    onFilterDropdownVisibleChange: visible => {
       if (visible) {
         setTimeout(() => searchInput.select());
       }
     },
-    render: (text) =>
+    render: text =>
       searchedColumn === dataIndex ? (
         <Highlighter
           highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -129,7 +131,7 @@ const CategoryTableView = ({
 
   /* handles the transfer of new or update/edited category information to function */
   // Allows for backend action to occur based on modalType
-  const onCreate = (values) => {
+  const onCreate = values => {
     if (modalType === "edit") {
       handleSubmitEdit(values, record.id);
     } else if (modalType === "add") {
@@ -204,7 +206,7 @@ const CategoryTableView = ({
   };
 
   /* handles render of "Edit Category" modal */
-  const handleEditModal = (record) => {
+  const handleEditModal = record => {
     setEditVisible(true);
     setRecord(record);
     setModalType("edit");
@@ -219,7 +221,7 @@ const CategoryTableView = ({
   /* gets sort direction for a table column */
   // Use for tables that need a French and English column
   // Will change sort capability of column based on current language of page
-  const getSortDirection = (column) => {
+  const getSortDirection = column => {
     const currentLanguage =
       intl.formatMessage({ id: "language.code" }) === "en" ? "en" : "fr";
     if (column === currentLanguage) {
@@ -248,12 +250,12 @@ const CategoryTableView = ({
         onOk={() => {
           addForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               addForm.resetFields();
               onCreate(values);
               handleOk();
             })
-            .catch((info) => {
+            .catch(info => {
               handleCancel();
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
@@ -338,11 +340,11 @@ const CategoryTableView = ({
         onOk={() => {
           editForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               editForm.resetFields();
               onCreate(values);
             })
-            .catch((info) => {
+            .catch(info => {
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
             });
@@ -484,7 +486,7 @@ const CategoryTableView = ({
           defaultMessage: "Edit",
         }),
         key: "edit",
-        render: (record) => (
+        render: record => (
           <div>
             <Button
               type="primary"
@@ -504,6 +506,10 @@ const CategoryTableView = ({
     ];
     return categoryTableColumns;
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTable.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTable.jsx
@@ -23,8 +23,7 @@ const CompetencyTable = ({ intl, type }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
-
+  const [networkErrors, setNetworkErrors] = useState([]);
   const size = "large";
 
   /* get competency information */
@@ -35,7 +34,7 @@ const CompetencyTable = ({ intl, type }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -193,7 +192,7 @@ const CompetencyTable = ({ intl, type }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
-      networkError={networkError}
+      networkErrors={networkErrors}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTable.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTable.jsx
@@ -23,6 +23,7 @@ const CompetencyTable = ({ intl, type }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -34,6 +35,7 @@ const CompetencyTable = ({ intl, type }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -62,7 +64,7 @@ const CompetencyTable = ({ intl, type }) => {
   }, [getCompetencies, loading, reset]);
 
   /* get part of the title for the page */
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -85,13 +87,13 @@ const CompetencyTable = ({ intl, type }) => {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
 
   /* handles addition of a competency */
-  const handleSubmitAdd = async (values) => {
+  const handleSubmitAdd = async values => {
     try {
       const url = `${backendAddress}api/admin/options/${type}`;
 
@@ -148,7 +150,7 @@ const CompetencyTable = ({ intl, type }) => {
 
   /* helper function to rowSelection */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const onSelectChange = (selectedRowKeys) => {
+  const onSelectChange = selectedRowKeys => {
     // Can access the keys of each competency selected in the table
     setSelectedRowKeys(selectedRowKeys);
   };
@@ -156,7 +158,7 @@ const CompetencyTable = ({ intl, type }) => {
   /* handles row selection in the table */
   // Consult: function taken from Ant Design table components (updated to functional)
   const rowSelection = {
-    onChange: (selectedRowKeys) => {
+    onChange: selectedRowKeys => {
       onSelectChange(selectedRowKeys);
     },
   };
@@ -191,6 +193,7 @@ const CompetencyTable = ({ intl, type }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
+      networkError={networkError}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}
@@ -199,7 +202,7 @@ const CompetencyTable = ({ intl, type }) => {
       data={convertToViewableInformation()}
     />
   );
-}
+};
 
 CompetencyTable.propTypes = {
   intl: IntlPropType,

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -21,7 +21,7 @@ import {
 } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
@@ -35,7 +35,7 @@ const CompetencyTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
-  networkError,
+  networkErrors,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -487,8 +487,8 @@ const CompetencyTableView = ({
     return competencyTableColumns;
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -545,6 +545,7 @@ CompetencyTableView.propTypes = {
   size: PropTypes.string.isRequired,
   rowSelection: PropTypes.objectOf(PropTypes.any).isRequired,
   data: PropTypes.arrayOf(PropTypes.any).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
   // data: PropTypes.srr({
   //   getCategoryInformation: PropTypes.shape({
   //     description: PropTypes.string,

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -22,6 +22,7 @@ import {
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import { IntlPropType } from "../../../customPropTypes";
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
  *  CompetencyTableView(props)
@@ -34,6 +35,7 @@ const CompetencyTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
+  networkError,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -66,7 +68,7 @@ const CompetencyTableView = ({
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -74,7 +76,7 @@ const CompetencyTableView = ({
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -104,17 +106,17 @@ const CompetencyTableView = ({
         </Button>
       </div>
     ),
-    filterIcon: (filtered) => (
+    filterIcon: filtered => (
       <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visible) => {
+    onFilterDropdownVisibleChange: visible => {
       if (visible) {
         setTimeout(() => searchInput.select());
       }
     },
-    render: (text) =>
+    render: text =>
       searchedColumn === dataIndex ? (
         <Highlighter
           highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -190,7 +192,7 @@ const CompetencyTableView = ({
 
   /* handles the transfer of new or update/edited competency information to function */
   // Allows for backend action to occur based on modalType
-  const onCreate = (values) => {
+  const onCreate = values => {
     if (modalType === "edit") {
       handleSubmitEdit(values, record.id);
     } else if (modalType === "add") {
@@ -224,7 +226,7 @@ const CompetencyTableView = ({
   };
 
   /* handles render of "Edit Competency" modal */
-  const handleEditModal = (record) => {
+  const handleEditModal = record => {
     setEditVisible(true);
     setRecord(record);
     setModalType("edit");
@@ -256,12 +258,12 @@ const CompetencyTableView = ({
         onOk={() => {
           addForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               addForm.resetFields();
               onCreate(values);
               handleOk();
             })
-            .catch((info) => {
+            .catch(info => {
               handleCancel();
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
@@ -346,11 +348,11 @@ const CompetencyTableView = ({
         onOk={() => {
           editForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               editForm.resetFields();
               onCreate(values);
             })
-            .catch((info) => {
+            .catch(info => {
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
             });
@@ -406,7 +408,7 @@ const CompetencyTableView = ({
   /* gets sort direction for a table column */
   // Use for tables that need a French and English column
   // Will change sort capability of column based on current language of page
-  const getSortDirection = (column) => {
+  const getSortDirection = column => {
     const currentLanguage =
       intl.formatMessage({ id: "language.code" }) === "en" ? "en" : "fr";
     if (column === currentLanguage) {
@@ -464,7 +466,7 @@ const CompetencyTableView = ({
           defaultMessage: "Edit",
         }),
         key: "edit",
-        render: (record) => (
+        render: record => (
           <div>
             <Button
               type="primary"
@@ -484,6 +486,10 @@ const CompetencyTableView = ({
     ];
     return competencyTableColumns;
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTable.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTable.jsx
@@ -21,6 +21,7 @@ const DiplomaTable = ({ type, intl }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -32,6 +33,7 @@ const DiplomaTable = ({ type, intl }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -39,7 +41,7 @@ const DiplomaTable = ({ type, intl }) => {
   }, [type]);
 
   // Get part of the title for the page
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -83,13 +85,13 @@ const DiplomaTable = ({ type, intl }) => {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
 
   /* handles addition of a diploma */
-  const handleSubmitAdd = async (values) => {
+  const handleSubmitAdd = async values => {
     try {
       const url = `${backendAddress}api/admin/options/${type}`;
 
@@ -145,7 +147,7 @@ const DiplomaTable = ({ type, intl }) => {
 
   /* helper function to rowSelection */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const onSelectChange = (modifiedSelectedRowKeys) => {
+  const onSelectChange = modifiedSelectedRowKeys => {
     // Can access the keys of each diploma selected in the table
     setSelectedRowKeys(modifiedSelectedRowKeys);
   };
@@ -153,7 +155,7 @@ const DiplomaTable = ({ type, intl }) => {
   /* handles row selection in the table */
   // Consult: function taken from Ant Design table components (updated to functional)
   const rowSelection = {
-    onChange: (modifiedSelectedRowKeys) => {
+    onChange: modifiedSelectedRowKeys => {
       onSelectChange(modifiedSelectedRowKeys);
     },
   };
@@ -188,6 +190,7 @@ const DiplomaTable = ({ type, intl }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
+      networkError={networkError}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTable.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTable.jsx
@@ -21,7 +21,7 @@ const DiplomaTable = ({ type, intl }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const size = "large";
 
@@ -33,7 +33,7 @@ const DiplomaTable = ({ type, intl }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -190,7 +190,7 @@ const DiplomaTable = ({ type, intl }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
-      networkError={networkError}
+      networkErrors={networkErrors}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -20,6 +20,7 @@ import {
 } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
  *  DiplomaTableView(props)
@@ -31,6 +32,7 @@ const DiplomaTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
+  networkError,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -62,7 +64,7 @@ const DiplomaTableView = ({
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -70,7 +72,7 @@ const DiplomaTableView = ({
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -100,7 +102,7 @@ const DiplomaTableView = ({
         </Button>
       </div>
     ),
-    filterIcon: (filtered) => (
+    filterIcon: filtered => (
       <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
     ),
     onFilter: (value, currentRecord) =>
@@ -108,12 +110,12 @@ const DiplomaTableView = ({
         .toString()
         .toLowerCase()
         .includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visible) => {
+    onFilterDropdownVisibleChange: visible => {
       if (visible) {
         setTimeout(() => searchInput.select());
       }
     },
-    render: (text) =>
+    render: text =>
       searchedColumn === dataIndex ? (
         <Highlighter
           highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -189,7 +191,7 @@ const DiplomaTableView = ({
 
   /* handles the transfer of new or update/edited diploma information to function */
   // Allows for backend action to occur based on modalType
-  const onCreate = (values) => {
+  const onCreate = values => {
     if (modalType === "edit") {
       handleSubmitEdit(values, record.id);
     } else if (modalType === "add") {
@@ -223,7 +225,7 @@ const DiplomaTableView = ({
   };
 
   /* handles render of "Edit Diploma" modal */
-  const handleEditModal = (item) => {
+  const handleEditModal = item => {
     setEditVisible(true);
     setRecord(item);
     setModalType("edit");
@@ -255,12 +257,12 @@ const DiplomaTableView = ({
         onOk={() => {
           addForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               addForm.resetFields();
               onCreate(values);
               handleOk();
             })
-            .catch((info) => {
+            .catch(info => {
               handleCancel();
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
@@ -345,11 +347,11 @@ const DiplomaTableView = ({
         onOk={() => {
           editForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               editForm.resetFields();
               onCreate(values);
             })
-            .catch((info) => {
+            .catch(info => {
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
             });
@@ -405,7 +407,7 @@ const DiplomaTableView = ({
   /* gets sort direction for a table column */
   // Use for tables that need a French and English column
   // Will change sort capability of column based on current language of page
-  const getSortDirection = (column) => {
+  const getSortDirection = column => {
     const currentLanguage =
       intl.formatMessage({ id: "language.code" }) === "en" ? "en" : "fr";
     if (column === currentLanguage) {
@@ -463,7 +465,7 @@ const DiplomaTableView = ({
           defaultMessage: "Edit",
         }),
         key: "edit",
-        render: (item) => (
+        render: item => (
           <div>
             <Button
               type="primary"
@@ -483,6 +485,10 @@ const DiplomaTableView = ({
     ];
     return diplomaTableCol;
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -20,6 +20,7 @@ import {
 } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
@@ -32,7 +33,7 @@ const DiplomaTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
-  networkError,
+  networkErrors,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -486,8 +487,8 @@ const DiplomaTableView = ({
     return diplomaTableCol;
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -554,6 +555,7 @@ DiplomaTableView.propTypes = {
   searchedColumn: PropTypes.string.isRequired,
   selectedRowKeys: PropTypes.arrayOf(PropTypes.any).isRequired,
   size: PropTypes.string.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(DiplomaTableView);

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTable.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTable.jsx
@@ -22,7 +22,7 @@ const SchoolTable = ({ type, intl }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const size = "large";
 
@@ -34,7 +34,7 @@ const SchoolTable = ({ type, intl }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -189,7 +189,7 @@ const SchoolTable = ({ type, intl }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
-      networkError={networkError}
+      networkErrors={networkErrors}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTable.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTable.jsx
@@ -22,6 +22,7 @@ const SchoolTable = ({ type, intl }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -33,6 +34,7 @@ const SchoolTable = ({ type, intl }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -63,7 +65,7 @@ const SchoolTable = ({ type, intl }) => {
   }, [getSchools, loading, reset]);
 
   /* get part of the title for the page */
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -86,13 +88,13 @@ const SchoolTable = ({ type, intl }) => {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
 
   /* handles addition of a school */
-  const handleSubmitAdd = async (values) => {
+  const handleSubmitAdd = async values => {
     try {
       const url = `${backendAddress}api/admin/options/${type}`;
 
@@ -150,7 +152,7 @@ const SchoolTable = ({ type, intl }) => {
 
   /* helper function to rowSelection */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const onSelectChange = (_selectedRowKeys) => {
+  const onSelectChange = _selectedRowKeys => {
     // Can access the keys of each school selected in the table
     setSelectedRowKeys(_selectedRowKeys);
   };
@@ -158,7 +160,7 @@ const SchoolTable = ({ type, intl }) => {
   /* handles row selection in the table */
   // Consult: function taken from Ant Design table components (updated to functional)
   const rowSelection = {
-    onChange: (_selectedRowKeys) => {
+    onChange: _selectedRowKeys => {
       onSelectChange(_selectedRowKeys);
     },
   };
@@ -187,6 +189,7 @@ const SchoolTable = ({ type, intl }) => {
       handleSubmitAdd={handleSubmitAdd}
       handleSubmitEdit={handleSubmitEdit}
       handleSubmitDelete={handleSubmitDelete}
+      networkError={networkError}
       selectedRowKeys={selectedRowKeys}
       searchedColumn={searchedColumn}
       searchText={searchText}

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -21,6 +21,7 @@ import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { IntlPropType } from "../../../customPropTypes";
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
  *  SchoolTableView(props)
@@ -32,6 +33,7 @@ const SchoolTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
+  networkError,
   intl,
   selectedRowKeys,
   searchedColumn,
@@ -67,7 +69,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -75,7 +77,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -115,7 +117,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
 
     return {
       filterDropdown,
-      filterIcon: (filtered) => (
+      filterIcon: filtered => (
         <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
       ),
       onFilter: (_value, _record) =>
@@ -123,12 +125,12 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
           .toString()
           .toLowerCase()
           .includes(_value.toLowerCase()),
-      onFilterDropdownVisibleChange: (visible) => {
+      onFilterDropdownVisibleChange: visible => {
         if (visible) {
           setTimeout(() => searchInput.select());
         }
       },
-      render: (text) =>
+      render: text =>
         searchedColumn === dataIndex ? (
           <Highlighter
             highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -207,7 +209,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
 
   /* handles the transfer of new or update/edited school information to function */
   // Allows for backend action to occur based on modalType
-  const onCreate = (values) => {
+  const onCreate = values => {
     if (modalType === "edit") {
       handleSubmitEdit(values, record.id);
     } else if (modalType === "add") {
@@ -241,7 +243,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
   };
 
   /* handles render of "Edit School" modal */
-  const handleEditModal = (_record) => {
+  const handleEditModal = _record => {
     setEditVisible(true);
     setRecord(_record);
     setModalType("edit");
@@ -273,12 +275,12 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
         onOk={() => {
           addForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               addForm.resetFields();
               onCreate(values);
               handleOk();
             })
-            .catch((info) => {
+            .catch(info => {
               handleCancel();
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
@@ -389,11 +391,11 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
         onOk={() => {
           editForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               editForm.resetFields();
               onCreate(values);
             })
-            .catch((info) => {
+            .catch(info => {
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
             });
@@ -530,7 +532,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
           defaultMessage: "Edit",
         }),
         key: "edit",
-        render: (_record) => (
+        render: _record => (
           <div>
             <Button
               type="primary"
@@ -550,6 +552,10 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
       },
     ];
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>
@@ -590,7 +596,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
       </Row>
     </>
   );
-}
+};
 
 SchoolTableView.propTypes = {
   handleSearch: PropTypes.func.isRequired,

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -20,7 +20,7 @@ import {
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
@@ -33,7 +33,7 @@ const SchoolTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
-  networkError,
+  networkErrors,
   intl,
   selectedRowKeys,
   searchedColumn,
@@ -553,8 +553,8 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
     ];
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -619,6 +619,7 @@ SchoolTableView.propTypes = {
       state: PropTypes.string,
     })
   ).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 SchoolTableView.defaultProps = {

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
@@ -24,7 +24,7 @@ const SkillTable = ({ intl, type }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const size = "large";
 
@@ -37,7 +37,7 @@ const SkillTable = ({ intl, type }) => {
 
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -52,6 +52,7 @@ const SkillTable = ({ intl, type }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -245,7 +246,7 @@ const SkillTable = ({ intl, type }) => {
       searchedColumn={searchedColumn}
       searchText={searchText}
       size={size}
-      networkError={networkError}
+      networkErrors={networkErrors}
       rowSelection={rowSelection}
       data={getSkillInformation()}
       categories={categories}

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTable.jsx
@@ -24,6 +24,7 @@ const SkillTable = ({ intl, type }) => {
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -36,6 +37,7 @@ const SkillTable = ({ intl, type }) => {
 
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -81,7 +83,7 @@ const SkillTable = ({ intl, type }) => {
   }, [getCategories, getSkill, loading, reset]);
 
   /* get part of the title for the page */
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -104,14 +106,14 @@ const SkillTable = ({ intl, type }) => {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
 
   /* handles addition of a skill */
   // eslint-disable-next-line consistent-return
-  const handleSubmitAdd = async (values) => {
+  const handleSubmitAdd = async values => {
     try {
       const url = `${backendAddress}api/admin/options/${type}`;
 
@@ -137,7 +139,7 @@ const SkillTable = ({ intl, type }) => {
 
       if (typeof values.editSkillCategory === "string") {
         const index = categories.findIndex(
-          (object) =>
+          object =>
             object.descriptionEn === values.editSkillCategory ||
             object.descriptionFr === values.editSkillCategory
         );
@@ -149,7 +151,7 @@ const SkillTable = ({ intl, type }) => {
         });
       } else {
         const categoryObject = categories.find(
-          (category) => category.id === values.editSkillCategory
+          category => category.id === values.editSkillCategory
         );
         await axios.put(url, {
           descriptionEn: values.editSkillEn,
@@ -186,7 +188,7 @@ const SkillTable = ({ intl, type }) => {
 
   /* helper function to rowSelection */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const onSelectChange = (selectedRowKeys) => {
+  const onSelectChange = selectedRowKeys => {
     // Can access the keys of each skill selected in the table
     setSelectedRowKeys(selectedRowKeys);
   };
@@ -194,7 +196,7 @@ const SkillTable = ({ intl, type }) => {
   /* handles row selection in the table */
   // Consult: function taken from Ant Design table components (updated to functional)
   const rowSelection = {
-    onChange: (selectedRowKeys) => {
+    onChange: selectedRowKeys => {
       onSelectChange(selectedRowKeys);
     },
   };
@@ -218,7 +220,7 @@ const SkillTable = ({ intl, type }) => {
       allSkills[i].key = allSkills[i].id;
     }
 
-    allSkills.forEach((e) => {
+    allSkills.forEach(e => {
       e.categoryNameEn = e.category.descriptionEn;
       e.categoryNameFr = e.category.descriptionFr;
     });
@@ -243,6 +245,7 @@ const SkillTable = ({ intl, type }) => {
       searchedColumn={searchedColumn}
       searchText={searchText}
       size={size}
+      networkError={networkError}
       rowSelection={rowSelection}
       data={getSkillInformation()}
       categories={categories}

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -22,7 +22,7 @@ import {
 } from "@ant-design/icons";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
@@ -35,7 +35,7 @@ const SkillTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
-  networkError,
+  networkErrors,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -584,8 +584,8 @@ const SkillTableView = ({
     );
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -649,6 +649,7 @@ SkillTableView.propTypes = {
   //   }),
   // }).isRequired,
   categories: PropTypes.arrayOf(PropTypes.any).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 SkillTableView.defaultProps = {

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -23,6 +23,7 @@ import {
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import { IntlPropType } from "../../../customPropTypes";
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 
 /**
  *  SkillTableView(props)
@@ -34,6 +35,7 @@ const SkillTableView = ({
   handleSubmitAdd,
   handleSubmitEdit,
   handleSubmitDelete,
+  networkError,
   selectedRowKeys,
   searchedColumn,
   searchText,
@@ -70,7 +72,7 @@ const SkillTableView = ({
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -78,7 +80,7 @@ const SkillTableView = ({
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -108,17 +110,17 @@ const SkillTableView = ({
         </Button>
       </div>
     ),
-    filterIcon: (filtered) => (
+    filterIcon: filtered => (
       <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visible) => {
+    onFilterDropdownVisibleChange: visible => {
       if (visible) {
         setTimeout(() => searchInput.select());
       }
     },
-    render: (text) =>
+    render: text =>
       searchedColumn === dataIndex ? (
         <Highlighter
           highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -133,7 +135,7 @@ const SkillTableView = ({
 
   /* handles the transfer of new or update/edited skill information to function */
   // Allows for backend action to occur based on modalType
-  const onCreate = (values) => {
+  const onCreate = values => {
     if (modalType === "edit") {
       handleSubmitEdit(values, record.id);
     } else if (modalType === "add") {
@@ -187,7 +189,7 @@ const SkillTableView = ({
   };
 
   /* handles render of "Edit Skill" modal */
-  const handleEditModal = (record) => {
+  const handleEditModal = record => {
     setEditVisible(true);
     setRecord(record);
     setModalType("edit");
@@ -260,11 +262,11 @@ const SkillTableView = ({
         onOk={() => {
           editForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               editForm.resetFields();
               onCreate(values);
             })
-            .catch((info) => {
+            .catch(info => {
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
             });
@@ -333,7 +335,7 @@ const SkillTableView = ({
                 option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
               }
             >
-              {categories.map((category) => {
+              {categories.map(category => {
                 return (
                   <Option value={category.id} key={category.id}>
                     {intl.formatMessage({ id: "language.code" }) === "en"
@@ -421,7 +423,7 @@ const SkillTableView = ({
           defaultMessage: "Edit",
         }),
         key: "edit",
-        render: (record) => (
+        render: record => (
           <div>
             <Button
               type="primary"
@@ -471,12 +473,12 @@ const SkillTableView = ({
         onOk={() => {
           addForm
             .validateFields()
-            .then((values) => {
+            .then(values => {
               addForm.resetFields();
               onCreate(values);
               handleOk();
             })
-            .catch((info) => {
+            .catch(info => {
               handleCancel();
               // eslint-disable-next-line no-console
               console.log("Validate Failed:", info);
@@ -566,7 +568,7 @@ const SkillTableView = ({
                 option.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
               }
             >
-              {categories.map((category) => {
+              {categories.map(category => {
                 return (
                   <Option value={category.id} key={category.id}>
                     {intl.formatMessage({ id: "language.code" }) === "en"
@@ -581,6 +583,10 @@ const SkillTableView = ({
       </Modal>
     );
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>

--- a/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
@@ -24,7 +24,7 @@ function UserTable({ intl, type }) {
   const [reset, setReset] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const size = "large";
 
@@ -35,7 +35,7 @@ function UserTable({ intl, type }) {
 
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -181,7 +181,7 @@ function UserTable({ intl, type }) {
       profileStatusValue={profileStatusValue}
       handleSearch={handleSearch}
       handleReset={handleReset}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 }

--- a/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
@@ -24,6 +24,7 @@ function UserTable({ intl, type }) {
   const [reset, setReset] = useState(false);
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
+  const [networkError, setNetworkError] = useState(null);
 
   const size = "large";
 
@@ -34,6 +35,7 @@ function UserTable({ intl, type }) {
 
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -78,7 +80,7 @@ function UserTable({ intl, type }) {
   };
 
   /* get part of the title for the page */
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -101,7 +103,7 @@ function UserTable({ intl, type }) {
 
   /* handles reset of column search functionality */
   // Consult: function taken from Ant Design table components (updated to functional)
-  const handleReset = (clearFilters) => {
+  const handleReset = clearFilters => {
     clearFilters();
     setSearchText("");
   };
@@ -142,7 +144,7 @@ function UserTable({ intl, type }) {
       convertData[i].key = convertData[i].id;
     }
 
-    convertData.forEach((e) => {
+    convertData.forEach(e => {
       e.fullName = e.user.name;
       e.formatCreatedAt = moment(e.createdAt).format("LLL");
       e.profileLink = `/secured/profile/${e.id}`;
@@ -179,6 +181,7 @@ function UserTable({ intl, type }) {
       profileStatusValue={profileStatusValue}
       handleSearch={handleSearch}
       handleReset={handleReset}
+      networkError={networkError}
     />
   );
 }

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -20,7 +20,7 @@ import {
 import moment from "moment";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 /**
  *  UserTableView(props)
@@ -37,7 +37,7 @@ const UserTableView = ({
   profileStatusValue,
   handleSearch,
   handleReset,
-  networkError,
+  networkErrors,
 }) => {
   let searchInput;
 
@@ -363,8 +363,8 @@ const UserTableView = ({
     return tableColumns;
   };
 
-  if (networkError) {
-    return <AdminErrorContent networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <AdminErrorContent networkErrors={networkErrors} />;
   }
 
   return (
@@ -396,6 +396,7 @@ UserTableView.propTypes = {
   searchText: PropTypes.string.isRequired,
   size: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.any).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
   // data: PropTypes.shape({
   //   getCategoryInformation: PropTypes.shape({
   //     description: PropTypes.string,

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -21,7 +21,7 @@ import moment from "moment";
 import Highlighter from "react-highlight-words";
 import { injectIntl } from "react-intl";
 import { IntlPropType } from "../../../customPropTypes";
-
+import AdminErrorContent from "../adminErrorContent/AdminErrorContent";
 /**
  *  UserTableView(props)
  *  This component renders the user table for the Admin User Page.
@@ -37,6 +37,7 @@ const UserTableView = ({
   profileStatusValue,
   handleSearch,
   handleReset,
+  networkError,
 }) => {
   let searchInput;
 
@@ -69,7 +70,7 @@ const UserTableView = ({
     }) => (
       <div style={{ padding: 8 }}>
         <Input
-          ref={(node) => {
+          ref={node => {
             searchInput = node;
           }}
           placeholder={`${intl.formatMessage({
@@ -77,7 +78,7 @@ const UserTableView = ({
             defaultMessage: "Search for",
           })} ${title}`}
           value={selectedKeys[0]}
-          onChange={(e) =>
+          onChange={e =>
             setSelectedKeys(e.target.value ? [e.target.value] : [])
           }
           onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
@@ -107,17 +108,17 @@ const UserTableView = ({
         </Button>
       </div>
     ),
-    filterIcon: (filtered) => (
+    filterIcon: filtered => (
       <SearchOutlined style={{ color: filtered ? "#1890ff" : undefined }} />
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visible) => {
+    onFilterDropdownVisibleChange: visible => {
       if (visible) {
         setTimeout(() => searchInput.select());
       }
     },
-    render: (text) =>
+    render: text =>
       searchedColumn === dataIndex ? (
         <Highlighter
           highlightStyle={{ backgroundColor: "#ffc069", padding: 0 }}
@@ -137,7 +138,7 @@ const UserTableView = ({
         <Select
           defaultValue={profileStatusValue(inactive, flagged)}
           style={{ width: 120 }}
-          onChange={(value) => {
+          onChange={value => {
             handleDropdownChange(value, id);
           }}
         >
@@ -258,7 +259,7 @@ const UserTableView = ({
           id: "admin.view",
           defaultMessage: "View",
         }),
-        render: (record) => (
+        render: record => (
           <span>
             <Button
               type="primary"
@@ -349,7 +350,7 @@ const UserTableView = ({
           id: "admin.profileStatus",
           defaultMessage: "Profile Status",
         }),
-        render: (record) => {
+        render: record => {
           return renderStatusDropdown(
             record.id,
             record.user.inactive,
@@ -361,6 +362,10 @@ const UserTableView = ({
 
     return tableColumns;
   };
+
+  if (networkError) {
+    return <AdminErrorContent networkError={networkError} />;
+  }
 
   return (
     <>
@@ -378,7 +383,7 @@ const UserTableView = ({
       </Row>
     </>
   );
-}
+};
 
 UserTableView.propTypes = {
   intl: IntlPropType,

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
@@ -2,14 +2,17 @@ import React from "react";
 import PropTypes from "prop-types";
 import ProfileLayoutView from "./ProfileLayoutView";
 
-import { ProfileInfoPropType } from "../../../customPropTypes";
+import {
+  ProfileInfoPropType,
+  NetworkErrorsPropType,
+} from "../../../customPropTypes";
 
-const ProfileLayout = ({ data, changeLanguage, networkError }) => {
+const ProfileLayout = ({ data, changeLanguage, networkErrors }) => {
   return (
     <ProfileLayoutView
       changeLanguage={changeLanguage}
       data={data}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };
@@ -17,6 +20,7 @@ const ProfileLayout = ({ data, changeLanguage, networkError }) => {
 ProfileLayout.propTypes = {
   data: ProfileInfoPropType,
   changeLanguage: PropTypes.func.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 ProfileLayout.defaultProps = {

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
@@ -4,8 +4,14 @@ import ProfileLayoutView from "./ProfileLayoutView";
 
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
-const ProfileLayout = ({ data, changeLanguage }) => {
-  return <ProfileLayoutView changeLanguage={changeLanguage} data={data} />;
+const ProfileLayout = ({ data, changeLanguage, networkError }) => {
+  return (
+    <ProfileLayoutView
+      changeLanguage={changeLanguage}
+      data={data}
+      networkError={networkError}
+    />
+  );
 };
 
 ProfileLayout.propTypes = {

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -19,18 +19,22 @@ import Experience from "../../experience/Experience";
 import Education from "../../education/Education";
 import Projects from "../../projects/Projects";
 import EmployeeSummary from "../../employeeSummary/EmployeeSummary";
+import ProfileError from "./profileError/profileError";
 
 const { Link } = Anchor;
 const { Title, Text } = Typography;
 
-const ProfileLayoutView = ({ data, changeLanguage }) => {
+const ProfileLayoutView = ({ data, changeLanguage, networkError }) => {
   // useParams returns an object of key/value pairs from URL parameters
   const { id } = useParams();
   const urlID = id;
   const userID = localStorage.getItem("userId");
 
   // Visibility values
-  const { visibleCards } = data;
+  let visibleCards;
+  if (data && data.visibleCards) {
+    visibleCards = data.visibleCards;
+  }
 
   /* Component Styles */
   const styles = {
@@ -555,10 +559,17 @@ const ProfileLayoutView = ({ data, changeLanguage }) => {
     );
   };
 
+  const generateContent = () => {
+    if (networkError) {
+      return <ProfileError networkError={networkError} />;
+    }
+    return displayAllProfileCards();
+  };
+
   return (
     <AppLayout
       changeLanguage={changeLanguage}
-      sideBarContent={generateProfileSidebarContent()}
+      sideBarContent={networkError ? null : generateProfileSidebarContent()}
       displaySideBar
     >
       <PageHeader
@@ -567,7 +578,7 @@ const ProfileLayoutView = ({ data, changeLanguage }) => {
         }}
         title={<FormattedMessage id="my.profile" />}
       />
-      {displayAllProfileCards()}
+      {generateContent()}
     </AppLayout>
   );
 };

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -5,7 +5,10 @@ import { PageHeader, Anchor, Typography, Row, Col } from "antd";
 import { TagsTwoTone, RiseOutlined, TrophyOutlined } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import AppLayout from "../appLayout/AppLayout";
-import { ProfileInfoPropType } from "../../../customPropTypes";
+import {
+  ProfileInfoPropType,
+  NetworkErrorsPropType,
+} from "../../../customPropTypes";
 
 import ProfileCards from "../../profileCards/ProfileCards";
 import BasicInfo from "../../basicInfo/BasicInfo";
@@ -24,7 +27,7 @@ import ProfileError from "./profileError/profileError";
 const { Link } = Anchor;
 const { Title, Text } = Typography;
 
-const ProfileLayoutView = ({ data, changeLanguage, networkError }) => {
+const ProfileLayoutView = ({ data, changeLanguage, networkErrors }) => {
   // useParams returns an object of key/value pairs from URL parameters
   const { id } = useParams();
   const urlID = id;
@@ -560,8 +563,8 @@ const ProfileLayoutView = ({ data, changeLanguage, networkError }) => {
   };
 
   const generateContent = () => {
-    if (networkError) {
-      return <ProfileError networkError={networkError} />;
+    if (networkErrors && networkErrors.length) {
+      return <ProfileError networkErrors={networkErrors} />;
     }
     return displayAllProfileCards();
   };
@@ -569,7 +572,7 @@ const ProfileLayoutView = ({ data, changeLanguage, networkError }) => {
   return (
     <AppLayout
       changeLanguage={changeLanguage}
-      sideBarContent={networkError ? null : generateProfileSidebarContent()}
+      sideBarContent={networkErrors ? null : generateProfileSidebarContent()}
       displaySideBar
     >
       <PageHeader
@@ -586,6 +589,7 @@ const ProfileLayoutView = ({ data, changeLanguage, networkError }) => {
 ProfileLayoutView.propTypes = {
   data: ProfileInfoPropType,
   changeLanguage: PropTypes.func.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 ProfileLayoutView.defaultProps = {

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -572,7 +572,11 @@ const ProfileLayoutView = ({ data, changeLanguage, networkErrors }) => {
   return (
     <AppLayout
       changeLanguage={changeLanguage}
-      sideBarContent={networkErrors ? null : generateProfileSidebarContent()}
+      sideBarContent={
+        networkErrors && networkErrors.length
+          ? null
+          : generateProfileSidebarContent()
+      }
       displaySideBar
     >
       <PageHeader

--- a/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileError.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileError.jsx
@@ -1,8 +1,12 @@
 import React from "react";
 import ProfileErrorView from "./profileErrorView";
+import { NetworkErrorsPropType } from "../../../../customPropTypes";
 
-const ProfileError = ({ networkError }) => {
-  return <ProfileErrorView networkError={networkError} />;
+const ProfileError = ({ networkErrors }) => {
+  return <ProfileErrorView networkErrors={networkErrors} />;
 };
 
+ProfileError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
+};
 export default ProfileError;

--- a/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileError.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileError.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ProfileErrorView from "./profileErrorView";
+
+const ProfileError = ({ networkError }) => {
+  return <ProfileErrorView networkError={networkError} />;
+};
+
+export default ProfileError;

--- a/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const ProfileErrorView = ({ networkError }) => {
+  const styles = {
+    errorTitle: {
+      paddingLeft: "8px",
+      fontWeight: "bold",
+      color: "rgba(0, 0, 0, 0.85)",
+    },
+  };
+  return (
+    <>
+      <>
+        <WarningOutlined />
+        <span style={styles.errorTitle}>
+          <FormattedMessage id="error.network" />
+        </span>
+      </>
+      <div>
+        <div>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </div>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <div>{networkError.response.data.status}</div>
+            <div>{networkError.response.data.message}</div>
+          </>
+        ) : (
+          <div>no response from backend server</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(ProfileErrorView);

--- a/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
@@ -51,7 +51,7 @@ const ProfileErrorView = ({ networkErrors }) => {
                   </>
                 ) : (
                   <div style={styles.itemDescription}>
-                    No response from backend
+                    <FormattedMessage id="error.no.backend.response" />
                   </div>
                 )
               }

--- a/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/profileError/profileErrorView.jsx
@@ -1,38 +1,70 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
+import { List } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { NetworkErrorsPropType } from "../../../../customPropTypes";
 
-const ProfileErrorView = ({ networkError }) => {
+const ProfileErrorView = ({ networkErrors }) => {
   const styles = {
-    errorTitle: {
+    errorTitleText: {
       paddingLeft: "8px",
       fontWeight: "bold",
       color: "rgba(0, 0, 0, 0.85)",
+    },
+    itemTitleText: {
+      wordBreak: "break-word",
+      fontSize: "14px",
+      fontWeight: "normal",
+    },
+    itemDescription: {
+      wordBreak: "break-word",
     },
   };
   return (
     <>
       <>
         <WarningOutlined />
-        <span style={styles.errorTitle}>
+        <span style={styles.errorTitleText}>
           <FormattedMessage id="error.network" />
         </span>
       </>
-      <div>
-        <div>
-          {networkError.config.method.toUpperCase()} {networkError.config.url}
-        </div>
-        {networkError && networkError.response && networkError.response.data ? (
-          <>
-            <div>{networkError.response.data.status}</div>
-            <div>{networkError.response.data.message}</div>
-          </>
-        ) : (
-          <div>no response from backend server</div>
+      <List
+        size="small"
+        dataSource={networkErrors}
+        renderItem={item => (
+          <List.Item>
+            <List.Item.Meta
+              title={
+                <span style={styles.itemTitleText}>
+                  {item.config.method.toUpperCase()} {item.config.url}
+                </span>
+              }
+              description={
+                item.response && item.response.data ? (
+                  <>
+                    <div style={styles.itemDescription}>
+                      {item.response.status}
+                    </div>
+                    <div style={styles.itemDescription}>
+                      {item.response.statusText}
+                    </div>
+                  </>
+                ) : (
+                  <div style={styles.itemDescription}>
+                    No response from backend
+                  </div>
+                )
+              }
+            />
+          </List.Item>
         )}
-      </div>
+      />
     </>
   );
+};
+
+ProfileErrorView.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(ProfileErrorView);

--- a/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
@@ -11,6 +11,8 @@ const { backendAddress } = config;
 const ProfileCards = ({ data, title, content, editUrl, cardName, id }) => {
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [disabled, setDisabled] = useState(true);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // useParams returns an object of key/value pairs from URL parameters
   const urlID = useParams().id;
@@ -24,11 +26,45 @@ const ProfileCards = ({ data, title, content, editUrl, cardName, id }) => {
       const result = await axios.get(url);
       return setProfileInfo(result.data);
     } catch (error) {
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
     }
   }, [urlID]);
+
+  /*
+   * Handle Visibility Toggle
+   *
+   * Handle card visibility toggle by updating state and saving state to backend
+   */
+  const handleVisibilityToggle = async () => {
+    // Update visibleCards state in profile
+    try {
+      // Get current card visibility status from db
+      const url = `${backendAddress}api/profile/${urlID}`;
+      const result = await axios.get(url);
+
+      try {
+        const { visibleCards } = result.data;
+        // change the stored value
+        const cardNameToBeModified = cardName;
+        visibleCards[cardNameToBeModified] = !disabled;
+        setDisabled(visibleCards[cardNameToBeModified]);
+        // save toggle value in db
+        await axios.put(`${backendAddress}api/profile/${urlID}`, {
+          visibleCards,
+        });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.log(error);
+      }
+    } catch (error) {
+      setNetworkErrors(oldArray => oldArray.concat(error));
+      // eslint-disable-next-line no-console
+      console.log(error);
+    }
+  };
 
   // get all required data component
   const getAllData = useCallback(async () => {
@@ -59,9 +95,13 @@ const ProfileCards = ({ data, title, content, editUrl, cardName, id }) => {
       cardName={cardName}
       getAllData={getAllData}
       id={id}
+      handleVisibilityToggle={handleVisibilityToggle}
+      networkErrors={networkErrors}
+      disabled={disabled}
+      setDisabled={setDisabled}
     />
   );
-}
+};
 
 ProfileCards.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -8,12 +8,11 @@ import {
 } from "@ant-design/icons";
 import { Card, Switch, Button, Row, Col, Tooltip } from "antd";
 import { FormattedMessage } from "react-intl";
-
-import axios from "axios";
-import { ProfileInfoPropType } from "../../customPropTypes";
-import config from "../../config";
-
-const { backendAddress } = config;
+import ProfileCardsError from "./profileCardsError/ProfileCardsError";
+import {
+  ProfileInfoPropType,
+  NetworkErrorsPropType,
+} from "../../customPropTypes";
 
 function ProfileCardsView({
   cardName,
@@ -23,41 +22,17 @@ function ProfileCardsView({
   id,
   content,
   style,
+  handleVisibilityToggle,
+  networkErrors,
+  disabled,
+  setDisabled,
 }) {
   const history = useHistory();
-  const [disabled, setDisabled] = useState(true);
 
   // useParams returns an object of key/value pairs from URL parameters
   const newId = useParams().id;
   const urlID = newId;
   const userID = localStorage.getItem("userId");
-  /*
-   * Handle Visibility Toggle
-   *
-   * Handle card visibility toggle by updating state and saving state to backend
-   */
-  const handleVisibilityToggle = async () => {
-    // Update visibleCards state in profile
-    try {
-      // Get current card visibility status from db
-      const url = `${backendAddress}api/profile/${urlID}`;
-      const result = await axios.get(url);
-      const { visibleCards } = result.data;
-
-      // change the stored value
-      const cardNameToBeModified = cardName;
-      visibleCards[cardNameToBeModified] = !disabled;
-      setDisabled(visibleCards[cardNameToBeModified]);
-
-      // save toggle value in db
-      await axios.put(`${backendAddress}api/profile/${urlID}`, {
-        visibleCards,
-      });
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.log(error);
-    }
-  };
 
   /*
    * Handle Visibility Toggle
@@ -124,7 +99,7 @@ function ProfileCardsView({
       const cardNameToBeModified = cardName;
       setDisabled(visibleCards[cardNameToBeModified]);
     }
-  }, [cardName, editUrl, profileInfo, title, id, content, style]);
+  }, [cardName, editUrl, profileInfo, setDisabled, title, id, content, style]);
 
   let styles;
   if (disabled === true) {
@@ -140,7 +115,9 @@ function ProfileCardsView({
       },
     };
   }
-
+  if (networkErrors && networkErrors.length) {
+    return <ProfileCardsError networkErrors={networkErrors} title={title} />;
+  }
   return (
     <div>
       <Card
@@ -163,6 +140,7 @@ ProfileCardsView.propTypes = {
   id: PropTypes.string.isRequired,
   content: PropTypes.element.isRequired,
   style: PropTypes.objectOf(PropTypes.string),
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 ProfileCardsView.defaultProps = {

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import PropTypes from "prop-types";
 import { useParams, useHistory } from "react-router-dom";
 import {
@@ -141,6 +141,9 @@ ProfileCardsView.propTypes = {
   content: PropTypes.element.isRequired,
   style: PropTypes.objectOf(PropTypes.string),
   networkErrors: NetworkErrorsPropType.isRequired,
+  handleVisibilityToggle: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
+  setDisabled: PropTypes.func.isRequired,
 };
 
 ProfileCardsView.defaultProps = {

--- a/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsError.jsx
+++ b/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsError.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ProfileCardsErrorView from "./ProfileCardsErrorView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
+
+const ProfileCardsError = ({ networkErrors, title }) => {
+  return <ProfileCardsErrorView networkErrors={networkErrors} title={title} />;
+};
+
+ProfileCardsError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
+};
+
+export default ProfileCardsError;

--- a/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsError.jsx
+++ b/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsError.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ProfileCardsErrorView from "./ProfileCardsErrorView";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
@@ -8,6 +9,7 @@ const ProfileCardsError = ({ networkErrors, title }) => {
 
 ProfileCardsError.propTypes = {
   networkErrors: NetworkErrorsPropType.isRequired,
+  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
 };
 
 export default ProfileCardsError;

--- a/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
+++ b/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { Card, List } from "antd";
+import PropTypes from "prop-types";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
 const ProfileCardsErrorView = ({ networkErrors, title }) => {
@@ -22,7 +23,7 @@ const ProfileCardsErrorView = ({ networkErrors, title }) => {
         <>
           <WarningOutlined />
           <span style={styles.errorTitleText}>
-            {<FormattedMessage id="error.network" />}
+            <FormattedMessage id="error.network" />
           </span>
         </>
         <List
@@ -63,6 +64,7 @@ const ProfileCardsErrorView = ({ networkErrors, title }) => {
 
 ProfileCardsErrorView.propTypes = {
   networkErrors: NetworkErrorsPropType.isRequired,
+  title: PropTypes.oneOfType([PropTypes.element, PropTypes.string]).isRequired,
 };
 
 export default injectIntl(ProfileCardsErrorView);

--- a/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
+++ b/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
-import { List } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { Card, List } from "antd";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const SearchFilterErrorView = ({ networkErrors }) => {
+const ProfileCardsErrorView = ({ networkErrors, title }) => {
   const styles = {
     errorTitleText: {
       paddingLeft: "8px",
@@ -12,32 +12,24 @@ const SearchFilterErrorView = ({ networkErrors }) => {
       color: "rgba(0, 0, 0, 0.85)",
     },
     itemTitleText: {
-      wordBreak: "break-word",
       fontSize: "14px",
       fontWeight: "normal",
     },
-    itemDescription: {
-      wordBreak: "break-word",
-    },
-    centeredText: {
-      textAlign: "center",
-    },
   };
-
   return (
-    <>
-      <>
-        <WarningOutlined />
-        <span style={styles.errorTitleText}>
-          <FormattedMessage id="error.network" />
-        </span>
-      </>
-      <List
-        size="small"
-        dataSource={networkErrors}
-        renderItem={item => (
-          <List.Item>
-            <div style={{ textAlign: "center" }}>
+    <div>
+      <Card title={title}>
+        <>
+          <WarningOutlined />
+          <span style={styles.errorTitleText}>
+            {<FormattedMessage id="error.network" />}
+          </span>
+        </>
+        <List
+          size="small"
+          dataSource={networkErrors}
+          renderItem={item => (
+            <List.Item>
               <List.Item.Meta
                 title={
                   <span style={styles.itemTitleText}>
@@ -61,16 +53,16 @@ const SearchFilterErrorView = ({ networkErrors }) => {
                   )
                 }
               />
-            </div>
-          </List.Item>
-        )}
-      />
-    </>
+            </List.Item>
+          )}
+        />
+      </Card>
+    </div>
   );
 };
 
-SearchFilterErrorView.propTypes = {
+ProfileCardsErrorView.propTypes = {
   networkErrors: NetworkErrorsPropType.isRequired,
 };
 
-export default injectIntl(SearchFilterErrorView);
+export default injectIntl(ProfileCardsErrorView);

--- a/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
+++ b/services/frontend-v3/src/components/profileCards/profileCardsError/ProfileCardsErrorView.jsx
@@ -49,7 +49,7 @@ const ProfileCardsErrorView = ({ networkErrors, title }) => {
                     </>
                   ) : (
                     <div style={styles.itemDescription}>
-                      No response from backend
+                      <FormattedMessage id="error.no.backend.response" />
                     </div>
                   )
                 }

--- a/services/frontend-v3/src/components/profileForms/doneSetup/DoneSetup.jsx
+++ b/services/frontend-v3/src/components/profileForms/doneSetup/DoneSetup.jsx
@@ -12,6 +12,7 @@ const { backendAddress } = config;
  */
 const DoneSetup = () => {
   const [load, setLoad] = useState(false);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // useEffect to run once component is mounted
   useEffect(() => {
@@ -24,6 +25,7 @@ const DoneSetup = () => {
         await axios.get(url);
         return 1;
       } catch (error) {
+        setNetworkErrors(oldArray => oldArray.concat(error));
         throw Error(error);
       }
     };
@@ -44,7 +46,7 @@ const DoneSetup = () => {
     getAllData();
   }, []);
 
-  return <DoneSetupView load={load} />;
+  return <DoneSetupView load={load} networkErrors={networkErrors} />;
 };
 
 export default DoneSetup;

--- a/services/frontend-v3/src/components/profileForms/doneSetup/DoneSetupView.jsx
+++ b/services/frontend-v3/src/components/profileForms/doneSetup/DoneSetupView.jsx
@@ -7,6 +7,8 @@ import {
 } from "@ant-design/icons";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
+import EditProfileError from "../editProfileError/editProfileError";
 
 const { Title, Paragraph } = Typography;
 
@@ -15,11 +17,17 @@ const { Title, Paragraph } = Typography;
  *
  *  Controller for the Done Setup Page.
  */
-const DoneSetupView = ({ load }) => {
+const DoneSetupView = ({ load, networkErrors }) => {
   /* Component Styles */
   const styles = {
     skeleton: {
       textAlign: "center",
+      width: "100%",
+      minHeight: "400px",
+      background: "#fff",
+      padding: "30px 30px",
+    },
+    uncenteredSkeleton: {
       width: "100%",
       minHeight: "400px",
       background: "#fff",
@@ -38,6 +46,14 @@ const DoneSetupView = ({ load }) => {
       marginLeft: "10px",
     },
   };
+
+  if (networkErrors && networkErrors.length) {
+    return (
+      <div style={styles.uncenteredSkeleton}>
+        <EditProfileError networkErrors={networkErrors} />;
+      </div>
+    );
+  }
 
   if (!load) {
     return (
@@ -98,6 +114,7 @@ const DoneSetupView = ({ load }) => {
 
 DoneSetupView.propTypes = {
   load: PropTypes.bool.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default DoneSetupView;

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import EditProfileErrorView from "./editProfileErrorView";
+
+const EditProfileError = ({ networkError }) => {
+  return <EditProfileErrorView networkError={networkError} />;
+};
+
+export default EditProfileError;

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
@@ -1,8 +1,18 @@
 import React from "react";
 import EditProfileErrorView from "./editProfileErrorView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const EditProfileError = ({ networkError }) => {
-  return <EditProfileErrorView networkError={networkError} />;
+const EditProfileError = ({ networkErrors, customErrorTitle }) => {
+  return (
+    <EditProfileErrorView
+      networkErrors={networkErrors}
+      customErrorTitle={customErrorTitle}
+    />
+  );
+};
+
+EditProfileError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default EditProfileError;

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileError.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import EditProfileErrorView from "./editProfileErrorView";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
@@ -13,6 +14,11 @@ const EditProfileError = ({ networkErrors, customErrorTitle }) => {
 
 EditProfileError.propTypes = {
   networkErrors: NetworkErrorsPropType.isRequired,
+  customErrorTitle: PropTypes.string,
+};
+
+EditProfileError.defaultProps = {
+  customErrorTitle: undefined,
 };
 
 export default EditProfileError;

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
@@ -52,7 +52,7 @@ const EditProfileErrorView = ({ networkErrors, customErrorTitle }) => {
                   </>
                 ) : (
                   <div style={styles.itemDescription}>
-                    No response from backend
+                    <FormattedMessage id="error.no.backend.response" />
                   </div>
                 )
               }

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
@@ -1,38 +1,70 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { List } from "antd";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const EditProfileErrorView = ({ networkError }) => {
+const EditProfileErrorView = ({ networkErrors, customErrorTitle }) => {
   const styles = {
-    errorTitle: {
+    errorTitleText: {
       paddingLeft: "8px",
       fontWeight: "bold",
       color: "rgba(0, 0, 0, 0.85)",
+    },
+    itemTitleText: {
+      wordBreak: "break-word",
+      fontSize: "14px",
+      fontWeight: "normal",
+    },
+    itemDescription: {
+      wordBreak: "break-word",
     },
   };
   return (
     <>
       <>
         <WarningOutlined />
-        <span style={styles.errorTitle}>
-          <FormattedMessage id="error.network" />
+        <span style={styles.errorTitleText}>
+          {customErrorTitle || <FormattedMessage id="error.network" />}
         </span>
       </>
-      <div>
-        <div>
-          {networkError.config.method.toUpperCase()} {networkError.config.url}
-        </div>
-        {networkError && networkError.response && networkError.response.data ? (
-          <>
-            <div>{networkError.response.data.status}</div>
-            <div>{networkError.response.data.message}</div>
-          </>
-        ) : (
-          <div>no response from backend server</div>
+      <List
+        size="small"
+        dataSource={networkErrors}
+        renderItem={item => (
+          <List.Item>
+            <List.Item.Meta
+              title={
+                <span style={styles.itemTitleText}>
+                  {item.config.method.toUpperCase()} {item.config.url}
+                </span>
+              }
+              description={
+                item.response && item.response.data ? (
+                  <>
+                    <div style={styles.itemDescription}>
+                      {item.response.status}
+                    </div>
+                    <div style={styles.itemDescription}>
+                      {item.response.statusText}
+                    </div>
+                  </>
+                ) : (
+                  <div style={styles.itemDescription}>
+                    No response from backend
+                  </div>
+                )
+              }
+            />
+          </List.Item>
         )}
-      </div>
+      />
     </>
   );
+};
+
+EditProfileErrorView.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(EditProfileErrorView);

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const EditProfileErrorView = ({ networkError }) => {
+  const styles = {
+    errorTitle: {
+      paddingLeft: "8px",
+      fontWeight: "bold",
+      color: "rgba(0, 0, 0, 0.85)",
+    },
+  };
+  return (
+    <>
+      <>
+        <WarningOutlined />
+        <span style={styles.errorTitle}>
+          <FormattedMessage id="error.network" />
+        </span>
+      </>
+      <div>
+        <div>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </div>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <div>{networkError.response.data.status}</div>
+            <div>{networkError.response.data.message}</div>
+          </>
+        ) : (
+          <div>no response from backend server</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(EditProfileErrorView);

--- a/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
+++ b/services/frontend-v3/src/components/profileForms/editProfileError/editProfileErrorView.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { List } from "antd";
+import PropTypes from "prop-types";
 import { NetworkErrorsPropType } from "../../../customPropTypes";
 
 const EditProfileErrorView = ({ networkErrors, customErrorTitle }) => {
@@ -65,6 +66,11 @@ const EditProfileErrorView = ({ networkErrors, customErrorTitle }) => {
 
 EditProfileErrorView.propTypes = {
   networkErrors: NetworkErrorsPropType.isRequired,
+  customErrorTitle: PropTypes.string,
+};
+
+EditProfileErrorView.defaultProps = {
+  customErrorTitle: undefined,
 };
 
 export default injectIntl(EditProfileErrorView);

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -19,6 +19,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
   const [securityOptions, setSecurityOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [networkError, setNetworkError] = useState(null);
 
   // Get current language code
   const locale = intl.formatMessage({
@@ -43,6 +44,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setSubstantiveOptions(options);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -65,6 +67,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setClassificationOptions(options);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -87,6 +90,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setSecurityOptions(options);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -101,6 +105,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -117,7 +122,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       .then(() => {
         setLoad(true);
       })
-      .catch((error) => {
+      .catch(error => {
         setLoad(false);
         // eslint-disable-next-line no-console
         console.log(error);
@@ -133,6 +138,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       formType={formType}
       locale={locale}
       load={load}
+      networkError={networkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -19,7 +19,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
   const [securityOptions, setSecurityOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Get current language code
   const locale = intl.formatMessage({
@@ -44,7 +44,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setSubstantiveOptions(options);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -67,7 +67,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setClassificationOptions(options);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -90,7 +90,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setSecurityOptions(options);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -105,7 +105,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -138,7 +138,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
       formType={formType}
       locale={locale}
       load={load}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -24,8 +24,10 @@ import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
 } from "../../../customPropTypes";
+import editProfileError from "../editProfileError/editProfileError";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
+import EditProfileError from "../editProfileError/editProfileError";
 
 const { backendAddress } = config;
 const { Option } = Select;
@@ -41,6 +43,7 @@ const EmploymentDataFormView = props => {
     classificationOptions,
     formType,
     load,
+    networkError,
     profileInfo,
     securityOptions,
     substantiveOptions,
@@ -469,6 +472,14 @@ const EmploymentDataFormView = props => {
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
+
   if (!load) {
     return (
       /* If form data is loading then wait */
@@ -477,6 +488,7 @@ const EmploymentDataFormView = props => {
       </div>
     );
   }
+
   /* Once data had loaded display form */
   return (
     <div style={styles.content}>

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -23,8 +23,8 @@ import moment from "moment";
 import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../../customPropTypes";
-import editProfileError from "../editProfileError/editProfileError";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
 import EditProfileError from "../editProfileError/editProfileError";
@@ -43,7 +43,7 @@ const EmploymentDataFormView = props => {
     classificationOptions,
     formType,
     load,
-    networkError,
+    networkErrors,
     profileInfo,
     securityOptions,
     substantiveOptions,
@@ -472,10 +472,10 @@ const EmploymentDataFormView = props => {
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -611,6 +611,7 @@ EmploymentDataFormView.propTypes = {
   profileInfo: ProfileInfoPropType,
   securityOptions: KeyTitleOptionsPropType,
   substantiveOptions: KeyTitleOptionsPropType,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 EmploymentDataFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -16,6 +16,7 @@ const LangProficiencyForm = ({ formType }) => {
   const [proficiencyOptions, setProficiencyOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [networkError, setNetworkError] = useState(null);
 
   // Get user profile for form drop down
   const getProfileInfo = async () => {
@@ -27,6 +28,7 @@ const LangProficiencyForm = ({ formType }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -71,6 +73,7 @@ const LangProficiencyForm = ({ formType }) => {
   return (
     <LangProficiencyFormView
       languageOptions={languageOptions}
+      networkError={networkError}
       proficiencyOptions={proficiencyOptions}
       profileInfo={profileInfo}
       formType={formType}

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -16,7 +16,7 @@ const LangProficiencyForm = ({ formType }) => {
   const [proficiencyOptions, setProficiencyOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Get user profile for form drop down
   const getProfileInfo = async () => {
@@ -28,7 +28,7 @@ const LangProficiencyForm = ({ formType }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -73,7 +73,7 @@ const LangProficiencyForm = ({ formType }) => {
   return (
     <LangProficiencyFormView
       languageOptions={languageOptions}
-      networkError={networkError}
+      networkErrors={networkErrors}
       proficiencyOptions={proficiencyOptions}
       profileInfo={profileInfo}
       formType={formType}

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -21,6 +21,7 @@ import PropTypes from "prop-types";
 import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../../customPropTypes";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
@@ -39,7 +40,7 @@ const LangProficiencyFormView = ({
   formType,
   languageOptions,
   load,
-  networkError,
+  networkErrors,
   proficiencyOptions,
   profileInfo,
 }) => {
@@ -491,10 +492,10 @@ const LangProficiencyFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -573,6 +574,7 @@ LangProficiencyFormView.propTypes = {
   load: PropTypes.bool.isRequired,
   proficiencyOptions: KeyTitleOptionsPropType,
   profileInfo: ProfileInfoPropType,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 LangProficiencyFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -24,6 +24,7 @@ import {
 } from "../../../customPropTypes";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
+import EditProfileError from "../editProfileError/editProfileError";
 
 const { backendAddress } = config;
 const { Option } = Select;
@@ -38,6 +39,7 @@ const LangProficiencyFormView = ({
   formType,
   languageOptions,
   load,
+  networkError,
   proficiencyOptions,
   profileInfo,
 }) => {
@@ -489,6 +491,14 @@ const LangProficiencyFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
+
   if (!load) {
     return (
       /* If form data is loading then wait */

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -35,7 +35,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
     undefined
   );
   const [savedExFeederBool, setSavedExFeederBool] = useState(undefined);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Get current language code
   const locale = intl.formatMessage({
@@ -87,7 +87,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -114,7 +114,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setDevelopmentalGoalOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -162,7 +162,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setRelocationOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -190,7 +190,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setLookingForNewJobOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -218,7 +218,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setCareerMobilityOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -246,7 +246,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setTalentMatrixResultOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -322,7 +322,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       savedExFeederBool={savedExFeederBool}
       formType={formType}
       load={load}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -19,16 +19,23 @@ const PersonalGrowthForm = ({ formType, intl }) => {
   const [load, setLoad] = useState(false);
   const [developmentalGoalOptions, setDevelopmentalGoalOptions] = useState([]);
   const [savedDevelopmentalGoals, setSavedDevelopmentalGoals] = useState([]);
-  const [interestedInRemoteOptions, setInterestedInRemoteOptions] = useState([]);
+  const [interestedInRemoteOptions, setInterestedInRemoteOptions] = useState(
+    []
+  );
   const [relocationOptions, setRelocationOptions] = useState([]);
   const [savedRelocationLocations, setSavedRelocationLocations] = useState([]);
   const [lookingForNewJobOptions, setLookingForNewJobOptions] = useState([]);
   const [savedLookingForNewJob, setSavedLookingForNewJob] = useState(undefined);
   const [careerMobilityOptions, setCareerMobilityOptions] = useState([]);
   const [savedCareerMobility, setSavedCareerMobility] = useState(undefined);
-  const [talentMatrixResultOptions, setTalentMatrixResultOptions] = useState([]);
-  const [savedTalentMatrixResult, setSavedTalentMatrixResult] = useState(undefined);
+  const [talentMatrixResultOptions, setTalentMatrixResultOptions] = useState(
+    []
+  );
+  const [savedTalentMatrixResult, setSavedTalentMatrixResult] = useState(
+    undefined
+  );
   const [savedExFeederBool, setSavedExFeederBool] = useState(undefined);
+  const [networkError, setNetworkError] = useState(null);
 
   // Get current language code
   const locale = intl.formatMessage({
@@ -80,6 +87,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -106,6 +114,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setDevelopmentalGoalOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -153,6 +162,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setRelocationOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -180,6 +190,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setLookingForNewJobOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -207,6 +218,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setCareerMobilityOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -234,6 +246,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setTalentMatrixResultOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -259,7 +272,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       setSavedCareerMobility(careerMobility ? careerMobility.id : undefined);
       setSavedExFeederBool(exFeeder);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profileInfo]);
 
   // useEffect when locale changes
@@ -283,7 +296,14 @@ const PersonalGrowthForm = ({ formType, intl }) => {
         // eslint-disable-next-line no-console
         console.log(error);
       });
-  }, [getCareerMobilityOptions, getDevelopmentalGoalOptions, getInterestedInRemoteOptions, getLookingForNewJobOptions, getRelocationOptions, getTalentMatrixResultOptions]);
+  }, [
+    getCareerMobilityOptions,
+    getDevelopmentalGoalOptions,
+    getInterestedInRemoteOptions,
+    getLookingForNewJobOptions,
+    getRelocationOptions,
+    getTalentMatrixResultOptions,
+  ]);
 
   return (
     <PersonalGrowthFormView
@@ -302,6 +322,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
       savedExFeederBool={savedExFeederBool}
       formType={formType}
       load={load}
+      networkError={networkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -24,6 +24,7 @@ import PropTypes from "prop-types";
 import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../../customPropTypes";
 import EditProfileError from "../editProfileError/editProfileError";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
@@ -55,7 +56,7 @@ const PersonalGrowthFormView = ({
   savedExFeederBool,
   formType,
   load,
-  networkError,
+  networkErrors,
 }) => {
   const history = useHistory();
   const [form] = Form.useForm();
@@ -364,10 +365,10 @@ const PersonalGrowthFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -599,6 +600,7 @@ PersonalGrowthFormView.propTypes = {
   savedExFeederBool: PropTypes.bool,
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
   load: PropTypes.bool.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 PersonalGrowthFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -25,6 +25,7 @@ import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
 } from "../../../customPropTypes";
+import EditProfileError from "../editProfileError/editProfileError";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 
 import config from "../../../config";
@@ -54,6 +55,7 @@ const PersonalGrowthFormView = ({
   savedExFeederBool,
   formType,
   load,
+  networkError,
 }) => {
   const history = useHistory();
   const [form] = Form.useForm();
@@ -362,6 +364,13 @@ const PersonalGrowthFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
   if (!load) {
     return (
       /* If form data is loading then wait */

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -10,6 +10,7 @@ const PrimaryInfoForm = ({ formType }) => {
   const [locationOptions, setLocationOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [networkError, setNetworkError] = useState(null);
 
   // Get possible locations for form drop down
   const getLocations = async () => {
@@ -18,6 +19,7 @@ const PrimaryInfoForm = ({ formType }) => {
       setLocationOptions(result.data ? result.data : []);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -32,6 +34,7 @@ const PrimaryInfoForm = ({ formType }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
+      //setNetworkError(error);
       return 0;
     }
   };
@@ -43,7 +46,7 @@ const PrimaryInfoForm = ({ formType }) => {
       .then(() => {
         setLoad(true);
       })
-      .catch((error) => {
+      .catch(error => {
         // eslint-disable-next-line no-console
         console.log(error);
       });
@@ -54,6 +57,7 @@ const PrimaryInfoForm = ({ formType }) => {
       locationOptions={locationOptions}
       profileInfo={profileInfo}
       load={load}
+      networkError={networkError}
       formType={formType}
     />
   );

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -34,7 +34,6 @@ const PrimaryInfoForm = ({ formType }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      //setNetworkErrors(oldArray => oldArray.concat(error));
       return 0;
     }
   };

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -10,7 +10,7 @@ const PrimaryInfoForm = ({ formType }) => {
   const [locationOptions, setLocationOptions] = useState([]);
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Get possible locations for form drop down
   const getLocations = async () => {
@@ -19,7 +19,7 @@ const PrimaryInfoForm = ({ formType }) => {
       setLocationOptions(result.data ? result.data : []);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -34,7 +34,7 @@ const PrimaryInfoForm = ({ formType }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      //setNetworkError(error);
+      //setNetworkErrors(oldArray => oldArray.concat(error));
       return 0;
     }
   };
@@ -57,7 +57,7 @@ const PrimaryInfoForm = ({ formType }) => {
       locationOptions={locationOptions}
       profileInfo={profileInfo}
       load={load}
-      networkError={networkError}
+      networkErrors={networkErrors}
       formType={formType}
     />
   );

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -16,6 +16,7 @@ import { LinkOutlined, RightOutlined, CheckOutlined } from "@ant-design/icons";
 import { FormattedMessage } from "react-intl";
 import axios from "axios";
 import PropTypes from "prop-types";
+import EditProfileError from "../editProfileError/editProfileError";
 import {
   IdDescriptionPropType,
   ProfileInfoPropType,
@@ -27,7 +28,13 @@ const { backendAddress } = config;
 const { Option } = Select;
 const { Title } = Typography;
 
-function PrimaryInfoFormView({ locationOptions, profileInfo, load, formType }) {
+function PrimaryInfoFormView({
+  locationOptions,
+  profileInfo,
+  load,
+  networkError,
+  formType,
+}) {
   const history = useHistory();
   const [form] = Form.useForm();
 
@@ -297,6 +304,14 @@ function PrimaryInfoFormView({ locationOptions, profileInfo, load, formType }) {
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
+
   if (!load) {
     return (
       /* If form data is loading then wait */
@@ -305,6 +320,7 @@ function PrimaryInfoFormView({ locationOptions, profileInfo, load, formType }) {
       </div>
     );
   }
+
   /* Once data had loaded display form */
   return (
     <div style={styles.content}>

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -20,6 +20,7 @@ import EditProfileError from "../editProfileError/editProfileError";
 import {
   IdDescriptionPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../../customPropTypes";
 
 import config from "../../../config";
@@ -32,7 +33,7 @@ function PrimaryInfoFormView({
   locationOptions,
   profileInfo,
   load,
-  networkError,
+  networkErrors,
   formType,
 }) {
   const history = useHistory();
@@ -304,10 +305,10 @@ function PrimaryInfoFormView({
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -475,6 +476,7 @@ PrimaryInfoFormView.propTypes = {
   profileInfo: ProfileInfoPropType,
   load: PropTypes.bool.isRequired,
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 PrimaryInfoFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -19,6 +19,7 @@ const QualificationsForm = ({ formType }) => {
   const [savedEducation, setSavedEducation] = useState([]);
   const [savedExperience, setSavedExperience] = useState([]);
   const [savedProjects, setSavedProjects] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   /**
    * Get User Profile
@@ -34,7 +35,7 @@ const QualificationsForm = ({ formType }) => {
       return 1;
     } catch (error) {
       setLoad(false);
-      
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -111,7 +112,7 @@ const QualificationsForm = ({ formType }) => {
       getSavedExperience();
       getSavedProjects();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profileInfo]);
 
   // useEffect to run once component is mounted
@@ -128,6 +129,8 @@ const QualificationsForm = ({ formType }) => {
       savedProjects={savedProjects}
       formType={formType}
       load={load}
+      networkError={networkError}
+      setNetworkError={setNetworkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -19,7 +19,7 @@ const QualificationsForm = ({ formType }) => {
   const [savedEducation, setSavedEducation] = useState([]);
   const [savedExperience, setSavedExperience] = useState([]);
   const [savedProjects, setSavedProjects] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   /**
    * Get User Profile
@@ -35,7 +35,7 @@ const QualificationsForm = ({ formType }) => {
       return 1;
     } catch (error) {
       setLoad(false);
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return 0;
@@ -129,8 +129,8 @@ const QualificationsForm = ({ formType }) => {
       savedProjects={savedProjects}
       formType={formType}
       load={load}
-      networkError={networkError}
-      setNetworkError={setNetworkError}
+      networkErrors={networkErrors}
+      setNetworkErrors={setNetworkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -19,7 +19,7 @@ import EducationForm from "./educationForm/EducationForm";
 import ExperienceForm from "./experienceForm/ExperienceForm";
 import { ProfileInfoPropType } from "../../../customPropTypes";
 import config from "../../../config";
-
+import EditProfileError from "../editProfileError/editProfileError";
 const { backendAddress } = config;
 const { Title } = Typography;
 
@@ -35,6 +35,8 @@ const QualificationsFormView = ({
   savedProjects,
   formType,
   load,
+  networkError,
+  setNetworkError,
 }) => {
   const history = useHistory();
   const [form] = Form.useForm();
@@ -311,6 +313,13 @@ const QualificationsFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
   if (!load) {
     return (
       /* If form data is loading then wait */
@@ -352,6 +361,7 @@ const QualificationsFormView = ({
                         remove={remove}
                         profileInfo={profileInfo}
                         style={styles}
+                        setNetworkError={setNetworkError}
                       />
                     ))}
                     <Form.Item>
@@ -394,6 +404,7 @@ const QualificationsFormView = ({
                         remove={remove}
                         profileInfo={profileInfo}
                         style={styles}
+                        setNetworkError={setNetworkError}
                       />
                     ))}
                     <Form.Item>

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -487,6 +487,7 @@ QualificationsFormView.propTypes = {
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
   load: PropTypes.bool.isRequired,
   networkErrors: NetworkErrorsPropType.isRequired,
+  setNetworkErrors: PropTypes.func.isRequired,
 };
 
 QualificationsFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -17,9 +17,13 @@ import axios from "axios";
 import PropTypes from "prop-types";
 import EducationForm from "./educationForm/EducationForm";
 import ExperienceForm from "./experienceForm/ExperienceForm";
-import { ProfileInfoPropType } from "../../../customPropTypes";
+import {
+  ProfileInfoPropType,
+  NetworkErrorsPropType,
+} from "../../../customPropTypes";
 import config from "../../../config";
 import EditProfileError from "../editProfileError/editProfileError";
+
 const { backendAddress } = config;
 const { Title } = Typography;
 
@@ -35,8 +39,8 @@ const QualificationsFormView = ({
   savedProjects,
   formType,
   load,
-  networkError,
-  setNetworkError,
+  networkErrors,
+  setNetworkErrors,
 }) => {
   const history = useHistory();
   const [form] = Form.useForm();
@@ -313,10 +317,10 @@ const QualificationsFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -361,7 +365,7 @@ const QualificationsFormView = ({
                         remove={remove}
                         profileInfo={profileInfo}
                         style={styles}
-                        setNetworkError={setNetworkError}
+                        setNetworkErrors={setNetworkErrors}
                       />
                     ))}
                     <Form.Item>
@@ -404,7 +408,7 @@ const QualificationsFormView = ({
                         remove={remove}
                         profileInfo={profileInfo}
                         style={styles}
-                        setNetworkError={setNetworkError}
+                        setNetworkErrors={setNetworkErrors}
                       />
                     ))}
                     <Form.Item>
@@ -482,6 +486,7 @@ QualificationsFormView.propTypes = {
   savedProjects: PropTypes.arrayOf(PropTypes.string),
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
   load: PropTypes.bool.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 QualificationsFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
@@ -10,7 +10,6 @@ import {
   IntlPropType,
   ProfileInfoPropType,
   StylesPropType,
-  NetworkErrorsPropType,
 } from "../../../../customPropTypes";
 import config from "../../../../config";
 
@@ -132,7 +131,7 @@ EducationForm.propTypes = {
   remove: PropTypes.func.isRequired,
   profileInfo: ProfileInfoPropType.isRequired,
   style: StylesPropType.isRequired,
-  networkErrors: NetworkErrorsPropType.isRequired,
+  setNetworkErrors: PropTypes.func.isRequired,
 };
 
 EducationForm.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
@@ -21,7 +21,15 @@ const { backendAddress } = config;
  *  This component is strongly linked ot Qualifications Form.
  *  It generated the form fields for each education item the user creates in the qualifications form.
  */
-const EducationForm = ({ form, field, intl, remove, profileInfo, style }) => {
+const EducationForm = ({
+  form,
+  field,
+  intl,
+  remove,
+  profileInfo,
+  setNetworkError,
+  style,
+}) => {
   // Define States
   const [load, setLoad] = useState(false);
   const [diplomaOptions, setDiplomaOptions] = useState([]);
@@ -55,6 +63,7 @@ const EducationForm = ({ form, field, intl, remove, profileInfo, style }) => {
       setDiplomaOptions(options);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -81,6 +90,7 @@ const EducationForm = ({ form, field, intl, remove, profileInfo, style }) => {
       setSchoolOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
@@ -10,6 +10,7 @@ import {
   IntlPropType,
   ProfileInfoPropType,
   StylesPropType,
+  NetworkErrorsPropType,
 } from "../../../../customPropTypes";
 import config from "../../../../config";
 
@@ -27,7 +28,7 @@ const EducationForm = ({
   intl,
   remove,
   profileInfo,
-  setNetworkError,
+  setNetworkErrors,
   style,
 }) => {
   // Define States
@@ -63,7 +64,7 @@ const EducationForm = ({
       setDiplomaOptions(options);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -90,7 +91,7 @@ const EducationForm = ({
       setSchoolOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -131,6 +132,7 @@ EducationForm.propTypes = {
   remove: PropTypes.func.isRequired,
   profileInfo: ProfileInfoPropType.isRequired,
   style: StylesPropType.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 EducationForm.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -21,7 +21,7 @@ const TalentForm = ({ formType, intl }) => {
   const [savedCompetencies, setSavedCompetencies] = useState([]);
   const [savedSkills, setSavedSkills] = useState([]);
   const [savedMentorshipSkills, setSavedMentorshipSkills] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // get current language code
   const locale = intl.formatMessage({
@@ -41,7 +41,7 @@ const TalentForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   };
@@ -69,7 +69,7 @@ const TalentForm = ({ formType, intl }) => {
       setCompetencyOptions(options);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -110,7 +110,7 @@ const TalentForm = ({ formType, intl }) => {
       setSkillOptions(dataTree);
       return 1;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       throw new Error(error);
     }
   }, [locale]);
@@ -188,7 +188,7 @@ const TalentForm = ({ formType, intl }) => {
       savedMentorshipSkills={savedMentorshipSkills}
       formType={formType}
       load={load}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -21,6 +21,7 @@ const TalentForm = ({ formType, intl }) => {
   const [savedCompetencies, setSavedCompetencies] = useState([]);
   const [savedSkills, setSavedSkills] = useState([]);
   const [savedMentorshipSkills, setSavedMentorshipSkills] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   // get current language code
   const locale = intl.formatMessage({
@@ -40,6 +41,7 @@ const TalentForm = ({ formType, intl }) => {
       setProfileInfo(result.data);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   };
@@ -67,6 +69,7 @@ const TalentForm = ({ formType, intl }) => {
       setCompetencyOptions(options);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -107,6 +110,7 @@ const TalentForm = ({ formType, intl }) => {
       setSkillOptions(dataTree);
       return 1;
     } catch (error) {
+      setNetworkError(error);
       throw new Error(error);
     }
   }, [locale]);
@@ -157,7 +161,7 @@ const TalentForm = ({ formType, intl }) => {
       getSavedSkills();
       getSavedMentorshipSkill();
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [profileInfo]);
 
   // useEffect to run once component is mounted
@@ -184,6 +188,7 @@ const TalentForm = ({ formType, intl }) => {
       savedMentorshipSkills={savedMentorshipSkills}
       formType={formType}
       load={load}
+      networkError={networkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -20,6 +20,7 @@ import PropTypes from "prop-types";
 import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../../customPropTypes";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
@@ -40,7 +41,7 @@ const TalentFormView = props => {
     profileInfo,
     skillOptions,
     competencyOptions,
-    networkError,
+    networkErrors,
     savedCompetencies,
     savedSkills,
     savedMentorshipSkills,
@@ -514,10 +515,10 @@ const TalentFormView = props => {
   /** **********************************
    ********* Render Component *********
    *********************************** */
-  if (networkError) {
+  if (networkErrors && networkErrors.length) {
     return (
       <div style={styles.skeleton}>
-        <EditProfileError networkError={networkError} />
+        <EditProfileError networkErrors={networkErrors} />
       </div>
     );
   }
@@ -637,6 +638,7 @@ TalentFormView.propTypes = {
   savedMentorshipSkills: PropTypes.arrayOf(PropTypes.string),
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
   load: PropTypes.bool.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 TalentFormView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -23,6 +23,7 @@ import {
 } from "../../../customPropTypes";
 import FormLabelTooltip from "../../formLabelTooltip/FormLabelTooltip";
 import config from "../../../config";
+import EditProfileError from "../editProfileError/editProfileError";
 
 const { backendAddress } = config;
 const { Option } = Select;
@@ -39,6 +40,7 @@ const TalentFormView = props => {
     profileInfo,
     skillOptions,
     competencyOptions,
+    networkError,
     savedCompetencies,
     savedSkills,
     savedMentorshipSkills,
@@ -512,6 +514,14 @@ const TalentFormView = props => {
   /** **********************************
    ********* Render Component *********
    *********************************** */
+  if (networkError) {
+    return (
+      <div style={styles.skeleton}>
+        <EditProfileError networkError={networkError} />
+      </div>
+    );
+  }
+
   if (!load) {
     return (
       /* If form data is loading then wait */

--- a/services/frontend-v3/src/components/profileForms/welcome/Welcome.jsx
+++ b/services/frontend-v3/src/components/profileForms/welcome/Welcome.jsx
@@ -15,6 +15,7 @@ const { backendAddress } = config;
 function Welcome() {
   const [load, setLoad] = useState(false);
   const [gedsProfiles, setGedsProfiles] = useState([]);
+  const [gedsProfileNetworkError, setGedsProfileNetworkError] = useState(null);
 
   /* useEffect to run once component is mounted */
   useEffect(() => {
@@ -32,6 +33,7 @@ function Welcome() {
         setGedsProfiles(result.data);
         return 1;
       } catch (error) {
+        setGedsProfileNetworkError(error);
         // eslint-disable-next-line no-console
         console.log(error);
         return 0;
@@ -55,7 +57,13 @@ function Welcome() {
     getAllData();
   }, []);
 
-  return <WelcomeView gedsProfiles={gedsProfiles} load={load} />;
+  return (
+    <WelcomeView
+      gedsProfiles={gedsProfiles}
+      gedsProfileNetworkError={gedsProfileNetworkError}
+      load={load}
+    />
+  );
 }
 
 export default Welcome;

--- a/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
@@ -8,15 +8,16 @@ import {
   UserAddOutlined,
   RocketOutlined,
   LoadingOutlined,
+  WarningOutlined,
 } from "@ant-design/icons";
 import axios from "axios";
-import { IntlPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
 import config from "../../../config";
-
+import EditProfileError from "../editProfileError/editProfileError";
 const { Title, Paragraph } = Typography;
 const { backendAddress } = config;
 
-function WelcomeView({ gedsProfiles, intl, load }) {
+function WelcomeView({ gedsProfiles, gedsProfileNetworkError, intl, load }) {
   const history = useHistory();
 
   // get current language code
@@ -71,6 +72,9 @@ function WelcomeView({ gedsProfiles, intl, load }) {
       fontStyle: "italic",
       marginTop: "-4px",
     },
+    gedsErrorMessage: {
+      fontSize: "14px;",
+    },
   };
 
   /*
@@ -78,13 +82,10 @@ function WelcomeView({ gedsProfiles, intl, load }) {
    *
    * Generate large square button for GEDS profiles
    */
-  const generateProfileBtn = ({
-    icon,
-    firstTitle,
-    secondTitle,
-    thirdTitle,
-    value,
-  }) => {
+  const generateProfileBtn = (
+    { icon, firstTitle, secondTitle, thirdTitle, value },
+    disableOnClick
+  ) => {
     // truncate text to not overflow card
     const truncateString = (text, length) => {
       if (text && text.length > length) {
@@ -109,7 +110,10 @@ function WelcomeView({ gedsProfiles, intl, load }) {
     };
 
     return (
-      <Button style={styles.btn} onClick={createProfile}>
+      <Button
+        style={styles.btn}
+        onClick={disableOnClick ? null : createProfile}
+      >
         {/* icon */}
         <div style={styles.btnIcon}>{icon}</div>
 
@@ -164,14 +168,19 @@ function WelcomeView({ gedsProfiles, intl, load }) {
       return (
         <div>
           {/* loading button */}
-          {generateProfileBtn({
-            icon: <LoadingOutlined />,
-            firstTitle: intl.formatMessage({ id: "setup.welcome.geds.title" }),
-            secondTitle: intl.formatMessage({
-              id: "setup.welcome.geds.description",
+          {
+            (generateProfileBtn({
+              icon: <LoadingOutlined />,
+              firstTitle: intl.formatMessage({
+                id: "setup.welcome.geds.title",
+              }),
+              secondTitle: intl.formatMessage({
+                id: "setup.welcome.geds.description",
+              }),
+              type: "default",
             }),
-            type: "default",
-          })}
+            true)
+          }
           {/* new user button */}
           {generateProfileBtn({
             icon: <UserAddOutlined />,
@@ -195,6 +204,7 @@ function WelcomeView({ gedsProfiles, intl, load }) {
             value: item,
           });
         })}
+
         {/* new user button */}
         {generateProfileBtn({
           icon: <UserAddOutlined />,
@@ -219,6 +229,14 @@ function WelcomeView({ gedsProfiles, intl, load }) {
         <FormattedMessage id="setup.welcome.action" />
       </Paragraph>
       {generateGedsProfileList()}
+      {gedsProfileNetworkError ? (
+        <div style={styles.gedsErrorMessage}>
+          <EditProfileError
+            networkErrors={[gedsProfileNetworkError]}
+            customErrorTitle="Could not retreive GEDS data"
+          />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -227,6 +245,7 @@ WelcomeView.propTypes = {
   gedsProfiles: PropTypes.arrayOf(PropTypes.any),
   intl: IntlPropType,
   load: PropTypes.bool.isRequired,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 WelcomeView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
@@ -8,12 +8,12 @@ import {
   UserAddOutlined,
   RocketOutlined,
   LoadingOutlined,
-  WarningOutlined,
 } from "@ant-design/icons";
 import axios from "axios";
-import { IntlPropType, NetworkErrorsPropType } from "../../../customPropTypes";
+import { IntlPropType, NetworkErrorPropType } from "../../../customPropTypes";
 import config from "../../../config";
 import EditProfileError from "../editProfileError/editProfileError";
+
 const { Title, Paragraph } = Typography;
 const { backendAddress } = config;
 
@@ -245,12 +245,13 @@ WelcomeView.propTypes = {
   gedsProfiles: PropTypes.arrayOf(PropTypes.any),
   intl: IntlPropType,
   load: PropTypes.bool.isRequired,
-  networkErrors: NetworkErrorsPropType.isRequired,
+  gedsProfileNetworkError: NetworkErrorPropType,
 };
 
 WelcomeView.defaultProps = {
   gedsProfiles: [],
   intl: undefined,
+  gedsProfileNetworkError: undefined,
 };
 
 export default injectIntl(WelcomeView);

--- a/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
@@ -11,7 +11,7 @@ const { backendAddress } = config;
 
 const ResultsCard = ({ history }) => {
   const [results, setResults] = useState(null);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   useEffect(() => {
     const urlSections = window.location.toString().split("?");
@@ -25,7 +25,7 @@ const ResultsCard = ({ history }) => {
           );
           setResults(result.data);
         } catch (error) {
-          setNetworkError(error);
+          setNetworkErrors(oldArray => oldArray.concat(error));
         }
       };
       gatherResults();
@@ -38,7 +38,7 @@ const ResultsCard = ({ history }) => {
     <ResultsCardView
       history={history}
       results={results}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from "react";
 import "@ant-design/compatible/assets/index.css";
 import axios from "axios";
 import { HistoryPropType } from "../../customPropTypes";
-import ProfileSkeleton from "../profileSkeleton/ProfileSkeleton";
 import config from "../../config";
 
 import ResultsCardView from "./ResultsCardView";
@@ -12,28 +11,37 @@ const { backendAddress } = config;
 
 const ResultsCard = ({ history }) => {
   const [results, setResults] = useState(null);
+  const [networkError, setNetworkError] = useState(null);
 
   useEffect(() => {
     const urlSections = window.location.toString().split("?");
 
     if (urlSections.length === 2) {
       const queryString = urlSections[1];
-      axios
-        .get(`${backendAddress}api/search/fuzzySearch?${queryString}`)
-        .then((result) => setResults(result.data));
+      const gatherResults = async () => {
+        try {
+          const result = await axios.get(
+            `${backendAddress}api/search/fuzzySearch?${queryString}`
+          );
+          setResults(result.data);
+        } catch (error) {
+          setNetworkError(error);
+        }
+      };
+      gatherResults();
     } else {
       setResults(new Error("invalid query"));
     }
   }, []);
 
-  if (!results) {
-    return <ProfileSkeleton />;
-  }
-  if (results instanceof Error) {
-    return `An error was encountered! Please try again.\n\n${String(results)}`;
-  }
-  return <ResultsCardView history={history} results={results} />;
-}
+  return (
+    <ResultsCardView
+      history={history}
+      results={results}
+      networkError={networkError}
+    />
+  );
+};
 
 ResultsCard.propTypes = {
   history: HistoryPropType.isRequired,

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardError.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardError.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import ResultsCardErrorView from "./ResultsCardErrorView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const ResultsCardError = ({ networkError }) => {
-  return <ResultsCardErrorView networkError={networkError} />;
+const ResultsCardError = ({ networkErrors }) => {
+  return <ResultsCardErrorView networkErrors={networkErrors} />;
+};
+
+ResultsCardError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default ResultsCardError;

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardError.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardError.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import ResultsCardErrorView from "./ResultsCardErrorView";
+
+const ResultsCardError = ({ networkError }) => {
+  return <ResultsCardErrorView networkError={networkError} />;
+};
+
+export default ResultsCardError;

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const ResultsCardErrorView = ({ networkError }) => {
+  const styles = {
+    errorTitle: {
+      paddingLeft: "8px",
+      fontWeight: "bold",
+      color: "rgba(0, 0, 0, 0.85)",
+    },
+  };
+  return (
+    <>
+      <>
+        <WarningOutlined />
+        <span style={styles.errorTitle}>
+          <FormattedMessage id="error.network" />
+        </span>
+      </>
+      <div>
+        <div>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </div>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <div>{networkError.response.data.status}</div>
+            <div>{networkError.response.data.message}</div>
+          </>
+        ) : (
+          <div>no response from backend server</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(ResultsCardErrorView);

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
@@ -47,7 +47,7 @@ const ResultsCardErrorView = ({ networkErrors }) => {
                   </>
                 ) : (
                   <div style={styles.itemDescription}>
-                    No response from backend
+                    <FormattedMessage id="error.no.backend.response" />
                   </div>
                 )
               }

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardError/ResultsCardErrorView.jsx
@@ -1,38 +1,66 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { List } from "antd";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const ResultsCardErrorView = ({ networkError }) => {
+const ResultsCardErrorView = ({ networkErrors }) => {
   const styles = {
-    errorTitle: {
+    errorTitleText: {
       paddingLeft: "8px",
       fontWeight: "bold",
       color: "rgba(0, 0, 0, 0.85)",
+    },
+    itemTitleText: {
+      fontSize: "14px",
+      fontWeight: "normal",
     },
   };
   return (
     <>
       <>
         <WarningOutlined />
-        <span style={styles.errorTitle}>
+        <span style={styles.errorTitleText}>
           <FormattedMessage id="error.network" />
         </span>
       </>
-      <div>
-        <div>
-          {networkError.config.method.toUpperCase()} {networkError.config.url}
-        </div>
-        {networkError && networkError.response && networkError.response.data ? (
-          <>
-            <div>{networkError.response.data.status}</div>
-            <div>{networkError.response.data.message}</div>
-          </>
-        ) : (
-          <div>no response from backend server</div>
+      <List
+        size="small"
+        dataSource={networkErrors}
+        renderItem={item => (
+          <List.Item>
+            <List.Item.Meta
+              title={
+                <span style={styles.itemTitleText}>
+                  {item.config.method.toUpperCase()} {item.config.url}
+                </span>
+              }
+              description={
+                item.response && item.response.data ? (
+                  <>
+                    <div style={styles.itemDescription}>
+                      {item.response.status}
+                    </div>
+                    <div style={styles.itemDescription}>
+                      {item.response.statusText}
+                    </div>
+                  </>
+                ) : (
+                  <div style={styles.itemDescription}>
+                    No response from backend
+                  </div>
+                )
+              }
+            />
+          </List.Item>
         )}
-      </div>
+      />
     </>
   );
+};
+
+ResultsCardErrorView.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(ResultsCardErrorView);

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
@@ -6,6 +6,7 @@ import {
   HistoryPropType,
   IntlPropType,
   ProfileInfoPropType,
+  NetworkErrorsPropType,
 } from "../../customPropTypes";
 import ProfileSkeleton from "../profileSkeleton/ProfileSkeleton";
 import prepareInfo from "../../functions/prepareInfo";
@@ -14,7 +15,7 @@ import ResultsCardError from "./ResultsCardError/ResultsCardError";
 const { Meta } = Card;
 const { Text } = Typography;
 
-const ResultsCardView = ({ history, intl, results, networkError }) => {
+const ResultsCardView = ({ history, intl, results, networkErrors }) => {
   const styles = {
     smallP: {
       lineHeight: "4px",
@@ -99,8 +100,8 @@ const ResultsCardView = ({ history, intl, results, networkError }) => {
     return preparedResults.map((person, key) => renderCard(person, key));
   };
 
-  if (networkError) {
-    return <ResultsCardError networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <ResultsCardError networkErrors={networkErrors} />;
   }
 
   if (!results) {
@@ -123,6 +124,7 @@ ResultsCardView.propTypes = {
   history: HistoryPropType.isRequired,
   intl: IntlPropType,
   results: PropTypes.arrayOf(ProfileInfoPropType),
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 ResultsCardView.defaultProps = {

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
@@ -9,11 +9,12 @@ import {
 } from "../../customPropTypes";
 import ProfileSkeleton from "../profileSkeleton/ProfileSkeleton";
 import prepareInfo from "../../functions/prepareInfo";
+import ResultsCardError from "./ResultsCardError/ResultsCardError";
 
 const { Meta } = Card;
 const { Text } = Typography;
 
-const ResultsCardView = ({ history, intl, results }) => {
+const ResultsCardView = ({ history, intl, results, networkError }) => {
   const styles = {
     smallP: {
       lineHeight: "4px",
@@ -69,7 +70,7 @@ const ResultsCardView = ({ history, intl, results }) => {
             })}
           </Divider>
 
-          {person.resultSkills.map((skill) => (
+          {person.resultSkills.map(skill => (
             <Tag
               color="#004441"
               style={{ marginBottom: "2px", marginTop: "2px" }}
@@ -82,7 +83,7 @@ const ResultsCardView = ({ history, intl, results }) => {
     );
   };
 
-  const renderResultCards = (dataSource) => {
+  const renderResultCards = dataSource => {
     if (!dataSource) {
       return <ProfileSkeleton />;
     }
@@ -97,6 +98,17 @@ const ResultsCardView = ({ history, intl, results }) => {
     );
     return preparedResults.map((person, key) => renderCard(person, key));
   };
+
+  if (networkError) {
+    return <ResultsCardError networkError={networkError} />;
+  }
+
+  if (!results) {
+    return <ProfileSkeleton />;
+  }
+  if (results instanceof Error) {
+    return `An error was encountered! Please try again.\n\n${String(results)}`;
+  }
 
   return (
     <div>

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -13,6 +13,7 @@ const SearchBar = ({ history }) => {
   const [branchOptions, setBranchOptions] = useState([]);
   const [locationOptions, setLocationOptions] = useState([]);
   const [classOptions, setClassOptions] = useState([]);
+  const [networkError, setNetworkError] = useState(null);
 
   // Fetches options for skills select field in advanced search
   const getSkills = async () => {
@@ -22,6 +23,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -33,9 +35,10 @@ const SearchBar = ({ history }) => {
     try {
       const results = await axios.get(`${backendAddress}api/option/getBranch`);
       return results.data.filter(
-        (elem) => elem.description && elem.description.en
+        elem => elem.description && elem.description.en
       );
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -50,6 +53,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -64,6 +68,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -71,7 +76,7 @@ const SearchBar = ({ history }) => {
   };
 
   // turns search values into query, redirects to results page with query
-  const handleSearch = (values) => {
+  const handleSearch = values => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
     history.push(url);
@@ -99,6 +104,7 @@ const SearchBar = ({ history }) => {
       classOptions={classOptions}
       branchOptions={branchOptions}
       handleSearch={handleSearch}
+      networkError={networkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -13,7 +13,7 @@ const SearchBar = ({ history }) => {
   const [branchOptions, setBranchOptions] = useState([]);
   const [locationOptions, setLocationOptions] = useState([]);
   const [classOptions, setClassOptions] = useState([]);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Fetches options for skills select field in advanced search
   const getSkills = async () => {
@@ -23,7 +23,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -38,7 +38,7 @@ const SearchBar = ({ history }) => {
         elem => elem.description && elem.description.en
       );
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -53,7 +53,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -68,7 +68,7 @@ const SearchBar = ({ history }) => {
       );
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -104,7 +104,7 @@ const SearchBar = ({ history }) => {
       classOptions={classOptions}
       branchOptions={branchOptions}
       handleSearch={handleSearch}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBarView.jsx
@@ -13,7 +13,11 @@ import {
 } from "antd";
 import { SearchOutlined, SettingOutlined } from "@ant-design/icons";
 import logo from "../../assets/MyTalent-Logo-Full-v2.svg";
-import { IntlPropType, IdDescriptionPropType } from "../../customPropTypes";
+import {
+  IntlPropType,
+  IdDescriptionPropType,
+  NetworkErrorsPropType,
+} from "../../customPropTypes";
 import SearchBarError from "./searchBarError/SearchBarError";
 
 const { Option } = Select;
@@ -26,7 +30,7 @@ const SearchBarView = ({
   classOptions,
   branchOptions,
   handleSearch,
-  networkError,
+  networkErrors,
 }) => {
   const [expand, setExpand] = useState(false);
   const [form] = Form.useForm();
@@ -117,8 +121,8 @@ const SearchBarView = ({
     if (!displayForm) {
       return <div />;
     }
-    if (networkError) {
-      return <SearchBarError networkError={networkError} />;
+    if (networkErrors && networkErrors.length) {
+      return <SearchBarError networkErrors={networkErrors} />;
     }
     return (
       <div style={{ marginBottom: "0" }}>
@@ -329,6 +333,7 @@ SearchBarView.propTypes = {
   skillOptions: IdDescriptionPropType.isRequired,
   handleSearch: PropTypes.func.isRequired,
   intl: IntlPropType,
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 SearchBarView.defaultProps = {

--- a/services/frontend-v3/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBarView.jsx
@@ -14,6 +14,7 @@ import {
 import { SearchOutlined, SettingOutlined } from "@ant-design/icons";
 import logo from "../../assets/MyTalent-Logo-Full-v2.svg";
 import { IntlPropType, IdDescriptionPropType } from "../../customPropTypes";
+import SearchBarError from "./searchBarError/SearchBarError";
 
 const { Option } = Select;
 const { Title } = Typography;
@@ -25,6 +26,7 @@ const SearchBarView = ({
   classOptions,
   branchOptions,
   handleSearch,
+  networkError,
 }) => {
   const [expand, setExpand] = useState(false);
   const [form] = Form.useForm();
@@ -91,7 +93,7 @@ const SearchBarView = ({
   };
 
   // Handle form submission
-  const onFinish = (values) => {
+  const onFinish = values => {
     handleSearch(values);
   };
 
@@ -105,7 +107,7 @@ const SearchBarView = ({
   };
 
   // Generate the advanced search fields
-  const getAdvancedSearchForm = (displayForm) => {
+  const getAdvancedSearchForm = displayForm => {
     // detect language
     const locale = intl.formatMessage({
       id: "language.code",
@@ -114,6 +116,9 @@ const SearchBarView = ({
 
     if (!displayForm) {
       return <div />;
+    }
+    if (networkError) {
+      return <SearchBarError networkError={networkError} />;
     }
     return (
       <div style={{ marginBottom: "0" }}>
@@ -124,7 +129,6 @@ const SearchBarView = ({
             </Title>
           </Col>
         </Row>
-
         <Row gutter={[48, 24]} style={{ padding: "0px 5%" }}>
           {/* form column one */}
           <Col span={8}>
@@ -149,7 +153,7 @@ const SearchBarView = ({
                 mode="multiple"
                 placeholder={searchLabel}
               >
-                {locationOptions.map((value) => {
+                {locationOptions.map(value => {
                   return (
                     <Option key={value.id}>{value.description[locale]}</Option>
                   );
@@ -173,7 +177,7 @@ const SearchBarView = ({
                 mode="multiple"
                 placeholder={searchLabel}
               >
-                {skillOptions.map((value) => {
+                {skillOptions.map(value => {
                   return (
                     <Option key={value.id}>{value.description[locale]}</Option>
                   );
@@ -196,7 +200,7 @@ const SearchBarView = ({
                 mode="multiple"
                 placeholder={searchLabel}
               >
-                {classOptions.map((value) => {
+                {classOptions.map(value => {
                   return <Option key={value.id}>{value.description}</Option>;
                 })}
               </Select>
@@ -218,7 +222,7 @@ const SearchBarView = ({
                 mode="multiple"
                 placeholder={searchLabel}
               >
-                {branchOptions.map((value) => {
+                {branchOptions.map(value => {
                   return (
                     <Option key={value.description.en}>
                       {value.description[locale]}

--- a/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarError.jsx
+++ b/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarError.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import SearchBarErrorView from "./SearchBarErrorView";
+
+const SearchBarError = ({ networkError }) => {
+  return <SearchBarErrorView networkError={networkError} />;
+};
+
+export default SearchBarError;

--- a/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarError.jsx
+++ b/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarError.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import SearchBarErrorView from "./SearchBarErrorView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const SearchBarError = ({ networkError }) => {
-  return <SearchBarErrorView networkError={networkError} />;
+const SearchBarError = ({ networkErrors }) => {
+  return <SearchBarErrorView networkErrors={networkErrors} />;
+};
+
+SearchBarError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default SearchBarError;

--- a/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
+++ b/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
@@ -51,7 +51,7 @@ const SearchBarErrorView = ({ networkErrors }) => {
                   </>
                 ) : (
                   <div style={styles.itemDescription}>
-                    No response from backend
+                    <FormattedMessage id="error.no.backend.response" />
                   </div>
                 )
               }

--- a/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
+++ b/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const SearchBarErrorView = ({ networkError }) => {
+  const styles = {
+    errorTitle: {
+      paddingLeft: "8px",
+      fontWeight: "bold",
+      color: "rgba(0, 0, 0, 0.85)",
+    },
+  };
+  return (
+    <>
+      <>
+        <WarningOutlined />
+        <span style={styles.errorTitle}>
+          <FormattedMessage id="error.network" />
+        </span>
+      </>
+      <div>
+        <div>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </div>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <div>{networkError.response.data.status}</div>
+            <div>{networkError.response.data.message}</div>
+          </>
+        ) : (
+          <div>no response from backend server</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(SearchBarErrorView);

--- a/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
+++ b/services/frontend-v3/src/components/searchBar/searchBarError/SearchBarErrorView.jsx
@@ -1,38 +1,70 @@
 import React from "react";
 import { WarningOutlined } from "@ant-design/icons";
+import { List } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const SearchBarErrorView = ({ networkError }) => {
+const SearchBarErrorView = ({ networkErrors }) => {
   const styles = {
-    errorTitle: {
+    errorTitleText: {
       paddingLeft: "8px",
       fontWeight: "bold",
       color: "rgba(0, 0, 0, 0.85)",
+    },
+    itemTitleText: {
+      wordBreak: "break-word",
+      fontSize: "14px",
+      fontWeight: "normal",
+    },
+    itemDescription: {
+      wordBreak: "break-word",
     },
   };
   return (
     <>
       <>
         <WarningOutlined />
-        <span style={styles.errorTitle}>
+        <span style={styles.errorTitleText}>
           <FormattedMessage id="error.network" />
         </span>
       </>
-      <div>
-        <div>
-          {networkError.config.method.toUpperCase()} {networkError.config.url}
-        </div>
-        {networkError && networkError.response && networkError.response.data ? (
-          <>
-            <div>{networkError.response.data.status}</div>
-            <div>{networkError.response.data.message}</div>
-          </>
-        ) : (
-          <div>no response from backend server</div>
+      <List
+        size="small"
+        dataSource={networkErrors}
+        renderItem={item => (
+          <List.Item>
+            <List.Item.Meta
+              title={
+                <span style={styles.itemTitleText}>
+                  {item.config.method.toUpperCase()} {item.config.url}
+                </span>
+              }
+              description={
+                item.response && item.response.data ? (
+                  <>
+                    <div style={styles.itemDescription}>
+                      {item.response.status}
+                    </div>
+                    <div style={styles.itemDescription}>
+                      {item.response.statusText}
+                    </div>
+                  </>
+                ) : (
+                  <div style={styles.itemDescription}>
+                    No response from backend
+                  </div>
+                )
+              }
+            />
+          </List.Item>
         )}
-      </div>
+      />
     </>
   );
+};
+
+SearchBarErrorView.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default injectIntl(SearchBarErrorView);

--- a/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
@@ -16,6 +16,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
   const [locationOptions, setLocationOptions] = useState([]);
   const [classOptions, setClassOptions] = useState([]);
   const [urlSearchFieldValues, setUrlSearchFieldValues] = useState(null);
+  const [networkError, setNetworkError] = useState(null);
 
   const toggle = () => {
     setExpand(!expand);
@@ -63,6 +64,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
         );
         return results.data;
       } catch (error) {
+        setNetworkError(error);
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -76,9 +78,10 @@ const SearchFilter = ({ history, changeLanguage }) => {
           `${backendAddress}api/option/getBranch`
         );
         return results.data.filter(
-          (elem) => elem.description && elem.description.en
+          elem => elem.description && elem.description.en
         );
       } catch (error) {
+        setNetworkError(error);
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -94,6 +97,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
 
         return results.data;
       } catch (error) {
+        setNetworkError(error);
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -109,6 +113,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
 
         return results.data;
       } catch (error) {
+        setNetworkError(error);
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -131,7 +136,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
   }, [getSearchFieldValues]);
 
   // page with query
-  const handleSearch = (values) => {
+  const handleSearch = values => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
     history.push(url);
@@ -149,6 +154,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
       handleSearch={handleSearch}
       toggle={toggle}
       urlSearchFieldValues={urlSearchFieldValues}
+      networkError={networkError}
     />
   );
 };

--- a/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
@@ -16,7 +16,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
   const [locationOptions, setLocationOptions] = useState([]);
   const [classOptions, setClassOptions] = useState([]);
   const [urlSearchFieldValues, setUrlSearchFieldValues] = useState(null);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const toggle = () => {
     setExpand(!expand);
@@ -64,7 +64,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
         );
         return results.data;
       } catch (error) {
-        setNetworkError(error);
+        setNetworkErrors(oldArray => oldArray.concat(error));
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -81,7 +81,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
           elem => elem.description && elem.description.en
         );
       } catch (error) {
-        setNetworkError(error);
+        setNetworkErrors(oldArray => oldArray.concat(error));
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -97,7 +97,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
 
         return results.data;
       } catch (error) {
-        setNetworkError(error);
+        setNetworkErrors(oldArray => oldArray.concat(error));
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -113,7 +113,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
 
         return results.data;
       } catch (error) {
-        setNetworkError(error);
+        setNetworkErrors(oldArray => oldArray.concat(error));
         // eslint-disable-next-line no-console
         console.log(error);
         return [];
@@ -154,7 +154,7 @@ const SearchFilter = ({ history, changeLanguage }) => {
       handleSearch={handleSearch}
       toggle={toggle}
       urlSearchFieldValues={urlSearchFieldValues}
-      networkError={networkError}
+      networkErrors={networkErrors}
     />
   );
 };

--- a/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { injectIntl } from "react-intl";
 import { Form, Col, Button, Input, Switch, Select, Row } from "antd";
 import "@ant-design/compatible/assets/index.css";
+import SearchFilterError from "./searchFilterError/SearchFilterError";
 import { IntlPropType, IdDescriptionPropType } from "../../customPropTypes";
 
 const SearchBarView = ({
@@ -13,11 +14,12 @@ const SearchBarView = ({
   locationOptions,
   intl,
   urlSearchFieldValues,
+  networkError,
 }) => {
   const { Option } = Select;
   const [form] = Form.useForm();
 
-  const onFinish = (values) => {
+  const onFinish = values => {
     handleSearch(values);
   };
 
@@ -70,6 +72,11 @@ const SearchBarView = ({
       defaultMessage: "Ex Feeder",
     }),
   ];
+
+  if (networkError) {
+    return <SearchFilterError networkError={networkError} />;
+  }
+
   return (
     <Form
       style={{ padding: "10px", overflow: "hidden" }}
@@ -89,7 +96,7 @@ const SearchBarView = ({
             mode="multiple"
             placeholder={searchLabel}
           >
-            {skillOptions.map((value) => {
+            {skillOptions.map(value => {
               return (
                 <Option key={value.id}>{value.description[locale]}</Option>
               );
@@ -105,7 +112,7 @@ const SearchBarView = ({
             mode="multiple"
             placeholder={searchLabel}
           >
-            {branchOptions.map((value) => {
+            {branchOptions.map(value => {
               return (
                 <Option key={value.description.en}>
                   {value.description[locale]}
@@ -123,7 +130,7 @@ const SearchBarView = ({
             mode="multiple"
             placeholder={searchLabel}
           >
-            {locationOptions.map((value) => {
+            {locationOptions.map(value => {
               return (
                 <Option key={value.id}>{value.description[locale]}</Option>
               );
@@ -139,7 +146,7 @@ const SearchBarView = ({
             mode="multiple"
             placeholder={searchLabel}
           >
-            {classOptions.map((value) => {
+            {classOptions.map(value => {
               return <Option key={value.id}>{value.description}</Option>;
             })}
           </Select>

--- a/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
@@ -4,7 +4,11 @@ import { injectIntl } from "react-intl";
 import { Form, Col, Button, Input, Switch, Select, Row } from "antd";
 import "@ant-design/compatible/assets/index.css";
 import SearchFilterError from "./searchFilterError/SearchFilterError";
-import { IntlPropType, IdDescriptionPropType } from "../../customPropTypes";
+import {
+  IntlPropType,
+  IdDescriptionPropType,
+  NetworkErrorsPropType,
+} from "../../customPropTypes";
 
 const SearchBarView = ({
   handleSearch,
@@ -14,7 +18,7 @@ const SearchBarView = ({
   locationOptions,
   intl,
   urlSearchFieldValues,
-  networkError,
+  networkErrors,
 }) => {
   const { Option } = Select;
   const [form] = Form.useForm();
@@ -73,8 +77,8 @@ const SearchBarView = ({
     }),
   ];
 
-  if (networkError) {
-    return <SearchFilterError networkError={networkError} />;
+  if (networkErrors && networkErrors.length) {
+    return <SearchFilterError networkErrors={networkErrors} />;
   }
 
   return (
@@ -197,6 +201,7 @@ SearchBarView.propTypes = {
     exFeeder: PropTypes.bool,
     name: PropTypes.string,
   }),
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 SearchBarView.defaultProps = {

--- a/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterError.jsx
+++ b/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterError.jsx
@@ -1,8 +1,13 @@
 import React from "react";
 import SearchFilterErrorView from "./SearchFilterErrorView";
+import { NetworkErrorsPropType } from "../../../customPropTypes";
 
-const SearchFilterError = ({ networkError }) => {
-  return <SearchFilterErrorView networkError={networkError} />;
+const SearchFilterError = ({ networkErrors }) => {
+  return <SearchFilterErrorView networkErrors={networkErrors} />;
+};
+
+SearchFilterError.propTypes = {
+  networkErrors: NetworkErrorsPropType.isRequired,
 };
 
 export default SearchFilterError;

--- a/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterError.jsx
+++ b/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterError.jsx
@@ -1,0 +1,8 @@
+import React from "react";
+import SearchFilterErrorView from "./SearchFilterErrorView";
+
+const SearchFilterError = ({ networkError }) => {
+  return <SearchFilterErrorView networkError={networkError} />;
+};
+
+export default SearchFilterError;

--- a/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterErrorView.jsx
+++ b/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterErrorView.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { WarningOutlined } from "@ant-design/icons";
+import { FormattedMessage, injectIntl } from "react-intl";
+
+const SearchFilterErrorView = ({ networkError }) => {
+  const styles = {
+    errorTitle: {
+      paddingLeft: "8px",
+      fontWeight: "bold",
+      color: "rgba(0, 0, 0, 0.85)",
+    },
+    requestInfo: {
+      wordBreak: "break-word",
+    },
+  };
+  return (
+    <>
+      <>
+        <WarningOutlined />
+        <span style={styles.errorTitle}>
+          <FormattedMessage id="error.network" />
+        </span>
+      </>
+      <div>
+        <div style={styles.requestInfo}>
+          {networkError.config.method.toUpperCase()} {networkError.config.url}
+        </div>
+        {networkError && networkError.response && networkError.response.data ? (
+          <>
+            <div>{networkError.response.data.status}</div>
+            <div>{networkError.response.data.message}</div>
+          </>
+        ) : (
+          <div>no response from backend server</div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export default injectIntl(SearchFilterErrorView);

--- a/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterErrorView.jsx
+++ b/services/frontend-v3/src/components/searchFilter/searchFilterError/SearchFilterErrorView.jsx
@@ -56,7 +56,7 @@ const SearchFilterErrorView = ({ networkErrors }) => {
                     </>
                   ) : (
                     <div style={styles.itemDescription}>
-                      No response from backend
+                      <FormattedMessage id="error.no.backend.response" />
                     </div>
                   )
                 }

--- a/services/frontend-v3/src/customPropTypes.js
+++ b/services/frontend-v3/src/customPropTypes.js
@@ -112,6 +112,8 @@ const FieldPropType = PropTypes.shape({
   fieldKey: PropTypes.number,
 });
 
+const NetworkErrorsPropType = PropTypes.arrayOf(PropTypes.object);
+
 const HistoryPropType = PropTypes.shape({
   action: PropTypes.string,
   block: PropTypes.func,
@@ -144,4 +146,5 @@ export {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
   StylesPropType,
+  NetworkErrorsPropType,
 };

--- a/services/frontend-v3/src/customPropTypes.js
+++ b/services/frontend-v3/src/customPropTypes.js
@@ -24,6 +24,26 @@ const IdDescriptionPropType = PropTypes.arrayOf(
   })
 );
 
+const AxiosErrorPropType = PropTypes.shape({
+  config: PropTypes.objectOf(PropTypes.any),
+  isAxiosError: PropTypes.bool,
+  request: PropTypes.object,
+  response: PropTypes.shape({
+    config: PropTypes.object,
+    data: PropTypes.shape({
+      message: PropTypes.string,
+      status: PropTypes.string,
+    }),
+    headers: PropTypes.objectOf(PropTypes.string),
+    request: PropTypes.object,
+    status: PropTypes.number,
+    statusText: PropTypes.string,
+  }),
+  toJSON: PropTypes.func,
+  message: PropTypes.string,
+  stack: PropTypes.string,
+});
+
 const FormInstancePropType = PropTypes.shape({
   getFieldValue: PropTypes.func,
   getFieldsValue: PropTypes.func,
@@ -114,6 +134,7 @@ const HistoryPropType = PropTypes.shape({
 const StylesPropType = PropTypes.objectOf(PropTypes.objectOf(PropTypes.string));
 
 export {
+  AxiosErrorPropType,
   FieldPropType,
   FormInstancePropType,
   HistoryPropType,

--- a/services/frontend-v3/src/customPropTypes.js
+++ b/services/frontend-v3/src/customPropTypes.js
@@ -112,7 +112,18 @@ const FieldPropType = PropTypes.shape({
   fieldKey: PropTypes.number,
 });
 
-const NetworkErrorsPropType = PropTypes.arrayOf(PropTypes.object);
+const NetworkErrorPropType = PropTypes.shape({
+  isAxiosError: PropTypes.bool,
+  config: PropTypes.object,
+  request: PropTypes.object,
+  // Note: PropTypes.number has to be used to represent undefined
+  response: PropTypes.oneOfType([PropTypes.object, PropTypes.number]),
+  toJSON: PropTypes.func,
+  message: PropTypes.string,
+  stack: PropTypes.string,
+});
+
+const NetworkErrorsPropType = PropTypes.arrayOf(NetworkErrorPropType);
 
 const HistoryPropType = PropTypes.shape({
   action: PropTypes.string,
@@ -146,5 +157,6 @@ export {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
   StylesPropType,
+  NetworkErrorPropType,
   NetworkErrorsPropType,
 };

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -120,6 +120,8 @@
 
   "basic.search.button.text": "Basic search",
 
+  "error.network": "An unexpected network error occured:",
+
   "landing.login.and.enter": "Sign in",
   "landing.welcome": "Welcome",
   "landing.benefits": "Benefits",

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -120,7 +120,7 @@
 
   "basic.search.button.text": "Basic search",
 
-  "error.network": "An unexpected network error occured:",
+  "error.network": "Unexpected network error(s) occured:",
 
   "landing.login.and.enter": "Sign in",
   "landing.welcome": "Welcome",

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -121,6 +121,7 @@
   "basic.search.button.text": "Basic search",
 
   "error.network": "Unexpected network error(s) occured:",
+  "error.no.backend.response": "No response from backend",
 
   "landing.login.and.enter": "Sign in",
   "landing.welcome": "Welcome",

--- a/services/frontend-v3/src/pages/Profile.jsx
+++ b/services/frontend-v3/src/pages/Profile.jsx
@@ -11,8 +11,9 @@ const Profile = ({ history, match, changeLanguage }) => {
   const [name, setName] = useState("Loading");
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [networkError, setNetworkError] = useState(null);
 
-  const updateProfileInfo = async (id) => {
+  const updateProfileInfo = async id => {
     const userID = localStorage.getItem("userId");
 
     // Send private data to ProfileLayout component, when current user
@@ -20,23 +21,30 @@ const Profile = ({ history, match, changeLanguage }) => {
     if (id === userID) {
       const fetchedData = await axios
         .get(`${backendAddress}api/private/profile/${id}`)
-        .then((res) => res.data)
+        .then(res => res.data)
         // eslint-disable-next-line no-console
-        .catch((error) => console.error(error));
-
+        .catch(error => {
+          setNetworkError(error);
+          console.error(error);
+          return 0;
+        });
       return fetchedData;
     }
     // Send public data to ProfileLayout component, when current user
     // is looking at someone else profile
     const fetchedData = await axios
       .get(`${backendAddress}api/profile/${id}`)
-      .then((res) => res.data)
+      .then(res => res.data)
       // eslint-disable-next-line no-console
-      .catch((error) => console.error(error));
+      .catch(error => {
+        setNetworkError(error);
+        setLoading(false);
+        console.error(error);
+      });
     return fetchedData;
   };
 
-  const goto = useCallback((link) => history.push(link), [history]);
+  const goto = useCallback(link => history.push(link), [history]);
 
   useEffect(() => {
     const { id } = match.params;
@@ -47,7 +55,7 @@ const Profile = ({ history, match, changeLanguage }) => {
     }
 
     if (data === null) {
-      updateProfileInfo(id).then((fetchedData) => {
+      updateProfileInfo(id).then(fetchedData => {
         if (fetchedData !== undefined) {
           setName(`${fetchedData.firstName} ${fetchedData.lastName}`);
           setData(fetchedData);
@@ -62,7 +70,13 @@ const Profile = ({ history, match, changeLanguage }) => {
   }, [name]);
 
   if (!loading) {
-    return <ProfileLayout changeLanguage={changeLanguage} data={data} />;
+    return (
+      <ProfileLayout
+        changeLanguage={changeLanguage}
+        data={data}
+        networkError={networkError}
+      />
+    );
   }
 
   return <ProfileSkeleton changeLanguage={changeLanguage} />;

--- a/services/frontend-v3/src/pages/Profile.jsx
+++ b/services/frontend-v3/src/pages/Profile.jsx
@@ -25,6 +25,7 @@ const Profile = ({ history, match, changeLanguage }) => {
         // eslint-disable-next-line no-console
         .catch(error => {
           setNetworkErrors(oldArray => oldArray.concat(error));
+          // eslint-disable-next-line no-console
           console.error(error);
           return 0;
         });
@@ -39,6 +40,7 @@ const Profile = ({ history, match, changeLanguage }) => {
       .catch(error => {
         setNetworkErrors(oldArray => oldArray.concat(error));
         setLoading(false);
+        // eslint-disable-next-line no-console
         console.error(error);
       });
     return fetchedData;

--- a/services/frontend-v3/src/pages/Profile.jsx
+++ b/services/frontend-v3/src/pages/Profile.jsx
@@ -11,7 +11,7 @@ const Profile = ({ history, match, changeLanguage }) => {
   const [name, setName] = useState("Loading");
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [networkError, setNetworkError] = useState(null);
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   const updateProfileInfo = async id => {
     const userID = localStorage.getItem("userId");
@@ -24,7 +24,7 @@ const Profile = ({ history, match, changeLanguage }) => {
         .then(res => res.data)
         // eslint-disable-next-line no-console
         .catch(error => {
-          setNetworkError(error);
+          setNetworkErrors(oldArray => oldArray.concat(error));
           console.error(error);
           return 0;
         });
@@ -37,7 +37,7 @@ const Profile = ({ history, match, changeLanguage }) => {
       .then(res => res.data)
       // eslint-disable-next-line no-console
       .catch(error => {
-        setNetworkError(error);
+        setNetworkErrors(oldArray => oldArray.concat(error));
         setLoading(false);
         console.error(error);
       });
@@ -74,7 +74,7 @@ const Profile = ({ history, match, changeLanguage }) => {
       <ProfileLayout
         changeLanguage={changeLanguage}
         data={data}
-        networkError={networkError}
+        networkErrors={networkErrors}
       />
     );
   }

--- a/services/frontend-v3/src/pages/admin/Dashboard.jsx
+++ b/services/frontend-v3/src/pages/admin/Dashboard.jsx
@@ -8,6 +8,7 @@ import StatCards from "../../components/admin/statCards/StatCards";
 import DashboardGraphs from "../../components/admin/dashboardGraphs/DashboardGraphs";
 import config from "../../config";
 import { IntlPropType } from "../../customPropTypes";
+import AdminErrorContent from "../../components/admin/adminErrorContent/AdminErrorContent";
 
 const { backendAddress } = config;
 
@@ -19,6 +20,7 @@ const { backendAddress } = config;
 const AdminDashboard = ({ changeLanguage, intl }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [networkError, setNetworkError] = useState(null);
 
   const type = "dashboard";
 
@@ -31,6 +33,7 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
 
       return results.data;
     } catch (error) {
+      setNetworkError(error);
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
@@ -38,7 +41,7 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
   };
 
   // Get part of the title for the page
-  const getDisplayType = (plural) => {
+  const getDisplayType = plural => {
     if (plural)
       return intl.formatMessage({
         id: `admin.${type}.plural`,
@@ -72,16 +75,27 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
     );
   }
 
+  const generateContent = () => {
+    if (networkError) {
+      return <AdminErrorContent networkError={networkError} />;
+    }
+    return (
+      <>
+        <PageHeader
+          title={intl.formatMessage({
+            id: "admin.dashboard.title",
+            defaultMessage: "Admin Dashboard",
+          })}
+        />
+        <StatCards data={data} />
+        <DashboardGraphs data={data} />
+      </>
+    );
+  };
+
   return (
     <AdminLayout changeLanguage={changeLanguage} displaySideBar type={type}>
-      <PageHeader
-        title={intl.formatMessage({
-          id: "admin.dashboard.title",
-          defaultMessage: "Admin Dashboard",
-        })}
-      />
-      <StatCards data={data} />
-      <DashboardGraphs data={data} />
+      {generateContent()}
     </AdminLayout>
   );
 };

--- a/services/frontend-v3/src/pages/admin/Dashboard.jsx
+++ b/services/frontend-v3/src/pages/admin/Dashboard.jsx
@@ -20,9 +20,7 @@ const { backendAddress } = config;
 const AdminDashboard = ({ changeLanguage, intl }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [networkError, setNetworkError] = useState(null);
-
-  const type = "dashboard";
+  const [networkErrors, setNetworkErrors] = useState([]);
 
   // Get dashboard data for statistic cards and graphes
   const getDashboardData = async () => {
@@ -33,12 +31,14 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
 
       return results.data;
     } catch (error) {
-      setNetworkError(error);
+      setNetworkErrors(oldArray => oldArray.concat(error));
       // eslint-disable-next-line no-console
       console.log(error);
       return [];
     }
   };
+
+  const type = "dashboard";
 
   // Get part of the title for the page
   const getDisplayType = plural => {
@@ -54,16 +54,26 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
     });
   };
 
-  // useEffect to run once component is mounted
   useEffect(() => {
-    const setState = async () => {
-      // Get the data for the dashboard cards and graphes
+    const getData = async () => {
       const dashboardData = await getDashboardData();
       setData(dashboardData);
       setLoading(false);
     };
-    setState();
-  });
+    getData();
+  }, []);
+
+  // useEffect to run once component is mounted
+  /* useEffect(() => {
+    
+    const setState = async () => {
+      // Get the data for the dashboard cards and graphes
+      
+    };
+    // if (loading) {
+    
+    // }
+  }, [loading, networkErrors]); */
 
   document.title = `${getDisplayType(false)} - Admin | I-Talent`;
 
@@ -76,8 +86,8 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
   }
 
   const generateContent = () => {
-    if (networkError) {
-      return <AdminErrorContent networkError={networkError} />;
+    if (networkErrors && networkErrors.length) {
+      return <AdminErrorContent networkErrors={networkErrors} />;
     }
     return (
       <>


### PR DESCRIPTION
Handles get request errors encountered by rendering error components instead of the content dependent on the get request.

closes #171 

Notes:
- The error components are almost identical. I could change the code so that all areas render the same error component instead, I thought it might be better to separate them so they can be stylized more differently in the future.

Images of all the different error components in action:
![AdvancedOptions](https://user-images.githubusercontent.com/30152653/82341995-1a768680-99bf-11ea-9297-4012bac5cc05.jpg)
![EditProfileError](https://user-images.githubusercontent.com/30152653/82341997-1b0f1d00-99bf-11ea-9eb1-7c450b37f482.jpg)
![filterOptionsError](https://user-images.githubusercontent.com/30152653/82341999-1b0f1d00-99bf-11ea-94d1-9e2ea330f1a4.jpg)
![profileCardErrors](https://user-images.githubusercontent.com/30152653/82342000-1ba7b380-99bf-11ea-8ddb-a201ca354d1b.jpg)
![profileError](https://user-images.githubusercontent.com/30152653/82342001-1ba7b380-99bf-11ea-9eb1-57d0cd927fd6.jpg)
![ResultsError](https://user-images.githubusercontent.com/30152653/82342003-1ba7b380-99bf-11ea-9ede-c256ff393dc9.jpg)
![welcomeError](https://user-images.githubusercontent.com/30152653/82342005-1ba7b380-99bf-11ea-8a3b-82e93ee5fc08.jpg)
![AdminError](https://user-images.githubusercontent.com/30152653/82342007-1c404a00-99bf-11ea-9d94-ec814a6dd883.jpg)



