### PR TITLE
[Fix] Qualification profile form end date

### DIFF
--- a/services/backend/src/core/profile/profile.js
+++ b/services/backend/src/core/profile/profile.js
@@ -226,7 +226,7 @@ async function updateProfile(request, response) {
           let { content } = exp;
           if (!startDate.isValid()) startDate = null;
           else startDate = startDate.format();
-          if (!endDate.isValid()) endDate = null;
+          if (!exp.endDate || !endDate.isValid()) endDate = null;
           else endDate = endDate.format();
           if (!exp.content) content = "";
           Experience.create({

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
@@ -66,11 +66,11 @@ const EducationFormView = ({
    */
   const toggleEndDate = () => {
     if (!disableEndDate) {
-      const educationFieldValues = form.getFieldsValue("education");
-      educationFieldValues.education[field.fieldKey].endDate = null;
+      const educationFieldValues = form.getFieldValue("education");
+      educationFieldValues[field.fieldKey].endDate = null;
       form.setFieldsValue(educationFieldValues);
     }
-    setDisableEndDate(!disableEndDate);
+    setDisableEndDate((prev) => !prev);
   };
 
   /*
@@ -81,8 +81,6 @@ const EducationFormView = ({
    */
   const disabledDatesBeforeStart = (current) => {
     const fieldPath = ["education", field.fieldKey, "startDate"];
-    // eslint-disable-next-line no-console
-    console.log(form.getFieldValue(fieldPath));
     if (form.getFieldValue(fieldPath)) {
       return (
         current &&
@@ -112,13 +110,15 @@ const EducationFormView = ({
   useEffect(() => {
     // set the default status of "ongoing" checkbox
     if (
+      profileInfo &&
+      field &&
       profileInfo.education[field.fieldKey] &&
       profileInfo.education[field.fieldKey].endDate.en
     ) {
       toggleEndDate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileInfo, field]);
+  }, [profileInfo]);
 
   /** **********************************
    ********* Render Component *********

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
@@ -66,8 +66,8 @@ const EducationFormView = ({
    */
   const toggleEndDate = () => {
     if (!disableEndDate) {
-      const educationFieldValues = form.getFieldValue("education");
-      educationFieldValues[field.fieldKey].endDate = null;
+      const educationFieldValues = form.getFieldsValue();
+      educationFieldValues.education[field.fieldKey].endDate = undefined;
       form.setFieldsValue(educationFieldValues);
     }
     setDisableEndDate((prev) => !prev);
@@ -232,7 +232,7 @@ const EducationFormView = ({
         </Form.Item>
         <div style={{ marginTop: "-10px" }}>
           {/* Checkbox if event is on-going */}
-          <Checkbox onChange={toggleEndDate} defaultChecked={disableEndDate}>
+          <Checkbox onChange={toggleEndDate} checked={disableEndDate}>
             <FormattedMessage id="profile.is.ongoing" />
           </Checkbox>
         </div>

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
@@ -222,15 +222,17 @@ const EducationFormView = ({
           label={<FormattedMessage id="profile.history.item.end.date" />}
           rules={!disableEndDate ? [Rules.required] : undefined}
         >
-          <DatePicker
-            picker="month"
-            style={style.datePicker}
-            disabledDate={disabledDatesBeforeStart}
-            disabled={disableEndDate}
-            placeholder="unknown"
-          />
+          {!disableEndDate && (
+            <DatePicker
+              picker="month"
+              style={style.datePicker}
+              disabledDate={disabledDatesBeforeStart}
+              disabled={disableEndDate}
+              placeholder="unknown"
+            />
+          )}
         </Form.Item>
-        <div style={{ marginTop: "-10px" }}>
+        <div style={{ marginTop: disableEndDate ? "-38px" : "-10px" }}>
           {/* Checkbox if event is on-going */}
           <Checkbox onChange={toggleEndDate} checked={disableEndDate}>
             <FormattedMessage id="profile.is.ongoing" />

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
@@ -30,13 +30,7 @@ const { TextArea } = Input;
  *  It is rendered when a user generates an experience item
  *  It contains jobTilt, Company, start date, end date, and description.
  */
-const ExperienceFormView = ({
-  form,
-  field,
-  remove,
-  profileInfo,
-  style,
-}) => {
+const ExperienceFormView = ({ form, field, remove, profileInfo, style }) => {
   const [disableEndDate, setDisableEndDate] = useState(true);
 
   const Rules = {
@@ -61,12 +55,11 @@ const ExperienceFormView = ({
    */
   const toggleEndDate = () => {
     if (!disableEndDate) {
-      const experienceFieldValues = form.getFieldsValue("experience");
-      experienceFieldValues.experience[field.fieldKey].endDate = null;
+      const experienceFieldValues = form.getFieldsValue();
+      experienceFieldValues.experience[field.fieldKey].endDate = undefined;
       form.setFieldsValue(experienceFieldValues);
     }
-    setDisableEndDate(!disableEndDate);
-    return undefined;
+    setDisableEndDate((prev) => !prev);
   };
 
   /*
@@ -106,13 +99,15 @@ const ExperienceFormView = ({
   useEffect(() => {
     // set the default status of "ongoing" checkbox
     if (
+      profileInfo &&
+      field &&
       profileInfo.careerSummary[field.fieldKey] &&
       profileInfo.careerSummary[field.fieldKey].endDate
     ) {
       toggleEndDate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileInfo, field]);
+  }, [profileInfo]);
 
   /** **********************************
    ********* Render Component *********
@@ -208,7 +203,7 @@ const ExperienceFormView = ({
         </Form.Item>
         <div style={{ marginTop: "-10px" }}>
           {/* Checkbox if event is on-going */}
-          <Checkbox onChange={toggleEndDate} defaultChecked={disableEndDate}>
+          <Checkbox onChange={toggleEndDate} checked={disableEndDate}>
             <FormattedMessage id="profile.is.ongoing" />
           </Checkbox>
         </div>

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
@@ -193,15 +193,17 @@ const ExperienceFormView = ({ form, field, remove, profileInfo, style }) => {
           label={<FormattedMessage id="profile.history.item.end.date" />}
           rules={!disableEndDate ? [Rules.required] : undefined}
         >
-          <DatePicker
-            picker="month"
-            style={style.datePicker}
-            disabledDate={disabledDatesBeforeStart}
-            disabled={disableEndDate}
-            placeholder="unknown"
-          />
+          {!disableEndDate && (
+            <DatePicker
+              picker="month"
+              style={style.datePicker}
+              disabledDate={disabledDatesBeforeStart}
+              disabled={disableEndDate}
+              placeholder="unknown"
+            />
+          )}
         </Form.Item>
-        <div style={{ marginTop: "-10px" }}>
+        <div style={{ marginTop: disableEndDate ? "-38px" : "-10px" }}>
           {/* Checkbox if event is on-going */}
           <Checkbox onChange={toggleEndDate} checked={disableEndDate}>
             <FormattedMessage id="profile.is.ongoing" />


### PR DESCRIPTION
### Changes
- Changed the backend so that the `endDate` doesn't default to the current date
- `setDisableEndDate` to toggle on its previous value
- Changed the `defaultChecked` prop to `checked`, so the CheckBox reflects the value of the state
- Removed dependency on `field` in the useEffect
- Will not show date picker when ongoing is selected 
_Before_
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/22248828/83443338-8de4b300-a417-11ea-9106-63824cc2ce28.png)
_After_
![image](https://user-images.githubusercontent.com/22248828/83443274-7ad1e300-a417-11ea-8cb8-d9bc0611d6e7.png)



closes #208