### PR TITLE
[Fix] Added missing French translations to error page and profile page

### DIFF
--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -117,7 +117,7 @@
   "sidebar.search.title": "Filtres de recherche",
   "sidebar.search.description": "Vous pouvez mettre à jour vos filtres de recherche",
 
-  "back.to.landing": "Retour à la page de destination",
+  "back.to.landing": "Retour à la page d'accueil",
   "search.no.results": "Aucun résultat trouvé",
 
   "button.apply": "Enregistrer",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -117,6 +117,7 @@
   "sidebar.search.title": "Filtres de recherche",
   "sidebar.search.description": "Vous pouvez mettre à jour vos filtres de recherche",
 
+  "back.to.landing": "Retour à la page de destination",
   "search.no.results": "Aucun résultat trouvé",
 
   "button.apply": "Enregistrer",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -337,6 +337,7 @@
   "profile.undefined": "Indéfinie",
   "profile.do.not.specify": "Ne pas spécifié",
   "profile.not.specified": "Non spécifié",
+  "profile.not.found": "Profil non trouvé",
   "profile.end.date.present": "Présent",
   "profile.relocation.locations": "Je suis disposé à transferé à",
   "profile.career.interests": "Mobilité de l'emploi",


### PR DESCRIPTION
- For French error page, added "back.to.landing" in fr_CA
- For French profile page added "profile.not.found" in fr_CA