### PR TITLE
[Feat] Added redux for change language

### DIFF
--- a/services/frontend-v3/package.json
+++ b/services/frontend-v3/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@ant-design/compatible": "^1.0.2",
     "@ant-design/icons": "^4.0.5",
+    "@reduxjs/toolkit": "^1.3.6",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
@@ -25,9 +26,12 @@
     "react-dom": "^16.13.1",
     "react-highlight-words": "^0.16.0",
     "react-intl": "^3.12.0",
+    "react-redux": "^7.2.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
+    "redux": "^4.0.5",
+    "redux-persist": "^6.0.0",
     "serve": "^11.3.0"
   },
   "scripts": {

--- a/services/frontend-v3/src/App.jsx
+++ b/services/frontend-v3/src/App.jsx
@@ -16,7 +16,7 @@ import { Secured, Admin } from "./routes";
 import store, { persistor } from "./redux";
 
 const App = () => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
   const [i18nConfig, setI18nConfig] = useState({});
 
   useEffect(() => {

--- a/services/frontend-v3/src/App.jsx
+++ b/services/frontend-v3/src/App.jsx
@@ -1,7 +1,7 @@
-/* eslint-disable react/jsx-filename-extension */
-
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Provider as ReduxProvider, useSelector } from "react-redux";
+import { PersistGate } from "redux-persist/integration/react";
 
 import { IntlProvider } from "react-intl";
 import moment from "moment";
@@ -13,41 +13,27 @@ import "moment/locale/fr-ca";
 import "./App.css";
 import { NotFound, LandingPage } from "./pages";
 import { Secured, Admin } from "./routes";
+import store, { persistor } from "./redux";
 
-function App() {
-  const [locale, setLocale] = useState(localStorage.getItem("lang") || "en");
+const App = () => {
+  const locale = useSelector((state) => state.settings.language);
+  const [i18nConfig, setI18nConfig] = useState({});
 
-  const i18nConfig = {
-    messages: locale === "fr" ? messagesFr : messagesEn,
-    formats: {
-      number: {
-        CAD: {
-          style: "currency",
-          currency: "USD",
-          currencyDisplay: "symbol",
+  useEffect(() => {
+    setI18nConfig({
+      messages: locale === "fr" ? messagesFr : messagesEn,
+      formats: {
+        number: {
+          CAD: {
+            style: "currency",
+            currency: "USD",
+            currencyDisplay: "symbol",
+          },
         },
       },
-    },
-  };
-
-  moment.locale(`${locale}-ca`);
-
-  const changeLanguage = lang => {
-    localStorage.setItem("lang", lang);
-    switch (locale) {
-      case "fr":
-        i18nConfig.messages = messagesFr;
-        break;
-      case "en":
-      default:
-        i18nConfig.messages = messagesEn;
-        break;
-    }
-
-    moment.locale(`${lang}-ca`);
-
-    setLocale(lang);
-  };
+    });
+    moment.locale(`${locale}-ca`);
+  }, [locale]);
 
   return (
     <IntlProvider
@@ -60,11 +46,10 @@ function App() {
           <Route
             exact
             path="/"
-            render={routeProps => {
+            render={(routeProps) => {
               const { history, location, match, staticContext } = routeProps;
               return (
                 <LandingPage
-                  changeLanguage={changeLanguage}
                   history={history}
                   location={location}
                   match={match}
@@ -75,11 +60,10 @@ function App() {
           />
           <Route
             path="/secured"
-            render={routeProps => {
+            render={(routeProps) => {
               const { history, location, match, staticContext } = routeProps;
               return (
                 <Secured
-                  changeLanguage={changeLanguage}
                   history={history}
                   location={location}
                   match={match}
@@ -90,11 +74,10 @@ function App() {
           />
           <Route
             path="/admin"
-            render={routeProps => {
+            render={(routeProps) => {
               const { history, location, match, staticContext } = routeProps;
               return (
                 <Admin
-                  changeLanguage={changeLanguage}
                   history={history}
                   location={location}
                   match={match}
@@ -108,5 +91,14 @@ function App() {
       </Router>
     </IntlProvider>
   );
-}
-export default App;
+};
+
+const ReduxWrappedApp = () => (
+  <ReduxProvider store={store}>
+    <PersistGate loading={null} persistor={persistor}>
+      <App />
+    </PersistGate>
+  </ReduxProvider>
+);
+
+export default ReduxWrappedApp;

--- a/services/frontend-v3/src/App.jsx
+++ b/services/frontend-v3/src/App.jsx
@@ -15,23 +15,25 @@ import { NotFound, LandingPage } from "./pages";
 import { Secured, Admin } from "./routes";
 import store, { persistor } from "./redux";
 
+const i18nConfigBuilder = (locale) => ({
+  messages: locale === "fr" ? messagesFr : messagesEn,
+  formats: {
+    number: {
+      CAD: {
+        style: "currency",
+        currency: "USD",
+        currencyDisplay: "symbol",
+      },
+    },
+  },
+});
+
 const App = () => {
   const { locale } = useSelector((state) => state.settings);
-  const [i18nConfig, setI18nConfig] = useState({});
+  const [i18nConfig, setI18nConfig] = useState(i18nConfigBuilder('en'));
 
   useEffect(() => {
-    setI18nConfig({
-      messages: locale === "fr" ? messagesFr : messagesEn,
-      formats: {
-        number: {
-          CAD: {
-            style: "currency",
-            currency: "USD",
-            currencyDisplay: "symbol",
-          },
-        },
-      },
-    });
+    setI18nConfig(i18nConfigBuilder(locale));
     moment.locale(`${locale}-ca`);
   }, [locale]);
 

--- a/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
+++ b/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-shadow */
 import React from "react";
 import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 import DashboardGraphsView from "./DashboardGraphsView";
 
 /**
@@ -9,10 +10,11 @@ import DashboardGraphsView from "./DashboardGraphsView";
  *  It setups the data (bridge) for rendering the component in the view.
  */
 const DashboardGraphs = ({ data }) => {
+  const locale = useSelector((state) => state.settings.language);
+
   /* only access data for graphes that uses corresponding language on page */
   const changeEnFr = (dataSource) => {
     if (dataSource) {
-      const locale = localStorage.getItem("lang") || "en";
       const data = dataSource.map((skill) => {
         return {
           name: skill.description[locale],

--- a/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
+++ b/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphs.jsx
@@ -10,7 +10,7 @@ import DashboardGraphsView from "./DashboardGraphsView";
  *  It setups the data (bridge) for rendering the component in the view.
  */
 const DashboardGraphs = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   /* only access data for graphes that uses corresponding language on page */
   const changeEnFr = (dataSource) => {

--- a/services/frontend-v3/src/components/basicInfo/BasicInfo.jsx
+++ b/services/frontend-v3/src/components/basicInfo/BasicInfo.jsx
@@ -4,8 +4,8 @@ import BasicInfoView from "./BasicInfoView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const BasicInfo = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
-  
+  const { locale } = useSelector((state) => state.settings);
+
   const getButtonLinks = () => {
     const { linkedinUrl, githubUrl, gcconnexUrl, email } = data;
     const buttonLinks = { buttons: [] };

--- a/services/frontend-v3/src/components/basicInfo/BasicInfo.jsx
+++ b/services/frontend-v3/src/components/basicInfo/BasicInfo.jsx
@@ -1,8 +1,11 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import BasicInfoView from "./BasicInfoView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const BasicInfo = ({ data }) => {
+  const locale = useSelector((state) => state.settings.language);
+  
   const getButtonLinks = () => {
     const { linkedinUrl, githubUrl, gcconnexUrl, email } = data;
     const buttonLinks = { buttons: [] };
@@ -54,8 +57,8 @@ const BasicInfo = ({ data }) => {
         acr: data.nameInitials,
         color: data.avatarColor,
       }}
-      jobTitle={data.jobTitle[localStorage.getItem("lang") || "en"]}
-      locale={localStorage.getItem("lang") || "en"}
+      jobTitle={data.jobTitle[locale]}
+      locale={locale}
       buttonLinks={getButtonLinks()}
     />
   );

--- a/services/frontend-v3/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend-v3/src/components/basicInfo/BasicInfoView.jsx
@@ -238,7 +238,7 @@ BasicInfoView.propTypes = {
     color: PropTypes.string,
   }).isRequired,
   jobTitle: PropTypes.string,
-  locale: PropTypes.string.isRequired,
+  locale: PropTypes.oneOf(["fr", "en"]).isRequired,
   buttonLinks: PropTypes.objectOf(PropTypes.any).isRequired,
 };
 

--- a/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
+++ b/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
@@ -5,8 +5,8 @@ import { useSelector } from "react-redux";
 import CareerInterestsView from "./CareerInterestsView";
 
 const CareerInterests = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
-  
+  const { locale } = useSelector((state) => state.settings);
+
   const getCareerInterestsInfo = () => {
     const interestedInRemote = {
       icon: "mail",

--- a/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
+++ b/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 import CareerInterestsView from "./CareerInterestsView";
 
 const CareerInterests = ({ data }) => {
+  const locale = useSelector((state) => state.settings.language);
+  
   const getCareerInterestsInfo = () => {
-    const locale = localStorage.getItem("lang") || "en";
-
     const interestedInRemote = {
       icon: "mail",
       title: <FormattedMessage id="profile.interested.in.remote" />,
@@ -30,8 +31,6 @@ const CareerInterests = ({ data }) => {
   };
 
   const getRelocationLocationsInfo = () => {
-    const locale = localStorage.getItem("lang") || "en";
-
     const relocationLocationsInfo = [];
     if (data.relocationLocations) {
       data.relocationLocations.forEach((locationElement) =>
@@ -45,7 +44,6 @@ const CareerInterests = ({ data }) => {
   return (
     <CareerInterestsView
       data={data}
-      locale={localStorage.getItem("lang") || "en"}
       info={getCareerInterestsInfo()}
       relocationLocationsInfo={getRelocationLocationsInfo()}
     />

--- a/services/frontend-v3/src/components/changeLanguage/ChangeLanguage.jsx
+++ b/services/frontend-v3/src/components/changeLanguage/ChangeLanguage.jsx
@@ -1,13 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import ChangeLanguageView from "./ChangeLanguageView";
 
-const ChangeLanguage = ({ changeLanguage }) => {
-  return <ChangeLanguageView changeLanguage={changeLanguage} />;
-};
-
-ChangeLanguage.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const ChangeLanguage = () => {
+  return <ChangeLanguageView />;
 };
 
 export default ChangeLanguage;

--- a/services/frontend-v3/src/components/changeLanguage/ChangeLanguageView.jsx
+++ b/services/frontend-v3/src/components/changeLanguage/ChangeLanguageView.jsx
@@ -2,17 +2,19 @@ import React from "react";
 import { GlobalOutlined } from "@ant-design/icons";
 import { Button } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
-import PropTypes from "prop-types";
+import { useDispatch } from "react-redux";
 import { IntlPropType } from "../../customPropTypes";
+import { setLanguage } from "../../redux/slices/settingsSlice";
 
-const ChangeLanguageView = ({ intl, changeLanguage }) => {
+const ChangeLanguageView = ({ intl }) => {
   const languageCode = intl.formatMessage({ id: "lang.code" });
+  const dispatch = useDispatch();
 
   const handleKeyPress = (e, lang) => {
     if (e.charCode === 32 || e.charCode === 13) {
       // Prevent the default action to stop scrolling when space is pressed
       e.preventDefault();
-      changeLanguage(lang);
+      dispatch(setLanguage(lang));
     }
   };
 
@@ -22,7 +24,7 @@ const ChangeLanguageView = ({ intl, changeLanguage }) => {
       type="default"
       tabIndex="0"
       onKeyPress={e => handleKeyPress(e, languageCode)}
-      onClick={() => changeLanguage(languageCode)}
+      onClick={() => dispatch(setLanguage(languageCode))}
       style={{ textTransform: "uppercase" }}
     >
       <GlobalOutlined />{" "}
@@ -35,7 +37,6 @@ const ChangeLanguageView = ({ intl, changeLanguage }) => {
 };
 
 ChangeLanguageView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   intl: IntlPropType,
 };
 

--- a/services/frontend-v3/src/components/changeLanguage/ChangeLanguageView.jsx
+++ b/services/frontend-v3/src/components/changeLanguage/ChangeLanguageView.jsx
@@ -4,7 +4,7 @@ import { Button } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { useDispatch } from "react-redux";
 import { IntlPropType } from "../../customPropTypes";
-import { setLanguage } from "../../redux/slices/settingsSlice";
+import { setLocale } from "../../redux/slices/settingsSlice";
 
 const ChangeLanguageView = ({ intl }) => {
   const languageCode = intl.formatMessage({ id: "lang.code" });
@@ -14,7 +14,7 @@ const ChangeLanguageView = ({ intl }) => {
     if (e.charCode === 32 || e.charCode === 13) {
       // Prevent the default action to stop scrolling when space is pressed
       e.preventDefault();
-      dispatch(setLanguage(lang));
+      dispatch(setLocale(lang));
     }
   };
 
@@ -23,8 +23,8 @@ const ChangeLanguageView = ({ intl }) => {
       ghost="true"
       type="default"
       tabIndex="0"
-      onKeyPress={e => handleKeyPress(e, languageCode)}
-      onClick={() => dispatch(setLanguage(languageCode))}
+      onKeyPress={(e) => handleKeyPress(e, languageCode)}
+      onClick={() => dispatch(setLocale(languageCode))}
       style={{ textTransform: "uppercase" }}
     >
       <GlobalOutlined />{" "}

--- a/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
+++ b/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
@@ -1,18 +1,18 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { injectIntl } from "react-intl";
+import { useSelector } from "react-redux";
 
 import CompetenciesView from "./CompetenciesView";
 
-const Competencies = ({ data, intl }) => {
-  const formatData = () => {
-    const locale = intl.formatMessage({ id: "language.code" });
+const Competencies = ({ data }) => {
+  const { locale } = useSelector((state) => state.settings);
 
+  const formatData = () => {
     const competencies = [];
     let key = 0;
 
     if (data.competencies) {
-      data.competencies.forEach(element => {
+      data.competencies.forEach((element) => {
         competencies[key] = element.description[locale];
         key += 1;
       });
@@ -35,9 +35,6 @@ Competencies.propTypes = {
       })
     ),
   }).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func,
-  }).isRequired,
 };
 
-export default injectIntl(Competencies);
+export default Competencies;

--- a/services/frontend-v3/src/components/developmentalGoals/DevelopmentalGoals.jsx
+++ b/services/frontend-v3/src/components/developmentalGoals/DevelopmentalGoals.jsx
@@ -1,19 +1,20 @@
 import React from "react";
-import { injectIntl } from "react-intl";
-import { IntlPropType, ProfileInfoPropType } from "../../customPropTypes";
+import { useSelector } from "react-redux";
+import { ProfileInfoPropType } from "../../customPropTypes";
 
 import DevelopmentalGoalsView from "./DevelopmentalGoalsView";
 
-function DevelopmentalGoals({ data, intl }) {
-  const formatData = dataSource => {
-    const profileData = { ...dataSource.data };
-    const locale = dataSource.intl.formatMessage({ id: "language.code" });
+const DevelopmentalGoals = ({ data }) => {
+  const { locale } = useSelector((state) => state.settings);
+
+  const formatData = (dataSource) => {
+    const profileData = { ...dataSource };
 
     const devGoals = [];
     let key = 0;
 
     if (profileData.developmentalGoals) {
-      profileData.developmentalGoals.forEach(devGoal => {
+      profileData.developmentalGoals.forEach((devGoal) => {
         devGoals[key] = devGoal.description[locale];
         key += 1;
       });
@@ -22,17 +23,15 @@ function DevelopmentalGoals({ data, intl }) {
     return devGoals;
   };
 
-  return <DevelopmentalGoalsView devGoals={formatData({ data, intl })} />;
-}
+  return <DevelopmentalGoalsView devGoals={formatData(data)} />;
+};
 
 DevelopmentalGoals.propTypes = {
   data: ProfileInfoPropType,
-  intl: IntlPropType,
 };
 
 DevelopmentalGoals.defaultProps = {
   data: null,
-  intl: undefined,
 };
 
-export default injectIntl(DevelopmentalGoals);
+export default DevelopmentalGoals;

--- a/services/frontend-v3/src/components/education/Education.jsx
+++ b/services/frontend-v3/src/components/education/Education.jsx
@@ -1,10 +1,13 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import moment from "moment";
+import { useSelector } from "react-redux";
 import { ProfileInfoPropType } from "../../customPropTypes";
 import EducationView from "./EducationView";
 
-function Education({ data }) {
+const Education = ({ data }) => {
+  const locale = useSelector((state) => state.settings.language);
+
   const getEducationDuration = (startDate, endDate) => {
     const formatedStartDate = moment(startDate).format("ll");
     const formatedEndDate = moment(endDate).format("ll");
@@ -25,7 +28,6 @@ function Education({ data }) {
   };
 
   const getEducationInfo = dataSource => {
-    const locale = localStorage.getItem("lang") || "en";
     const educationInfo = [];
     if (dataSource.education != null) {
       dataSource.education.forEach(educElement => {
@@ -47,7 +49,6 @@ function Education({ data }) {
 
   return (
     <EducationView
-      locale={localStorage.getItem("lang") || "en"}
       educationInfo={getEducationInfo(data)}
     />
   );

--- a/services/frontend-v3/src/components/education/Education.jsx
+++ b/services/frontend-v3/src/components/education/Education.jsx
@@ -6,7 +6,7 @@ import { ProfileInfoPropType } from "../../customPropTypes";
 import EducationView from "./EducationView";
 
 const Education = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   const getEducationDuration = (startDate, endDate) => {
     const formatedStartDate = moment(startDate).format("ll");
@@ -27,10 +27,10 @@ const Education = ({ data }) => {
     return duration;
   };
 
-  const getEducationInfo = dataSource => {
+  const getEducationInfo = (dataSource) => {
     const educationInfo = [];
     if (dataSource.education != null) {
-      dataSource.education.forEach(educElement => {
+      dataSource.education.forEach((educElement) => {
         const startDate = educElement.startDate[locale];
         const endDate = educElement.endDate[locale];
 
@@ -47,12 +47,8 @@ const Education = ({ data }) => {
     return [...educationInfo];
   };
 
-  return (
-    <EducationView
-      educationInfo={getEducationInfo(data)}
-    />
-  );
-}
+  return <EducationView educationInfo={getEducationInfo(data)} />;
+};
 
 Education.propTypes = { data: ProfileInfoPropType.isRequired };
 

--- a/services/frontend-v3/src/components/employeeSummary/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend-v3/src/components/employeeSummary/officialLanguage/OfficialLanguage.jsx
@@ -6,7 +6,7 @@ import OfficialLanguageView from "./OfficialLanguageView";
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
 const OfficialLanguage = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   const getFirstLanguageInfo = (dataSource) => {
     const firstLanguage = {

--- a/services/frontend-v3/src/components/employeeSummary/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend-v3/src/components/employeeSummary/officialLanguage/OfficialLanguage.jsx
@@ -1,12 +1,14 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import moment from "moment";
+import { useSelector } from "react-redux";
 import OfficialLanguageView from "./OfficialLanguageView";
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
 const OfficialLanguage = ({ data }) => {
-  const getFirstLanguageInfo = dataSource => {
-    const locale = localStorage.getItem("lang") || "en";
+  const locale = useSelector((state) => state.settings.language);
+
+  const getFirstLanguageInfo = (dataSource) => {
     const firstLanguage = {
       title: <FormattedMessage id="profile.first.language" />,
       description:
@@ -19,7 +21,7 @@ const OfficialLanguage = ({ data }) => {
     return [firstLanguage];
   };
 
-  const getSecondLanguageGradeInfo = dataSource => {
+  const getSecondLanguageGradeInfo = (dataSource) => {
     const secondaryReadingProficiency = {
       title: <FormattedMessage id="profile.reading" />,
       description:
@@ -57,7 +59,7 @@ const OfficialLanguage = ({ data }) => {
     ];
   };
 
-  const getSecondLanguageDateInfo = dataSource => {
+  const getSecondLanguageDateInfo = (dataSource) => {
     const formatedReadingDate = moment(dataSource.secondaryReadingDate).format(
       "ll"
     );

--- a/services/frontend-v3/src/components/employeeSummary/substantive/Substantive.jsx
+++ b/services/frontend-v3/src/components/employeeSummary/substantive/Substantive.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { useSelector } from "react-redux";
+import { FormattedMessage } from "react-intl";
 import SubstativeView from "./SubstantiveView";
 
-const Substantive = ({ intl, data }) => {
-  const formatData = () => {
-    const locale = intl.formatMessage({ id: "language.code" });
+const Substantive = ({ data }) => {
+  const { locale } = useSelector((state) => state.settings);
 
+  const formatData = () => {
     const classification = {
       title: <FormattedMessage id="profile.classification" />,
       description:
@@ -54,9 +55,6 @@ Substantive.propTypes = {
       }),
     }),
   }).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func,
-  }).isRequired,
 };
 
-export default injectIntl(Substantive);
+export default Substantive;

--- a/services/frontend-v3/src/components/landingLayout/landingLayout.jsx
+++ b/services/frontend-v3/src/components/landingLayout/landingLayout.jsx
@@ -1,15 +1,10 @@
 import React from "react";
 import { injectIntl } from "react-intl";
-import PropTypes from "prop-types";
 import LandingLayoutView from "./landingLayoutView";
 
 /** Logic for the landing route layout */
-const LandingLayout = ({ changeLanguage }) => {
-  return <LandingLayoutView changeLanguage={changeLanguage} />;
-};
-
-LandingLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const LandingLayout = () => {
+  return <LandingLayoutView />;
 };
 
 export default injectIntl(LandingLayout);

--- a/services/frontend-v3/src/components/landingLayout/landingLayoutView.jsx
+++ b/services/frontend-v3/src/components/landingLayout/landingLayoutView.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { Button } from "antd";
 import { FormattedMessage } from "react-intl";
-import PropTypes from "prop-types";
 import backgroundImage from "../../assets/myTalentLandingBackground.png";
 import LandingNavBarController from "./landingNavBar/landingNavBarController";
 
 /** UI for the landing route layout */
-const LandingLayoutView = ({ changeLanguage }) => {
+const LandingLayoutView = () => {
   return (
     <>
       <div
@@ -62,14 +61,10 @@ const LandingLayoutView = ({ changeLanguage }) => {
       </div>
 
       <div style={{ paddingTop: "0px" }}>
-        <LandingNavBarController changeLanguage={changeLanguage} />
+        <LandingNavBarController />
       </div>
     </>
   );
-};
-
-LandingLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default LandingLayoutView;

--- a/services/frontend-v3/src/components/landingLayout/landingNavBar/landingNavBarController.jsx
+++ b/services/frontend-v3/src/components/landingLayout/landingNavBar/landingNavBarController.jsx
@@ -1,14 +1,9 @@
 import React from "react";
-import PropTypes from "prop-types";
 import LandingNavBarView from "./landingNavBarView";
 
 /** UI for the landing route's sign in navigation bar */
-const LandingNavBarController = ({ changeLanguage }) => {
-  return <LandingNavBarView changeLanguage={changeLanguage} />;
-};
-
-LandingNavBarController.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const LandingNavBarController = () => {
+  return <LandingNavBarView />;
 };
 
 export default LandingNavBarController;

--- a/services/frontend-v3/src/components/landingLayout/landingNavBar/landingNavBarView.jsx
+++ b/services/frontend-v3/src/components/landingLayout/landingNavBar/landingNavBarView.jsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { Menu } from "antd";
 import { injectIntl, FormattedMessage } from "react-intl";
-import PropTypes from "prop-types";
 import ChangeLanguage from "../../changeLanguage/ChangeLanguage";
 import Logo from "../../../assets/Logo5.png";
 
 /** UI for the landing route's sign in navigation bar */
-const LandingNavBarView = ({ changeLanguage }) => {
+const LandingNavBarView = () => {
   return (
     <Menu color="blue" fixed="top" fluid inverted>
       <Menu.Item style={{ paddingBottom: "8px", paddingTop: "8px" }}>
@@ -16,13 +15,9 @@ const LandingNavBarView = ({ changeLanguage }) => {
         <FormattedMessage id="landing.login.and.enter" />
       </Menu.Item>
 
-      <ChangeLanguage changeLanguage={changeLanguage} />
+      <ChangeLanguage />
     </Menu>
   );
-};
-
-LandingNavBarView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default injectIntl(LandingNavBarView);

--- a/services/frontend-v3/src/components/layouts/adminLayout/AdminLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/adminLayout/AdminLayout.jsx
@@ -6,22 +6,15 @@ import AdminLayoutView from "./AdminLayoutView";
  *  AdminLayout(props)
  *  Controller for the Admin Layout.
  */
-const AdminLayout = (props) => {
-  const { changeLanguage, displaySideBar, type, children } = props;
-
+const AdminLayout = ({ displaySideBar, type, children }) => {
   return (
-    <AdminLayoutView
-      changeLanguage={changeLanguage}
-      displaySideBar={displaySideBar}
-      type={type}
-    >
+    <AdminLayoutView displaySideBar={displaySideBar} type={type}>
       {children}
     </AdminLayoutView>
   );
 };
 
 AdminLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   displaySideBar: PropTypes.bool.isRequired,
   type: PropTypes.oneOf([
     "dashboard",

--- a/services/frontend-v3/src/components/layouts/adminLayout/AdminLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/adminLayout/AdminLayoutView.jsx
@@ -24,7 +24,6 @@ import AppLayout from "../appLayout/AppLayout";
 const AdminLayoutView = (props) => {
   const {
     type,
-    changeLanguage,
     intl,
     keycloak,
     displaySideBar,
@@ -153,7 +152,6 @@ const AdminLayoutView = (props) => {
   /* Uses the AppLayout */
   return (
     <AppLayout
-      changeLanguage={changeLanguage}
       keycloak={keycloak}
       history={history}
       displaySideBar={displaySideBar}
@@ -165,7 +163,6 @@ const AdminLayoutView = (props) => {
 };
 
 AdminLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   displaySideBar: PropTypes.bool.isRequired,
   type: PropTypes.oneOf([
     "dashboard",
@@ -185,4 +182,5 @@ AdminLayoutView.defaultProps = {
   intl: undefined,
   keycloak: undefined,
 };
+
 export default injectIntl(AdminLayoutView);

--- a/services/frontend-v3/src/components/layouts/appLayout/AppLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/AppLayout.jsx
@@ -3,14 +3,12 @@ import PropTypes from "prop-types";
 import AppLayoutView from "./AppLayoutView";
 
 const AppLayout = ({
-  changeLanguage,
   displaySideBar,
   sideBarContent,
   children,
 }) => {
   return (
     <AppLayoutView
-      changeLanguage={changeLanguage}
       displaySideBar={displaySideBar}
       sideBarContent={sideBarContent}
     >
@@ -23,7 +21,6 @@ AppLayout.propTypes = {
   children: PropTypes.node.isRequired,
   sideBarContent: PropTypes.node,
   displaySideBar: PropTypes.bool.isRequired,
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 AppLayout.defaultProps = {

--- a/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.jsx
@@ -6,12 +6,7 @@ import SideNav from "../../sideNav/SideNav";
 
 const { Content } = Layout;
 
-const AppLayoutView = ({
-  changeLanguage,
-  sideBarContent,
-  displaySideBar,
-  children,
-}) => {
+const AppLayoutView = ({ sideBarContent, displaySideBar, children }) => {
   const styles = {
     contentLayout: {
       marginTop: "64px",
@@ -26,7 +21,7 @@ const AppLayoutView = ({
   return (
     <Layout style={{ minHeight: "100vh" }}>
       {/* Render Top Navigation Bar */}
-      <TopNav changeLanguage={changeLanguage} />
+      <TopNav />
       <Layout style={{ marginTop: 64 }}>
         {/* Render Side Navigation Bar */}
         <SideNav
@@ -43,7 +38,6 @@ const AppLayoutView = ({
 };
 
 AppLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   sideBarContent: PropTypes.node,
   displaySideBar: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,

--- a/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNav.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNav.jsx
@@ -1,13 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import TopNavView from "./TopNavView";
 
-const TopNav = ({ changeLanguage }) => {
-  return <TopNavView changeLanguage={changeLanguage} />;
-};
-
-TopNav.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const TopNav = () => {
+  return <TopNavView />;
 };
 
 export default TopNav;

--- a/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
@@ -8,14 +8,13 @@ import {
 } from "@ant-design/icons";
 import { Layout, Dropdown, Menu, Button } from "antd";
 import { FormattedMessage } from "react-intl";
-import PropTypes from "prop-types";
 import ChangeLanguage from "../../../changeLanguage/ChangeLanguage";
 import CustomAvatar from "../../../customAvatar/CustomAvatar";
 import Logo from "../../../../assets/MyTalent-Logo-Full-v2.svg";
 
 const { Header } = Layout;
 
-const TopNavView = ({ changeLanguage }) => {
+const TopNavView = () => {
   /* Component Styles */
   const styles = {
     header: {
@@ -125,14 +124,10 @@ const TopNavView = ({ changeLanguage }) => {
         {/* Render User Profile Dropdown */}
         {getAvatarDropdown(localStorage.getItem("name"))}
         {/* Render change language button */}
-        <ChangeLanguage changeLanguage={changeLanguage} />
+        <ChangeLanguage />
       </div>
     </Header>
   );
-};
-
-TopNavView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default TopNavView;

--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayout.jsx
@@ -6,14 +6,13 @@ import CreateProfileLayoutView from "./CreateProfileLayoutView";
  *  CreateProfileLayout(props)
  *  Controller for the Create Profile Layout.
  */
-const CreateProfileLayout = ({ changeLanguage, step }) => {
+const CreateProfileLayout = ({ step }) => {
   return (
-    <CreateProfileLayoutView changeLanguage={changeLanguage} formStep={step} />
+    <CreateProfileLayoutView formStep={step} />
   );
 };
 
 CreateProfileLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   step: PropTypes.string,
 };
 

--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
@@ -26,7 +26,7 @@ const { Step } = Steps;
  *  Render the layout for the create profile forms
  */
 const CreateProfileLayoutView = (props) => {
-  const { changeLanguage, formStep, intl } = props;
+  const { formStep, intl } = props;
   const history = useHistory();
   const [profileExists, setProfileExists] = useState(false);
 
@@ -228,7 +228,6 @@ const CreateProfileLayoutView = (props) => {
 
   return (
     <AppLayout
-      changeLanguage={changeLanguage}
       sideBarContent={sideBarContent}
       displaySideBar
     >
@@ -245,7 +244,6 @@ const CreateProfileLayoutView = (props) => {
 };
 
 CreateProfileLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   formStep: PropTypes.string,
   intl: IntlPropType,
 };

--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
 import { PageHeader, Steps } from "antd";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { useHistory } from "react-router-dom";
 import PropTypes from "prop-types";
 import axios from "axios";
+import { useSelector } from "react-redux";
 import AppLayout from "../appLayout/AppLayout";
 import config from "../../../config";
 import {
@@ -16,7 +17,6 @@ import {
   QualificationsForm,
   DoneSetup,
 } from "../../profileForms";
-import { IntlPropType } from "../../../customPropTypes";
 
 const { backendAddress } = config;
 const { Step } = Steps;
@@ -26,7 +26,7 @@ const { Step } = Steps;
  *  Render the layout for the create profile forms
  */
 const CreateProfileLayoutView = (props) => {
-  const { formStep, intl } = props;
+  const { formStep } = props;
   const history = useHistory();
   const [profileExists, setProfileExists] = useState(false);
 
@@ -113,7 +113,7 @@ const CreateProfileLayoutView = (props) => {
           current={stepInt}
           onChange={onChange}
         >
-          <Step title={intl.formatMessage({ id: "setup.welcome" })} />
+          <Step title={<FormattedMessage id="setup.welcome" />} />
           <Step
             title={<FormattedMessage id="setup.primary.information" />}
             description={
@@ -221,16 +221,10 @@ const CreateProfileLayoutView = (props) => {
   const form = profileFormSelect(formStep);
 
   // get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   return (
-    <AppLayout
-      sideBarContent={sideBarContent}
-      displaySideBar
-    >
+    <AppLayout sideBarContent={sideBarContent} displaySideBar>
       <PageHeader
         style={{
           padding: "0 0 15px 7px",
@@ -245,12 +239,10 @@ const CreateProfileLayoutView = (props) => {
 
 CreateProfileLayoutView.propTypes = {
   formStep: PropTypes.string,
-  intl: IntlPropType,
 };
 
 CreateProfileLayoutView.defaultProps = {
-  intl: undefined,
   formStep: "1",
 };
 
-export default injectIntl(CreateProfileLayoutView);
+export default CreateProfileLayoutView;

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayout.jsx
@@ -6,14 +6,13 @@ import EditProfileLayoutView from "./EditProfileLayoutView";
  *  EditProfileLayout(props)
  *  Controller for the Edit Profile Layout.
  */
-const EditProfileLayout = ({ changeLanguage, step }) => {
+const EditProfileLayout = ({ step }) => {
   return (
-    <EditProfileLayoutView changeLanguage={changeLanguage} formStep={step} />
+    <EditProfileLayoutView formStep={step} />
   );
 };
 
 EditProfileLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   step: PropTypes.string.isRequired,
 };
 

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
@@ -2,9 +2,9 @@ import React from "react";
 import { useHistory } from "react-router-dom";
 import { PageHeader, Menu } from "antd";
 import { RightOutlined } from "@ant-design/icons";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
-import { IntlPropType } from "../../../customPropTypes";
+import { useSelector } from "react-redux";
 import AppLayout from "../appLayout/AppLayout";
 import {
   EmploymentDataForm,
@@ -19,7 +19,7 @@ import {
  *  EditProfileLayoutView(props)
  *  Render the layout for the edit profile forms
  */
-const EditProfileLayoutView = ({ formStep, intl }) => {
+const EditProfileLayoutView = ({ formStep }) => {
   const history = useHistory();
 
   /*
@@ -27,7 +27,7 @@ const EditProfileLayoutView = ({ formStep, intl }) => {
    *
    * Generate the correct form based on the step
    */
-  const profileFormSelect = step => {
+  const profileFormSelect = (step) => {
     switch (step) {
       case "primary-info":
         return <PrimaryInfoForm formType="edit" />;
@@ -51,7 +51,7 @@ const EditProfileLayoutView = ({ formStep, intl }) => {
    *
    * Redirect to form based on sidebar selection
    */
-  const redirectToForm = data => {
+  const redirectToForm = (data) => {
     const url = `/secured/profile/edit/${data.key}`;
     history.push(url);
   };
@@ -61,7 +61,7 @@ const EditProfileLayoutView = ({ formStep, intl }) => {
    *
    * Generate the sidebar steps for create profile
    */
-  const getSideBarContent = step => {
+  const getSideBarContent = (step) => {
     return (
       <Menu onClick={redirectToForm} selectedKeys={step}>
         <Menu.Item key="primary-info">
@@ -98,16 +98,10 @@ const EditProfileLayoutView = ({ formStep, intl }) => {
   const form = profileFormSelect(formStep);
 
   // get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   return (
-    <AppLayout
-      sideBarContent={sideBarContent}
-      displaySideBar
-    >
+    <AppLayout sideBarContent={sideBarContent} displaySideBar>
       <PageHeader
         style={{
           padding: "0 0 15px 7px",
@@ -122,11 +116,6 @@ const EditProfileLayoutView = ({ formStep, intl }) => {
 
 EditProfileLayoutView.propTypes = {
   formStep: PropTypes.string.isRequired,
-  intl: IntlPropType,
 };
 
-EditProfileLayoutView.defaultProps = {
-  intl: undefined,
-};
-
-export default injectIntl(EditProfileLayoutView);
+export default EditProfileLayoutView;

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
@@ -19,7 +19,7 @@ import {
  *  EditProfileLayoutView(props)
  *  Render the layout for the edit profile forms
  */
-const EditProfileLayoutView = ({ changeLanguage, formStep, intl }) => {
+const EditProfileLayoutView = ({ formStep, intl }) => {
   const history = useHistory();
 
   /*
@@ -105,7 +105,6 @@ const EditProfileLayoutView = ({ changeLanguage, formStep, intl }) => {
 
   return (
     <AppLayout
-      changeLanguage={changeLanguage}
       sideBarContent={sideBarContent}
       displaySideBar
     >
@@ -122,7 +121,6 @@ const EditProfileLayoutView = ({ changeLanguage, formStep, intl }) => {
 };
 
 EditProfileLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   formStep: PropTypes.string.isRequired,
   intl: IntlPropType,
 };

--- a/services/frontend-v3/src/components/layouts/landingLayout/LandingLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/landingLayout/LandingLayout.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import LandingLayoutView from "./LandingLayoutView";
 
 /**
@@ -7,12 +6,8 @@ import LandingLayoutView from "./LandingLayoutView";
  *
  *  this is the controller for LandingLayoutView
  */
-const LandingLayout = ({ changeLanguage }) => {
-  return <LandingLayoutView changeLanguage={changeLanguage} />;
-};
-
-LandingLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const LandingLayout = () => {
+  return <LandingLayoutView />;
 };
 
 export default LandingLayout;

--- a/services/frontend-v3/src/components/layouts/landingLayout/LandingLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/landingLayout/LandingLayoutView.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Row, Col, Typography, Button } from "antd";
 import { FormattedMessage } from "react-intl";
-import PropTypes from "prop-types";
 import AppLayout from "../appLayout/AppLayout";
 import backgroundOptionOne from "../../../assets/landing-1.svg";
 import backgroundOptionTwo from "../../../assets/landing-2.svg";
@@ -15,7 +14,7 @@ const { Text, Title } = Typography;
  *
  *  this component renders the landing page.
  */
-const LandingLayoutView = ({ changeLanguage }) => {
+const LandingLayoutView = () => {
   /**
    * Random Picture Select
    *
@@ -32,7 +31,7 @@ const LandingLayoutView = ({ changeLanguage }) => {
   };
 
   return (
-    <AppLayout changeLanguage={changeLanguage} displaySideBar={false}>
+    <AppLayout displaySideBar={false}>
       <Row justify="center" style={{ marginTop: "120px" }}>
         <Col xs={22} md={10} lg={6} style={{ baddingTop: "60px" }}>
           <img
@@ -81,10 +80,6 @@ const LandingLayoutView = ({ changeLanguage }) => {
       </Row>
     </AppLayout>
   );
-};
-
-LandingLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default LandingLayoutView;

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
@@ -1,16 +1,14 @@
 import React from "react";
-import PropTypes from "prop-types";
 import ProfileLayoutView from "./ProfileLayoutView";
 
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
-const ProfileLayout = ({ data, changeLanguage }) => {
-  return <ProfileLayoutView changeLanguage={changeLanguage} data={data} />;
+const ProfileLayout = ({ data }) => {
+  return <ProfileLayoutView data={data} />;
 };
 
 ProfileLayout.propTypes = {
   data: ProfileInfoPropType,
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 ProfileLayout.defaultProps = {

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -3,7 +3,6 @@ import { useParams } from "react-router-dom";
 import { FormattedMessage } from "react-intl";
 import { PageHeader, Anchor, Typography, Row, Col } from "antd";
 import { TagsTwoTone, RiseOutlined, TrophyOutlined } from "@ant-design/icons";
-import PropTypes from "prop-types";
 import AppLayout from "../appLayout/AppLayout";
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
@@ -23,7 +22,7 @@ import EmployeeSummary from "../../employeeSummary/EmployeeSummary";
 const { Link } = Anchor;
 const { Title, Text } = Typography;
 
-const ProfileLayoutView = ({ data, changeLanguage }) => {
+const ProfileLayoutView = ({ data }) => {
   // useParams returns an object of key/value pairs from URL parameters
   const { id } = useParams();
   const urlID = id;
@@ -557,7 +556,6 @@ const ProfileLayoutView = ({ data, changeLanguage }) => {
 
   return (
     <AppLayout
-      changeLanguage={changeLanguage}
       sideBarContent={generateProfileSidebarContent()}
       displaySideBar
     >
@@ -574,7 +572,6 @@ const ProfileLayoutView = ({ data, changeLanguage }) => {
 
 ProfileLayoutView.propTypes = {
   data: ProfileInfoPropType,
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 ProfileLayoutView.defaultProps = {

--- a/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
+++ b/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { injectIntl } from "react-intl";
+import { useSelector } from "react-redux";
 
 import MentorshipView from "./MentorshipView";
 
-const Mentorship = ({ intl, data }) => {
+const Mentorship = ({ data }) => {
+  const { locale } = useSelector((state) => state.settings);
+
   const formatData = (list) => {
-    const locale = intl.formatMessage({ id: "language.code" });
     const categorizedList = {};
 
     if (list) {
@@ -23,7 +24,6 @@ const Mentorship = ({ intl, data }) => {
     return categorizedList;
   };
   const setUpCategories = (list) => {
-    const locale = intl.formatMessage({ id: "language.code" });
     const categorizedList = {};
     const categoriesTemp = {};
     const categories = [];
@@ -81,9 +81,6 @@ Mentorship.propTypes = {
   data: PropTypes.shape({
     mentorshipSkills: PropTypes.any,
   }).isRequired,
-  intl: PropTypes.shape({
-    formatMessage: PropTypes.func,
-  }).isRequired,
 };
 
-export default injectIntl(Mentorship);
+export default Mentorship;

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
-import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
-import { IntlPropType } from "../../../customPropTypes";
+import { useSelector } from "react-redux";
 import config from "../../../config";
 import EmploymentDataFormView from "./EmploymentDataFormView";
 
@@ -13,7 +12,7 @@ const { backendAddress } = config;
  *  Controller for the EmploymentDataFormView.
  *  It gathers the required data for rendering the component
  */
-const EmploymentDataForm = ({ formType, intl }) => {
+const EmploymentDataForm = ({ formType }) => {
   const [substantiveOptions, setSubstantiveOptions] = useState([]);
   const [classificationOptions, setClassificationOptions] = useState([]);
   const [securityOptions, setSecurityOptions] = useState([]);
@@ -21,10 +20,7 @@ const EmploymentDataForm = ({ formType, intl }) => {
   const [load, setLoad] = useState(false);
 
   // Get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   // Get substantive level options
   const getSubstantiveOptions = useCallback(async () => {
@@ -139,11 +135,6 @@ const EmploymentDataForm = ({ formType, intl }) => {
 
 EmploymentDataForm.propTypes = {
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
-  intl: IntlPropType,
 };
 
-EmploymentDataForm.defaultProps = {
-  intl: undefined,
-};
-
-export default injectIntl(EmploymentDataForm);
+export default EmploymentDataForm;

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
-import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
-import { IntlPropType } from "../../../customPropTypes";
+import { useSelector } from "react-redux";
 import PersonalGrowthFormView from "./PersonalGrowthFormView";
 import config from "../../../config";
 
@@ -13,7 +12,7 @@ const { backendAddress } = config;
  *  Controller for the PersonalGrowthFormView.
  *  It gathers the required data for rendering the component
  */
-const PersonalGrowthForm = ({ formType, intl }) => {
+const PersonalGrowthForm = ({ formType }) => {
   // Define States
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
@@ -31,10 +30,7 @@ const PersonalGrowthForm = ({ formType, intl }) => {
   const [savedExFeederBool, setSavedExFeederBool] = useState(undefined);
 
   // Get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   /**
    * Get saved Developmental Goals
@@ -308,10 +304,6 @@ const PersonalGrowthForm = ({ formType, intl }) => {
 
 PersonalGrowthForm.propTypes = {
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
-  intl: IntlPropType,
-};
-PersonalGrowthForm.defaultProps = {
-  intl: undefined,
 };
 
-export default injectIntl(PersonalGrowthForm);
+export default PersonalGrowthForm;

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationForm.jsx
@@ -1,13 +1,12 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
-import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
+import { useSelector } from "react-redux";
 
 import EducationFormView from "./EducationFormView";
 import {
   FieldPropType,
   FormInstancePropType,
-  IntlPropType,
   ProfileInfoPropType,
   StylesPropType,
 } from "../../../../customPropTypes";
@@ -21,17 +20,14 @@ const { backendAddress } = config;
  *  This component is strongly linked ot Qualifications Form.
  *  It generated the form fields for each education item the user creates in the qualifications form.
  */
-const EducationForm = ({ form, field, intl, remove, profileInfo, style }) => {
+const EducationForm = ({ form, field, remove, profileInfo, style }) => {
   // Define States
   const [load, setLoad] = useState(false);
   const [diplomaOptions, setDiplomaOptions] = useState([]);
   const [schoolOptions, setSchoolOptions] = useState([]);
 
   // get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   /**
    * Get Diploma Options
@@ -117,14 +113,9 @@ const EducationForm = ({ form, field, intl, remove, profileInfo, style }) => {
 EducationForm.propTypes = {
   form: FormInstancePropType.isRequired,
   field: FieldPropType.isRequired,
-  intl: IntlPropType,
   remove: PropTypes.func.isRequired,
   profileInfo: ProfileInfoPropType.isRequired,
   style: StylesPropType.isRequired,
 };
 
-EducationForm.defaultProps = {
-  intl: undefined,
-};
-
-export default injectIntl(EducationForm);
+export default EducationForm;

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import axios from "axios";
 import PropTypes from "prop-types";
-import { injectIntl } from "react-intl";
-import { IntlPropType } from "../../../customPropTypes";
+import { useSelector } from "react-redux";
 import TalentFormView from "./TalentFormView";
 import config from "../../../config";
 
@@ -13,7 +12,7 @@ const { backendAddress } = config;
  *  Controller for the EmploymentDataFormView.
  *  It gathers the required data for rendering the component
  */
-const TalentForm = ({ formType, intl }) => {
+const TalentForm = ({ formType }) => {
   const [profileInfo, setProfileInfo] = useState(null);
   const [skillOptions, setSkillOptions] = useState([]);
   const [competencyOptions, setCompetencyOptions] = useState([]);
@@ -23,10 +22,7 @@ const TalentForm = ({ formType, intl }) => {
   const [savedMentorshipSkills, setSavedMentorshipSkills] = useState([]);
 
   // get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   /**
    * Get user profile
@@ -190,11 +186,6 @@ const TalentForm = ({ formType, intl }) => {
 
 TalentForm.propTypes = {
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
-  intl: IntlPropType,
 };
 
-TalentForm.defaultProps = {
-  intl: undefined,
-};
-
-export default injectIntl(TalentForm);
+export default TalentForm;

--- a/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.jsx
@@ -10,20 +10,18 @@ import {
   LoadingOutlined,
 } from "@ant-design/icons";
 import axios from "axios";
+import { useSelector } from "react-redux";
 import { IntlPropType } from "../../../customPropTypes";
 import config from "../../../config";
 
 const { Title, Paragraph } = Typography;
 const { backendAddress } = config;
 
-function WelcomeView({ gedsProfiles, intl, load }) {
+const WelcomeView = ({ gedsProfiles, intl, load }) => {
   const history = useHistory();
 
   // get current language code
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
 
   /* Component Styles */
   const styles = {

--- a/services/frontend-v3/src/components/projects/Projects.jsx
+++ b/services/frontend-v3/src/components/projects/Projects.jsx
@@ -19,11 +19,7 @@ const Projects = ({ data }) => {
   }, [data]);
 
   return (
-    <ProjectsView
-      data={data}
-      locale={localStorage.getItem("lang") || "en"}
-      projectsInfo={projectsInfo}
-    />
+    <ProjectsView data={data} projectsInfo={projectsInfo} />
   );
 };
 

--- a/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
@@ -13,7 +13,7 @@ const { backendAddress } = config;
 
 const ResultsCard = ({ history }) => {
   const [results, setResults] = useState(null);
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   useEffect(() => {
     const urlSections = window.location.toString().split("?");

--- a/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 
 import "@ant-design/compatible/assets/index.css";
 import axios from "axios";
+import { useSelector } from "react-redux";
 import { HistoryPropType } from "../../customPropTypes";
 import ProfileSkeleton from "../profileSkeleton/ProfileSkeleton";
 import config from "../../config";
@@ -12,6 +13,7 @@ const { backendAddress } = config;
 
 const ResultsCard = ({ history }) => {
   const [results, setResults] = useState(null);
+  const locale = useSelector((state) => state.settings.language);
 
   useEffect(() => {
     const urlSections = window.location.toString().split("?");
@@ -32,8 +34,10 @@ const ResultsCard = ({ history }) => {
   if (results instanceof Error) {
     return `An error was encountered! Please try again.\n\n${String(results)}`;
   }
-  return <ResultsCardView history={history} results={results} />;
-}
+  return (
+    <ResultsCardView history={history} results={results} locale={locale} />
+  );
+};
 
 ResultsCard.propTypes = {
   history: HistoryPropType.isRequired,

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
@@ -13,7 +13,7 @@ import prepareInfo from "../../functions/prepareInfo";
 const { Meta } = Card;
 const { Text } = Typography;
 
-const ResultsCardView = ({ history, intl, results }) => {
+const ResultsCardView = ({ history, intl, results, locale }) => {
   const styles = {
     smallP: {
       lineHeight: "4px",
@@ -91,10 +91,9 @@ const ResultsCardView = ({ history, intl, results }) => {
         dataSource
       )}`;
     }
-    const preparedResults = prepareInfo(
-      dataSource,
-      localStorage.getItem("lang") || "en"
-    );
+    
+    const preparedResults = prepareInfo(dataSource, locale);
+
     return preparedResults.map((person, key) => renderCard(person, key));
   };
 
@@ -111,6 +110,7 @@ ResultsCardView.propTypes = {
   history: HistoryPropType.isRequired,
   intl: IntlPropType,
   results: PropTypes.arrayOf(ProfileInfoPropType),
+  locale: PropTypes.oneOf(["fr", "en"]).isRequired,
 };
 
 ResultsCardView.defaultProps = {

--- a/services/frontend-v3/src/components/resultsLayout/ResultLayout.jsx
+++ b/services/frontend-v3/src/components/resultsLayout/ResultLayout.jsx
@@ -3,16 +3,11 @@ import React from "react";
 import ResultLayoutView from "./ResultLayoutView";
 import { HistoryPropType } from "../../customPropTypes";
 
-const ResultLayout = ({ changeLanguage, history, children }) => {
-  return (
-    <ResultLayoutView changeLanguage={changeLanguage} history={history}>
-      {children}
-    </ResultLayoutView>
-  );
+const ResultLayout = ({ history, children }) => {
+  return <ResultLayoutView history={history}>{children}</ResultLayoutView>;
 };
 
 ResultLayout.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   children: PropTypes.node,
   history: HistoryPropType.isRequired,
 };

--- a/services/frontend-v3/src/components/resultsLayout/ResultLayoutView.jsx
+++ b/services/frontend-v3/src/components/resultsLayout/ResultLayoutView.jsx
@@ -7,7 +7,7 @@ import ResultsCard from "../resultsCard/ResultsCard";
 import SearchFilter from "../searchFilter/SearchFilter";
 import { HistoryPropType } from "../../customPropTypes";
 
-const ResultLayoutView = ({ changeLanguage, intl, history }) => {
+const ResultLayoutView = ({ intl, history }) => {
   const resultsTitle = intl.formatMessage({
     id: "results.title",
     defaultMessage: "Results",
@@ -15,21 +15,17 @@ const ResultLayoutView = ({ changeLanguage, intl, history }) => {
   return (
     <Layout>
       <AppLayout
-        changeLanguage={changeLanguage}
         displaySideBar
-        sideBarContent={
-          <SearchFilter changeLanguage={changeLanguage} history={history} />
-        }
+        sideBarContent={<SearchFilter history={history} />}
       >
         <PageHeader title={resultsTitle} />
-        <ResultsCard changeLanguage={changeLanguage} history={history} />
+        <ResultsCard history={history} />
       </AppLayout>
     </Layout>
   );
-}
+};
 
 ResultLayoutView.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   history: HistoryPropType.isRequired,
   intl: PropTypes.shape({
     formatMessage: PropTypes.func,

--- a/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback } from "react";
-import PropTypes from "prop-types";
 import axios from "axios";
 import queryString from "query-string";
 import { injectIntl } from "react-intl";
@@ -9,7 +8,7 @@ import { HistoryPropType } from "../../customPropTypes";
 
 const { backendAddress } = config;
 
-const SearchFilter = ({ history, changeLanguage }) => {
+const SearchFilter = ({ history }) => {
   const [expand, setExpand] = useState(false);
   const [skillOptions, setSkillOptions] = useState([]);
   const [branchOptions, setBranchOptions] = useState([]);
@@ -140,7 +139,6 @@ const SearchFilter = ({ history, changeLanguage }) => {
 
   return (
     <SearchFilterView
-      changeLanguage={changeLanguage}
       history={history}
       skillOptions={skillOptions}
       branchOptions={branchOptions}
@@ -154,7 +152,6 @@ const SearchFilter = ({ history, changeLanguage }) => {
 };
 
 SearchFilter.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   history: HistoryPropType.isRequired,
 };
 

--- a/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilterView.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { injectIntl } from "react-intl";
 import { Form, Col, Button, Input, Switch, Select, Row } from "antd";
 import "@ant-design/compatible/assets/index.css";
+import { useSelector } from "react-redux";
 import { IntlPropType, IdDescriptionPropType } from "../../customPropTypes";
 
 const SearchBarView = ({
@@ -28,10 +29,7 @@ const SearchBarView = ({
     }
   }, [form, urlSearchFieldValues]);
 
-  const locale = intl.formatMessage({
-    id: "language.code",
-    defaultMessage: "en",
-  });
+  const { locale } = useSelector((state) => state.settings);
   const searchLabel = intl.formatMessage({
     id: "button.search",
     defaultMessage: "Search",

--- a/services/frontend-v3/src/components/skillsCard/Skills.jsx
+++ b/services/frontend-v3/src/components/skillsCard/Skills.jsx
@@ -1,15 +1,16 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import SkillsView from "./SkillsView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const Skills = ({ data }) => {
-  const formatData = list => {
-    const locale = localStorage.getItem("lang") || "en";
+  const locale = useSelector((state) => state.settings.language);
 
+  const formatData = (list) => {
     const categorizedList = {};
 
     if (list) {
-      list.forEach(listElement => {
+      list.forEach((listElement) => {
         const key = listElement.description.categoryId;
 
         if (categorizedList[key] == null) {
@@ -23,8 +24,7 @@ const Skills = ({ data }) => {
     return categorizedList;
   };
 
-  const setUpCategories = list => {
-    const locale = localStorage.getItem("lang") || "en";
+  const setUpCategories = (list) => {
     const categorizedList = {};
     const categoriesTemp = {};
     const categories = [];
@@ -32,7 +32,7 @@ const Skills = ({ data }) => {
     let k = 0;
 
     if (list) {
-      list.forEach(listElement => {
+      list.forEach((listElement) => {
         const key = listElement.description.categoryId;
         if (categorizedList[key] == null) {
           categorizedList[key] = [listElement.description[locale]];
@@ -57,7 +57,7 @@ const Skills = ({ data }) => {
     return categories;
   };
 
-  const setUpSkills = dataSource => {
+  const setUpSkills = (dataSource) => {
     const skills = [];
 
     const categorizedSkillsList = formatData(dataSource);

--- a/services/frontend-v3/src/components/skillsCard/Skills.jsx
+++ b/services/frontend-v3/src/components/skillsCard/Skills.jsx
@@ -4,7 +4,7 @@ import SkillsView from "./SkillsView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const Skills = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   const formatData = (list) => {
     const categorizedList = {};

--- a/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
@@ -4,7 +4,7 @@ import TalentManagementView from "./TalentManagementView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const TalentManagement = ({ data }) => {
-  const locale = useSelector((state) => state.settings.language);
+  const { locale } = useSelector((state) => state.settings);
 
   return <TalentManagementView data={data} locale={locale} />;
 };

--- a/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
@@ -1,14 +1,12 @@
 import React from "react";
+import { useSelector } from "react-redux";
 import TalentManagementView from "./TalentManagementView";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const TalentManagement = ({ data }) => {
-  return (
-    <TalentManagementView
-      data={data}
-      locale={localStorage.getItem("lang") || "en"}
-    />
-  );
+  const locale = useSelector((state) => state.settings.language);
+
+  return <TalentManagementView data={data} locale={locale} />;
 };
 
 TalentManagement.propTypes = {

--- a/services/frontend-v3/src/pages/Home.jsx
+++ b/services/frontend-v3/src/pages/Home.jsx
@@ -1,17 +1,16 @@
 import React, { useEffect } from "react";
-import PropTypes from "prop-types";
 import { Row } from "antd";
 import SearchBar from "../components/searchBar/SearchBar";
 import AppLayout from "../components/layouts/appLayout/AppLayout";
 import { HistoryPropType } from "../customPropTypes";
 
-const Home = ({ changeLanguage, history }) => {
+const Home = ({ history }) => {
   useEffect(() => {
     document.title = "Home | I-Talent";
   }, []);
 
   return (
-    <AppLayout changeLanguage={changeLanguage} displaySideBar={false}>
+    <AppLayout displaySideBar={false}>
       <Row>
         <SearchBar history={history} />
       </Row>
@@ -20,7 +19,6 @@ const Home = ({ changeLanguage, history }) => {
 };
 
 Home.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   history: HistoryPropType.isRequired,
 };
 

--- a/services/frontend-v3/src/pages/LandingPage.jsx
+++ b/services/frontend-v3/src/pages/LandingPage.jsx
@@ -1,14 +1,9 @@
 import React from "react";
-import PropTypes from "prop-types";
 import LandingLayout from "../components/layouts/landingLayout/LandingLayout";
 
 /** UI for the landing route layout */
-const LandingPage = ({ changeLanguage }) => {
-  return <LandingLayout changeLanguage={changeLanguage} />;
-};
-
-LandingPage.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
+const LandingPage = () => {
+  return <LandingLayout />;
 };
 
 export default LandingPage;

--- a/services/frontend-v3/src/pages/Profile.jsx
+++ b/services/frontend-v3/src/pages/Profile.jsx
@@ -7,7 +7,7 @@ import ProfileLayout from "../components/layouts/profileLayout/ProfileLayout";
 
 const { backendAddress } = config;
 
-const Profile = ({ history, match, changeLanguage }) => {
+const Profile = ({ history, match }) => {
   const [name, setName] = useState("Loading");
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -62,14 +62,13 @@ const Profile = ({ history, match, changeLanguage }) => {
   }, [name]);
 
   if (!loading) {
-    return <ProfileLayout changeLanguage={changeLanguage} data={data} />;
+    return <ProfileLayout data={data} />;
   }
 
-  return <ProfileSkeleton changeLanguage={changeLanguage} />;
+  return <ProfileSkeleton />;
 };
 
 Profile.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   history: PropTypes.shape({
     push: PropTypes.func,
   }).isRequired,

--- a/services/frontend-v3/src/pages/ProfileCreate.jsx
+++ b/services/frontend-v3/src/pages/ProfileCreate.jsx
@@ -4,31 +4,25 @@ import PropTypes from "prop-types";
 import CreateProfileLayout from "../components/layouts/createProfileLayout/CreateProfileLayout";
 import { IntlPropType } from "../customPropTypes";
 
-const ProfileCreate = ({ intl, changeLanguage, match }) => {
+const ProfileCreate = ({ intl, match }) => {
   document.title = `${intl.formatMessage({ id: "create.profile" })} | I-Talent`;
 
-  return (
-    <CreateProfileLayout
-      changeLanguage={changeLanguage}
-      step={match.params.step}
-    />
-  );
+  return <CreateProfileLayout step={match.params.step} />;
 };
 
 ProfileCreate.propTypes = {
   intl: IntlPropType,
-  changeLanguage: PropTypes.func.isRequired,
   match: PropTypes.shape({
     params: PropTypes.shape({
-      step: PropTypes.any
-    })
+      step: PropTypes.any,
+    }),
   }),
 };
 
 ProfileCreate.defaultProps = {
   intl: undefined,
   match: {
-    params: undefined
+    params: undefined,
   },
 };
 

--- a/services/frontend-v3/src/pages/ProfileEdit.jsx
+++ b/services/frontend-v3/src/pages/ProfileEdit.jsx
@@ -4,20 +4,14 @@ import PropTypes from "prop-types";
 import { IntlPropType } from "../customPropTypes";
 import EditProfileLayout from "../components/layouts/editProfileLayout/EditProfileLayout";
 
-const ProfileEdit = ({ changeLanguage, intl, match }) => {
+const ProfileEdit = ({ intl, match }) => {
   document.title = `${intl.formatMessage({ id: "edit.profile" })} | I-Talent`;
 
-  return (
-    <EditProfileLayout
-      changeLanguage={changeLanguage}
-      step={match.params.step}
-    />
-  );
+  return <EditProfileLayout step={match.params.step} />;
 };
 
 ProfileEdit.propTypes = {
   intl: IntlPropType,
-  changeLanguage: PropTypes.func.isRequired,
   match: PropTypes.shape({
     isExact: PropTypes.bool,
     params: PropTypes.objectOf(PropTypes.any),

--- a/services/frontend-v3/src/pages/Results.jsx
+++ b/services/frontend-v3/src/pages/Results.jsx
@@ -1,17 +1,15 @@
 import React, { useEffect } from "react";
-import PropTypes from "prop-types";
 import { injectIntl } from "react-intl";
 import ResultLayout from "../components/resultsLayout/ResultLayout";
 import { HistoryPropType, IntlPropType } from "../customPropTypes";
 
-const Results = ({ changeLanguage, history, intl }) => {
+const Results = ({ history, intl }) => {
   useEffect(() => {
     document.title = `${intl.formatMessage({ id: "results.title" })} | I-Talent`;
   }, [intl]);
 
   return (
     <ResultLayout
-      changeLanguage={changeLanguage}
       history={history}
       displaySideBar
     />
@@ -19,7 +17,6 @@ const Results = ({ changeLanguage, history, intl }) => {
 };
 
 Results.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   history: HistoryPropType.isRequired,
   intl: IntlPropType,
 };

--- a/services/frontend-v3/src/pages/admin/Category.jsx
+++ b/services/frontend-v3/src/pages/admin/Category.jsx
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import CategoryTable from "../../components/admin/categoryTable/CategoryTable";
 
-const AdminCategory = ({ changeLanguage }) => {
+const AdminCategory = () => {
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type="category">
+    <AdminLayout displaySideBar type="category">
       <CategoryTable type="category" />
     </AdminLayout>
   );
-};
-
-AdminCategory.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default AdminCategory;

--- a/services/frontend-v3/src/pages/admin/Competency.jsx
+++ b/services/frontend-v3/src/pages/admin/Competency.jsx
@@ -1,22 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import CompetencyTable from "../../components/admin/competencyTable/CompetencyTable";
 
-const AdminCompetency = ({ changeLanguage }) => {
+const AdminCompetency = () => {
   return (
-    <AdminLayout
-      changeLanguage={changeLanguage}
-      displaySideBar
-      type="competency"
-    >
+    <AdminLayout displaySideBar type="competency">
       <CompetencyTable type="competency" />
     </AdminLayout>
   );
-};
-
-AdminCompetency.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default AdminCompetency;

--- a/services/frontend-v3/src/pages/admin/Dashboard.jsx
+++ b/services/frontend-v3/src/pages/admin/Dashboard.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 import axios from "axios";
 import { Skeleton, PageHeader } from "antd";
 import { injectIntl } from "react-intl";
@@ -16,7 +15,7 @@ const { backendAddress } = config;
  *  Controller for StatCards and DashboardGraphs.
  *  It gathers the required data for rendering these components.
  */
-const AdminDashboard = ({ changeLanguage, intl }) => {
+const AdminDashboard = ({ intl }) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -66,14 +65,14 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
 
   if (loading) {
     return (
-      <AdminLayout changeLanguage={changeLanguage} displaySideBar type={type}>
+      <AdminLayout displaySideBar type={type}>
         <Skeleton active />
       </AdminLayout>
     );
   }
 
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type={type}>
+    <AdminLayout displaySideBar type={type}>
       <PageHeader
         title={intl.formatMessage({
           id: "admin.dashboard.title",
@@ -88,10 +87,10 @@ const AdminDashboard = ({ changeLanguage, intl }) => {
 
 AdminDashboard.propTypes = {
   intl: IntlPropType,
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 AdminDashboard.defaultProps = {
   intl: undefined,
 };
+
 export default injectIntl(AdminDashboard);

--- a/services/frontend-v3/src/pages/admin/Diploma.jsx
+++ b/services/frontend-v3/src/pages/admin/Diploma.jsx
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import DiplomaTable from "../../components/admin/diplomaTable/DiplomaTable";
 
-const AdminDiploma = ({ changeLanguage }) => {
+const AdminDiploma = () => {
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type="diploma">
+    <AdminLayout displaySideBar type="diploma">
       <DiplomaTable type="diploma" />
     </AdminLayout>
   );
-};
-
-AdminDiploma.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default AdminDiploma;

--- a/services/frontend-v3/src/pages/admin/School.jsx
+++ b/services/frontend-v3/src/pages/admin/School.jsx
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import SchoolTable from "../../components/admin/schoolTable/SchoolTable";
 
-const AdminSchool = ({ changeLanguage }) => {
+const AdminSchool = () => {
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type="school">
+    <AdminLayout displaySideBar type="school">
       <SchoolTable type="school" />
     </AdminLayout>
   );
 };
-
-AdminSchool.propTypes = {
-  changeLanguage: PropTypes.func.isRequired
-}
 
 export default AdminSchool;

--- a/services/frontend-v3/src/pages/admin/Skill.jsx
+++ b/services/frontend-v3/src/pages/admin/Skill.jsx
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import SkillTable from "../../components/admin/skillTable/SkillTable";
 
-const AdminSkill = ({ changeLanguage }) => {
+const AdminSkill = () => {
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type="skill">
+    <AdminLayout displaySideBar type="skill">
       <SkillTable type="skill" />
     </AdminLayout>
   );
-};
-
-AdminSkill.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default AdminSkill;

--- a/services/frontend-v3/src/pages/admin/User.jsx
+++ b/services/frontend-v3/src/pages/admin/User.jsx
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import AdminLayout from "../../components/layouts/adminLayout/AdminLayout";
 import UserTable from "../../components/admin/userTable/UserTable";
 
-const AdminUser = ({ changeLanguage }) => {
+const AdminUser = () => {
   return (
-    <AdminLayout changeLanguage={changeLanguage} displaySideBar type="user">
+    <AdminLayout displaySideBar type="user">
       <UserTable type="user" />
     </AdminLayout>
   );
-};
-
-AdminUser.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default AdminUser;

--- a/services/frontend-v3/src/redux/index.js
+++ b/services/frontend-v3/src/redux/index.js
@@ -6,7 +6,6 @@ import rootReducer from "./slices";
 const persistConfig = {
   key: "root",
   storage,
-  // whitelist: ['settings']
 };
 
 const store = configureStore({

--- a/services/frontend-v3/src/redux/index.js
+++ b/services/frontend-v3/src/redux/index.js
@@ -1,0 +1,18 @@
+import { configureStore } from "@reduxjs/toolkit";
+import { persistReducer, persistStore } from "redux-persist";
+import storage from "redux-persist/lib/storage";
+import rootReducer from "./slices";
+
+const persistConfig = {
+  key: "root",
+  storage,
+  // whitelist: ['settings']
+};
+
+const store = configureStore({
+  reducer: persistReducer(persistConfig, rootReducer),
+});
+
+export const persistor = persistStore(store);
+
+export default store;

--- a/services/frontend-v3/src/redux/index.js
+++ b/services/frontend-v3/src/redux/index.js
@@ -1,5 +1,14 @@
-import { configureStore } from "@reduxjs/toolkit";
-import { persistReducer, persistStore } from "redux-persist";
+import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit";
+import {
+  persistReducer,
+  persistStore,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from "redux-persist";
 import storage from "redux-persist/lib/storage";
 import rootReducer from "./slices";
 
@@ -10,6 +19,11 @@ const persistConfig = {
 
 const store = configureStore({
   reducer: persistReducer(persistConfig, rootReducer),
+  middleware: getDefaultMiddleware({
+    serializableCheck: {
+      ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+    },
+  }),
 });
 
 export const persistor = persistStore(store);

--- a/services/frontend-v3/src/redux/slices/index.js
+++ b/services/frontend-v3/src/redux/slices/index.js
@@ -1,0 +1,6 @@
+import { combineReducers } from "redux";
+import settings from "./settingsSlice";
+
+export default combineReducers({
+  settings,
+});

--- a/services/frontend-v3/src/redux/slices/settingsSlice.js
+++ b/services/frontend-v3/src/redux/slices/settingsSlice.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-param-reassign */
+import { createSlice } from "@reduxjs/toolkit";
+
+const settingsSlice = createSlice({
+  name: "settings",
+  initialState: {
+    language: "en",
+  },
+  reducers: {
+    setLanguage(state, action) {
+      state.language = action.payload;
+    },
+    toggleLanguage(state) {
+      state.language = state.language === "en" ? "fr" : "en";
+    },
+  },
+});
+
+export const { setLanguage, toggleLanguage } = settingsSlice.actions;
+
+export default settingsSlice.reducer;

--- a/services/frontend-v3/src/redux/slices/settingsSlice.js
+++ b/services/frontend-v3/src/redux/slices/settingsSlice.js
@@ -4,18 +4,15 @@ import { createSlice } from "@reduxjs/toolkit";
 const settingsSlice = createSlice({
   name: "settings",
   initialState: {
-    language: "en",
+    locale: "en",
   },
   reducers: {
-    setLanguage(state, action) {
-      state.language = action.payload;
-    },
-    toggleLanguage(state) {
-      state.language = state.language === "en" ? "fr" : "en";
+    setLocale(state, action) {
+      state.locale = action.payload;
     },
   },
 });
 
-export const { setLanguage, toggleLanguage } = settingsSlice.actions;
+export const { setLocale } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/services/frontend-v3/src/routes/Admin.jsx
+++ b/services/frontend-v3/src/routes/Admin.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import Keycloak from "keycloak-js";
 import axios from "axios";
@@ -18,7 +17,7 @@ import keycloakConfig from "../keycloak";
 const { backendAddress } = config;
 const { keycloakJSONConfig } = keycloakConfig;
 
-const Admin = ({ changeLanguage }) => {
+const Admin = () => {
   const [authenticated, setAuthenticated] = useState(false);
   const [keycloak, setKeycloak] = useState(null);
   // const [isAdmin, setIsAdmin] = useState(false);
@@ -115,48 +114,28 @@ const Admin = ({ changeLanguage }) => {
           <Route
             exact
             path="/admin/dashboard"
-            render={() => <AdminDasboard changeLanguage={changeLanguage} />}
+            render={() => <AdminDasboard />}
           />
-          <Route
-            exact
-            path="/admin/users"
-            render={() => <AdminUser changeLanguage={changeLanguage} />}
-          />
-          <Route
-            exact
-            path="/admin/skills"
-            render={() => <AdminSkill changeLanguage={changeLanguage} />}
-          />
+          <Route exact path="/admin/users" render={() => <AdminUser />} />
+          <Route exact path="/admin/skills" render={() => <AdminSkill />} />
           <Route
             exact
             path="/admin/categories"
-            render={() => <AdminCategory changeLanguage={changeLanguage} />}
+            render={() => <AdminCategory />}
           />
           <Route
             exact
             path="/admin/competencies"
-            render={() => <AdminCompetency changeLanguage={changeLanguage} />}
+            render={() => <AdminCompetency />}
           />
-          <Route
-            exact
-            path="/admin/diploma"
-            render={() => <AdminDiploma changeLanguage={changeLanguage} />}
-          />
-          <Route
-            exact
-            path="/admin/school"
-            render={() => <AdminSchool changeLanguage={changeLanguage} />}
-          />
+          <Route exact path="/admin/diploma" render={() => <AdminDiploma />} />
+          <Route exact path="/admin/school" render={() => <AdminSchool />} />
         </div>
       );
     }
     return <div>Unable to authenticate!</div>;
   }
   return <div />;
-};
-
-Admin.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
 };
 
 export default Admin;

--- a/services/frontend-v3/src/routes/Secured.jsx
+++ b/services/frontend-v3/src/routes/Secured.jsx
@@ -17,7 +17,7 @@ import { createUser } from "../functions/login";
 
 const { keycloakJSONConfig } = keycloakConfig;
 
-const Secured = ({ changeLanguage, location }) => {
+const Secured = ({ location }) => {
   const [authenticated, setAuthenticated] = useState(false);
   const [keycloak, setKeycloak] = useState(null);
   const [redirect, setRedirect] = useState(null);
@@ -137,7 +137,6 @@ const Secured = ({ changeLanguage, location }) => {
               render={({ history }) => (
                 <Home
                   keycloak={keycloak}
-                  changeLanguage={changeLanguage}
                   history={history}
                 />
               )}
@@ -149,7 +148,6 @@ const Secured = ({ changeLanguage, location }) => {
               render={({ history }) => (
                 <Results
                   keycloak={keycloak}
-                  changeLanguage={changeLanguage}
                   history={history}
                 />
               )}
@@ -160,7 +158,6 @@ const Secured = ({ changeLanguage, location }) => {
               render={({ match }) => (
                 <ProfileCreate
                   keycloak={keycloak}
-                  changeLanguage={changeLanguage}
                   match={match}
                 />
               )}
@@ -171,7 +168,6 @@ const Secured = ({ changeLanguage, location }) => {
               render={({ match }) => (
                 <ProfileEdit
                   keycloak={keycloak}
-                  changeLanguage={changeLanguage}
                   match={match}
                 />
               )}
@@ -182,7 +178,6 @@ const Secured = ({ changeLanguage, location }) => {
               render={({ history, match }) => (
                 <Profile
                   keycloak={keycloak}
-                  changeLanguage={changeLanguage}
                   history={history}
                   match={match}
                 />
@@ -206,7 +201,6 @@ const Secured = ({ changeLanguage, location }) => {
 };
 
 Secured.propTypes = {
-  changeLanguage: PropTypes.func.isRequired,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }),

--- a/services/frontend-v3/yarn.lock
+++ b/services/frontend-v3/yarn.lock
@@ -1479,6 +1479,16 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@reduxjs/toolkit@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.3.6.tgz#306171fce2ab7423931736c34fa82190959dcd62"
+  integrity sha512-eNYURfoJa6mRNU5YtBVbmE5+nDoc4lpjZ181PBwRC6nIFYZdNR3GcoQ4uomFt8eHpXAUAdpCdxBlDsmwyXOt9Q==
+  dependencies:
+    immer "^6.0.1"
+    redux "^4.0.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
@@ -6159,6 +6169,11 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
+immer@^6.0.1:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-6.0.5.tgz#77187d13b71c6cee40dde3b8e87a50a7a636d630"
+  integrity sha512-Q2wd90qrgFieIpLzAO2q9NLEdmyp/sr76Ml4Vm5peUKgyTa2CQa3ey8zuzwSKOlKH7grCeGBGUcLLVCVW1aguA==
+
 immutable@^3.7.4:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
@@ -10328,7 +10343,7 @@ react-intl@^3.12.0:
     intl-messageformat-parser "^3.6.4"
     shallow-equal "^1.2.1"
 
-react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10342,6 +10357,17 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-redux@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.0.tgz#f970f62192b3981642fec46fd0db18a074fe879d"
+  integrity sha512-EvCAZYGfOLqwV7gh849xy9/pt55rJXPwmYvI4lilPM5rUT/1NxuuN59ipdBksRVSvz0KInbPnp4IfoXJXCqiDA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-router-dom@^5.1.2:
   version "5.1.2"
@@ -10551,6 +10577,24 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0, redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
+
 regenerate-unicode-properties@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz#e5de7111d655e7ba60c057dbe9ff37c87e65cdec"
@@ -10743,6 +10787,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@^1.5.0, resize-observer-polyfill@^1.5.1:
   version "1.5.1"
@@ -11845,6 +11894,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
This is just an initial wave of redux changes to get the feedback of devs on the team.

This PR shows that by using redux, we don't need to pass `changeLanguage` to pretty much every component and that we would not need to play with `localStorage` to get the value of the locale (`redux-persists` takes charge of persisting the state).

### Added modules
- `redux-persist` (https://github.com/rt2zz/redux-persist) - to persist the redux state in localStorage
- `@reduxjs/toolkit` (https://redux-toolkit.js.org/) - to make the use of redux way easier with slices and ability to mutate state
- `react-redux` (https://github.com/reduxjs/react-redux) - to use redux in a react project
- `redux` (https://github.com/reduxjs/redux) - to use redux

Feel free to comment or question or hate on this idea haha, let me know what you guys think

closes #265 