### PR TITLE
[Fix] Removed double url encoding

### DIFF
--- a/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend-v3/src/components/searchFilter/SearchFilter.jsx
@@ -132,7 +132,7 @@ const SearchFilter = ({ history }) => {
   // page with query
   const handleSearch = (values) => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
-    const url = `/secured/results?${encodeURI(query)}`;
+    const url = `/secured/results?${query}`;
     history.push(url);
     window.location.reload();
   };


### PR DESCRIPTION
According to https://github.com/sindresorhus/query-string#stringifyobject-options, `query-string` already encodes the URI and doing it twice results in the bug encountered

closes #271