### PR TITLE
[Fix] Official language fix in edit profile

### DIFF
--- a/services/backend/src/core/profile/profile.js
+++ b/services/backend/src/core/profile/profile.js
@@ -311,7 +311,7 @@ async function updateProfile(request, response) {
           profile.setSecondLanguageProficiency(selectLangProf);
         });
     }
-    if (!dbObject.secondLanguage) {
+    if (dbObject.secondLanguage === null) {
       SecLang.destroy({
         where: { id: profile.dataValues.secondLanguageProficiencyId },
       });

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -120,11 +120,6 @@ const LangProficiencyFormView = ({
     },
   };
 
-  /* toggle temporary role form */
-  const toggleSecLangForm = () => {
-    setDisplayMentorshipForm((prev) => !prev);
-  };
-
   /* Save data */
   const saveDataToDB = async (unalteredValues) => {
     const values = { ...unalteredValues };
@@ -240,6 +235,17 @@ const LangProficiencyFormView = ({
     return {};
   };
 
+  /* toggle temporary role form */
+  const toggleSecLangForm = () => {
+    setDisplayMentorshipForm((prev) => {
+      const data = savedValues || getInitialValues(profileInfo);
+      setFieldsChanged(
+        (!data.oralProficiency && !prev) || (data.oralProficiency && prev)
+      );
+      return !prev;
+    });
+  };
+
   /**
    * Returns true if the values in the form have changed based on its initial values or the saved values
    *
@@ -309,7 +315,10 @@ const LangProficiencyFormView = ({
   const onReset = () => {
     form.resetFields();
     message.info(intl.formatMessage({ id: "profile.form.clear" }));
-    checkIfFormValuesChanged();
+
+    const data = savedValues || getInitialValues(profileInfo);
+    setDisplayMentorshipForm(data.oralProficiency);
+    setFieldsChanged(false);
   };
 
   /*
@@ -598,7 +607,7 @@ const LangProficiencyFormView = ({
               tooltipText="Extra information"
             />
             <Switch
-              defaultChecked={displayMentorshipForm}
+              checked={displayMentorshipForm}
               onChange={toggleSecLangForm}
             />
             {getSecondLanguageForm(displayMentorshipForm)}


### PR DESCRIPTION
### Bug overview

1. When we want to delete the `secondLanguageProficiency` in the backend, we are passing the `secondLanguage` key with a null value, but the backend was just checking if the value was __falsy__ (aka null, undefined, 0, ''). When we are updating the profile in the other sections, we were not passing the `secondLanguage` key and the value was therefore undefined, so the value is __falsy__ and was deleting the `secondLanguageProficiency`.

closes #291

We need to check the type, more specifically (which is null in this instance). @MohamedRadwan (just a heads up, would not surprise me if there are other places in the backend that those things like that)

2. The switch value was just not properly updated when clearing the form

closes #320