### PR TITLE
[Fixed] Options api

### DIFF
--- a/services/backend/src/core/options/util/careerMobilities.js
+++ b/services/backend/src/core/options/util/careerMobilities.js
@@ -18,6 +18,9 @@ async function getCareerMobilities(request, response) {
           opCareerMobilitiesId: true,
           description: true,
         },
+        orderBy: {
+          description: "asc",
+        },
       }
     );
 

--- a/services/backend/src/core/options/util/categories.js
+++ b/services/backend/src/core/options/util/categories.js
@@ -166,6 +166,12 @@ async function createCategory(request, response) {
       response.status(422).json(error.errors);
       return;
     }
+    if (error.code === "P2002") {
+      response
+        .status(409)
+        .send("Category option already exists with that information");
+      return;
+    }
     response.status(500).send("Error creating a category option");
   }
 }
@@ -182,14 +188,22 @@ async function updateCategory(request, response) {
       },
       data: {
         translations: {
-          create: [
+          updateMany: [
             {
-              name: en,
-              language: "ENGLISH",
+              where: {
+                language: "ENGLISH",
+              },
+              data: {
+                name: en,
+              },
             },
             {
-              name: fr,
-              language: "FRENCH",
+              where: {
+                language: "FRENCH",
+              },
+              data: {
+                name: fr,
+              },
             },
           ],
         },
@@ -215,6 +229,12 @@ async function deleteCategory(request, response) {
 
     const { id } = request.body;
 
+    await prisma.opTransCategories.deleteMany({
+      where: {
+        opCategoriesId: id,
+      },
+    });
+
     await prisma.opCategories.delete({
       where: {
         id,
@@ -239,6 +259,14 @@ async function deleteCategories(request, response) {
     validationResult(request).throw();
 
     const { ids } = request.body;
+
+    await prisma.opTransCategories.deleteMany({
+      where: {
+        opCategoriesId: {
+          in: ids,
+        },
+      },
+    });
 
     await prisma.opCategories.deleteMany({
       where: {

--- a/services/backend/src/core/options/util/classifications.js
+++ b/services/backend/src/core/options/util/classifications.js
@@ -9,6 +9,9 @@ async function getClassifications(request, response) {
         id: true,
         name: true,
       },
+      orderBy: {
+        name: "asc",
+      },
     });
 
     response.status(200).json(classificationsQuery);

--- a/services/backend/src/core/options/util/competencies.js
+++ b/services/backend/src/core/options/util/competencies.js
@@ -100,6 +100,12 @@ async function createCompetency(request, response) {
       response.status(422).json(error.errors);
       return;
     }
+    if (error.code === "P2002") {
+      response
+        .status(409)
+        .send("Competency option already exists with that information");
+      return;
+    }
     response.status(500).send("Error creating a competency option");
   }
 }
@@ -116,14 +122,22 @@ async function updateCompetency(request, response) {
       },
       data: {
         translations: {
-          create: [
+          updateMany: [
             {
-              name: en,
-              language: "ENGLISH",
+              where: {
+                language: "ENGLISH",
+              },
+              data: {
+                name: en,
+              },
             },
             {
-              name: fr,
-              language: "FRENCH",
+              where: {
+                language: "FRENCH",
+              },
+              data: {
+                name: fr,
+              },
             },
           ],
         },
@@ -158,6 +172,12 @@ async function deleteCompetency(request, response) {
     await prisma.developmentalGoals.deleteMany({
       where: {
         competencyId: id,
+      },
+    });
+
+    await prisma.opTransCompetencies.deleteMany({
+      where: {
+        opCompetenciesId: id,
       },
     });
 
@@ -197,6 +217,14 @@ async function deleteCompetencies(request, response) {
     await prisma.developmentalGoals.deleteMany({
       where: {
         competencyId: {
+          in: ids,
+        },
+      },
+    });
+
+    await prisma.opTransCompetencies.deleteMany({
+      where: {
+        opCompetenciesId: {
           in: ids,
         },
       },

--- a/services/backend/src/core/options/util/developmentalGoals.js
+++ b/services/backend/src/core/options/util/developmentalGoals.js
@@ -9,23 +9,29 @@ async function getDevelopmentalGoals(request, response) {
 
     const { language } = request.query;
 
-    const skillsQuery = await prisma.opTransCompetencies.findMany({
-      where: {
-        language,
-      },
-      select: {
-        id: true,
-        name: true,
-      },
-    });
-
     const competenciesQuery = await prisma.opTransCompetencies.findMany({
       where: {
         language,
       },
       select: {
-        id: true,
+        opCompetenciesId: true,
         name: true,
+      },
+      orderBy: {
+        name: "asc",
+      },
+    });
+
+    const skillsQuery = await prisma.opTransSkills.findMany({
+      where: {
+        language,
+      },
+      select: {
+        opSkillsId: true,
+        name: true,
+      },
+      orderBy: {
+        name: "asc",
       },
     });
 

--- a/services/backend/src/core/options/util/lookingJobs.js
+++ b/services/backend/src/core/options/util/lookingJobs.js
@@ -17,6 +17,9 @@ async function getLookingJobs(request, response) {
         opLookingJobsId: true,
         description: true,
       },
+      orderBy: {
+        description: "asc",
+      },
     });
 
     const lookingJobs = lookingJobsQuery.map((i) => {

--- a/services/backend/src/core/options/util/schools.js
+++ b/services/backend/src/core/options/util/schools.js
@@ -54,12 +54,14 @@ async function getSchoolsAllLang(request, response) {
     });
 
     const schools = schoolsQuery.map((i) => {
+      const en = i.translations.find((j) => j.language === "ENGLISH");
+      const fr = i.translations.find((j) => j.language === "FRENCH");
       return {
         id: i.id,
         abbrProvince: i.abbrProvince,
         abbrCountry: i.abbrCountry,
-        en: i.translations.find((j) => j.language === "ENGLISH").name,
-        fr: i.translations.find((j) => j.language === "FRENCH").name,
+        en: en ? en.name : undefined,
+        fr: fr ? fr.name : undefined,
       };
     });
 
@@ -139,15 +141,23 @@ async function updateSchool(request, response) {
 
     if (en) {
       translations.push({
-        name: en,
-        language: "ENGLISH",
+        where: {
+          language: "ENGLISH",
+        },
+        data: {
+          name: en,
+        },
       });
     }
 
     if (fr) {
       translations.push({
-        name: fr,
-        language: "FRENCH",
+        where: {
+          language: "FRENCH",
+        },
+        data: {
+          name: fr,
+        },
       });
     }
 
@@ -159,7 +169,7 @@ async function updateSchool(request, response) {
         abbrCountry,
         abbrProvince,
         translations: {
-          create: translations,
+          updateMany: translations,
         },
       },
     });
@@ -181,7 +191,7 @@ async function deleteSchool(request, response) {
   try {
     validationResult(request).throw();
 
-    const { id } = request.query;
+    const { id } = request.body;
 
     await prisma.opTransSchools.deleteMany({
       where: {
@@ -189,7 +199,7 @@ async function deleteSchool(request, response) {
       },
     });
 
-    await prisma.opSchools.deleteMany({
+    await prisma.opSchools.delete({
       where: {
         id,
       },
@@ -212,11 +222,21 @@ async function deleteSchools(request, response) {
   try {
     validationResult(request).throw();
 
-    const { ids } = request.query;
+    const { ids } = request.body;
+
+    await prisma.opTransSchools.deleteMany({
+      where: {
+        opSchoolsId: {
+          in: ids,
+        },
+      },
+    });
 
     await prisma.opSchools.deleteMany({
       where: {
-        id: ids,
+        id: {
+          in: ids,
+        },
       },
     });
 

--- a/services/backend/src/core/options/util/securityClearances.js
+++ b/services/backend/src/core/options/util/securityClearances.js
@@ -18,6 +18,9 @@ async function getSecurityClearances(request, response) {
           opSecurityClearancesId: true,
           description: true,
         },
+        orderBy: {
+          description: "asc",
+        },
       }
     );
 

--- a/services/backend/src/core/options/util/skills.js
+++ b/services/backend/src/core/options/util/skills.js
@@ -101,6 +101,12 @@ async function createSkill(request, response) {
       response.status(422).json(error.errors);
       return;
     }
+    if (error.code === "P2002") {
+      response
+        .status(409)
+        .send("Category option already exists with that information");
+      return;
+    }
     response.status(500).send("Error creating a skill option");
   }
 }
@@ -117,19 +123,29 @@ async function updateSkill(request, response) {
       },
       data: {
         category: {
-          connect: {
-            id: categoryId,
-          },
+          connect: categoryId
+            ? {
+                id: categoryId,
+              }
+            : undefined,
         },
         translations: {
-          create: [
+          updateMany: [
             {
-              name: en,
-              language: "ENGLISH",
+              where: {
+                language: "ENGLISH",
+              },
+              data: {
+                name: en,
+              },
             },
             {
-              name: fr,
-              language: "FRENCH",
+              where: {
+                language: "FRENCH",
+              },
+              data: {
+                name: fr,
+              },
             },
           ],
         },
@@ -170,6 +186,12 @@ async function deleteSkill(request, response) {
     await prisma.developmentalGoals.deleteMany({
       where: {
         skillId: id,
+      },
+    });
+
+    await prisma.opTransSkills.deleteMany({
+      where: {
+        opSkillsId: id,
       },
     });
 
@@ -217,6 +239,14 @@ async function deleteSkills(request, response) {
     await prisma.developmentalGoals.deleteMany({
       where: {
         skillId: {
+          in: ids,
+        },
+      },
+    });
+
+    await prisma.opTransSkills.deleteMany({
+      where: {
+        opSkillsId: {
           in: ids,
         },
       },

--- a/services/backend/src/core/options/util/talentMatrixResults.js
+++ b/services/backend/src/core/options/util/talentMatrixResults.js
@@ -18,6 +18,9 @@ async function getTalentMatrixResults(request, response) {
           opTalentMatrixResultsId: true,
           description: true,
         },
+        orderBy: {
+          name: "asc",
+        },
       }
     );
 

--- a/services/backend/src/core/options/util/tenures.js
+++ b/services/backend/src/core/options/util/tenures.js
@@ -17,6 +17,9 @@ async function getTenures(request, response) {
         opTenuresId: true,
         name: true,
       },
+      orderBy: {
+        name: "asc",
+      },
     });
 
     const tenures = tenuresQuery.map((i) => {

--- a/services/backend/src/router/options/options.js
+++ b/services/backend/src/router/options/options.js
@@ -66,13 +66,18 @@ optionsRouter
   );
 optionsRouter.get("/categoriesAllLang", categories.getCategoriesAllLang);
 optionsRouter.get(
+  "/categoriesAllLang",
+  keycloak.protect("view-admin-console"),
+  categories.getCategoriesAllLang
+);
+optionsRouter.get(
   "/categoriesSkills",
   keycloak.protect("view-admin-console"),
   langValidator,
   categories.getCategoriesSkills
 );
 
-optionsRouter.get("/classfications", classifications.getClassifications);
+optionsRouter.get("/classifications", classifications.getClassifications);
 
 optionsRouter
   .route("/competencies")


### PR DESCRIPTION
### Changes
- Ordered/sorted the queries, per Ali's request
- For the following options (skills, schools, diplomas, developmentalGoals, categories, competencies)
  - Added extra warning if the user is trying to create something that is unique
  - Fixed update route (was creating new translations instead of updating)
  - Make the delete routes delete the translations entries