### PR TITLE
[Feat] Added validation for /admin and /stats

### DIFF
--- a/services/backend/src/core/admin/util/users.js
+++ b/services/backend/src/core/admin/util/users.js
@@ -51,8 +51,8 @@ const getUsers = async (request, response) => {
         firstName: i.firstName,
         lastName: i.lastName,
         status: i.status,
-        jobTitle: jobTitle.length > 0 ? jobTitle[0] : undefined,
-        tenure: tenure.length > 0 ? tenure[0] : undefined,
+        jobTitle: jobTitle.length > 0 ? jobTitle[0].jobTitle : undefined,
+        tenure: tenure.length > 0 ? tenure[0].name : undefined,
       };
     });
 

--- a/services/backend/src/core/admin/util/users.js
+++ b/services/backend/src/core/admin/util/users.js
@@ -1,9 +1,12 @@
+const { validationResult } = require("express-validator");
 const { PrismaClient } = require("../../../database/client");
 
 const prisma = new PrismaClient();
 
 const getUsers = async (request, response) => {
   try {
+    validationResult(request).throw();
+
     const { language } = request.query;
 
     const usersQuery = await prisma.users.findMany({
@@ -55,12 +58,19 @@ const getUsers = async (request, response) => {
 
     response.status(200).json(users);
   } catch (error) {
+    console.log(error);
+    if (error.errors) {
+      response.status(422).json(error.errors);
+      return;
+    }
     response.status(500).send("Error getting information about the users");
   }
 };
 
 const updateUserStatuses = async (request, response) => {
   try {
+    validationResult(request).throw();
+
     const userIds = Object.keys(request.body);
 
     await Promise.all(
@@ -78,6 +88,11 @@ const updateUserStatuses = async (request, response) => {
 
     response.status(200).send("Successfully updated the user statuses");
   } catch (error) {
+    console.log(error);
+    if (error.errors) {
+      response.status(422).json(error.errors);
+      return;
+    }
     response.status(500).send("Error updating the user statuses");
   }
 };

--- a/services/backend/src/core/statistics/util/dashboardCount.js
+++ b/services/backend/src/core/statistics/util/dashboardCount.js
@@ -12,6 +12,7 @@ async function countHiddenUsers(request, response) {
 
     response.status(200).json(hiddenUserCount);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error getting hidden user count");
   }
 }
@@ -26,6 +27,7 @@ async function countInactiveUsers(request, response) {
 
     response.status(200).json(inactiveUserCount);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error getting inactive user count");
   }
 }
@@ -36,6 +38,7 @@ async function countUsers(request, response) {
 
     response.status(200).json(userCount);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error getting user count");
   }
 }
@@ -50,6 +53,7 @@ async function countExFeederUsers(request, response) {
 
     response.status(200).json(exFeederUserCount);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error getting exFeeder user count");
   }
 }

--- a/services/backend/src/core/statistics/util/flaggedProfiles.js
+++ b/services/backend/src/core/statistics/util/flaggedProfiles.js
@@ -17,6 +17,7 @@ async function getHiddenUsers(request, response) {
 
     response.status(200).json(hiddenUsers);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error fetching hidden users");
   }
 }

--- a/services/backend/src/core/statistics/util/growthRate.js
+++ b/services/backend/src/core/statistics/util/growthRate.js
@@ -29,6 +29,7 @@ async function growthRateByWeek(request, response) {
 
     response.status(200).json(userCreationPerWeek);
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error fetching growth rate by week");
   }
 }
@@ -106,6 +107,7 @@ async function growthRateByMonth(request, response) {
       currentMonthUsersCount,
     });
   } catch (error) {
+    console.log(error);
     response.status(500).send("Error fetching growth rate by month");
   }
 }

--- a/services/backend/src/core/statistics/util/growthRate.js
+++ b/services/backend/src/core/statistics/util/growthRate.js
@@ -63,6 +63,7 @@ async function growthRateByMonth(request, response) {
       const currentMonth = oldestUserDate.month();
 
       growthRate[currentYear] = { [currentMonth]: 0 };
+      oldestUserDate.add(1, "month");
     }
 
     // Updated the growth rate according to user entries
@@ -78,7 +79,7 @@ async function growthRateByMonth(request, response) {
     const currentYear = moment().year();
     const currentMonth = moment().month();
 
-    const currentMonthUsersCount = growthRate[currentYear][currentMonth];
+    const currentMonthNewUserCount = growthRate[currentYear][currentMonth];
 
     let previousMonthAdditions = 0;
 
@@ -91,11 +92,11 @@ async function growthRateByMonth(request, response) {
 
     let growthRateFromPreviousMonth = 0;
 
-    if (previousMonthAdditions === 0) {
-      growthRateFromPreviousMonth = currentMonthUsersCount * 100;
+    if (!previousMonthAdditions || previousMonthAdditions === 0) {
+      growthRateFromPreviousMonth = currentMonthNewUserCount * 100;
     } else {
       growthRateFromPreviousMonth = Math.round(
-        ((currentMonthUsersCount - previousMonthAdditions) /
+        ((currentMonthNewUserCount - previousMonthAdditions) /
           previousMonthAdditions) *
           100
       );
@@ -104,7 +105,7 @@ async function growthRateByMonth(request, response) {
     response.status(200).json({
       growthRate,
       growthRateFromPreviousMonth,
-      currentMonthUsersCount,
+      currentMonthNewUserCount,
     });
   } catch (error) {
     console.log(error);

--- a/services/backend/src/core/statistics/util/topFive.js
+++ b/services/backend/src/core/statistics/util/topFive.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const { validationResult } = require("express-validator");
 const { PrismaClient } = require("../../../database/client");
 
 const prisma = new PrismaClient();
@@ -91,6 +92,8 @@ async function getTopFiveCompetenciesHelper(competencies, language) {
 
 async function getTopFiveSkills(request, response) {
   try {
+    validationResult(request).throw();
+
     const { language } = request.query;
 
     const skillIds = await prisma.skills.findMany({
@@ -104,12 +107,19 @@ async function getTopFiveSkills(request, response) {
 
     response.status(200).json(topFiveSkills);
   } catch (error) {
+    console.log(error);
+    if (error.errors) {
+      response.status(422).json(error.errors);
+      return;
+    }
     response.status(500).send("Error getting the top five skills");
   }
 }
 
 async function getTopFiveCompetencies(request, response) {
   try {
+    validationResult(request).throw();
+
     const { language } = request.query;
 
     const competencyIds = await prisma.developmentalGoals.findMany({
@@ -126,12 +136,19 @@ async function getTopFiveCompetencies(request, response) {
 
     response.status(200).json(topFiveCompetencies);
   } catch (error) {
+    console.log(error);
+    if (error.errors) {
+      response.status(422).json(error.errors);
+      return;
+    }
     response.status(500).send("Error getting the top five competencies");
   }
 }
 
 async function getTopFiveDevelopmentalGoals(request, response) {
   try {
+    validationResult(request).throw();
+
     const { language } = request.query;
 
     const competencyIds = await prisma.developmentalGoals.findMany({
@@ -167,6 +184,11 @@ async function getTopFiveDevelopmentalGoals(request, response) {
 
     response.status(200).json(topFiveDevelopmentGoals);
   } catch (error) {
+    console.log(error);
+    if (error.errors) {
+      response.status(422).json(error.errors);
+      return;
+    }
     response.status(500).send("Error getting the top five developmental goals");
   }
 }

--- a/services/backend/src/core/statistics/util/topFive.js
+++ b/services/backend/src/core/statistics/util/topFive.js
@@ -103,7 +103,7 @@ async function getTopFiveSkills(request, response) {
       },
     });
 
-    const topFiveSkills = getTopFiveSkillsHelper(skillIds, language);
+    const topFiveSkills = await getTopFiveSkillsHelper(skillIds, language);
 
     response.status(200).json(topFiveSkills);
   } catch (error) {
@@ -122,14 +122,14 @@ async function getTopFiveCompetencies(request, response) {
 
     const { language } = request.query;
 
-    const competencyIds = await prisma.developmentalGoals.findMany({
+    const competencyIds = await prisma.competencies.findMany({
       select: {
         id: true,
         competencyId: true,
       },
     });
 
-    const topFiveCompetencies = getTopFiveCompetenciesHelper(
+    const topFiveCompetencies = await getTopFiveCompetenciesHelper(
       competencyIds,
       language
     );
@@ -171,18 +171,17 @@ async function getTopFiveDevelopmentalGoals(request, response) {
       },
     });
 
-    const topFiveSkills = getTopFiveSkillsHelper(skillIds, language);
-    const topFiveCompetencies = getTopFiveCompetenciesHelper(
-      competencyIds,
-      language
+    const topFive = await Promise.all([
+      getTopFiveSkillsHelper(skillIds, language),
+      getTopFiveCompetenciesHelper(competencyIds, language),
+    ]);
+
+    const topFiveDevelopmentalGoals = [...topFive[0], ...topFive[1]].slice(
+      0,
+      5
     );
 
-    const topFiveDevelopmentGoals = [
-      ...topFiveSkills,
-      ...topFiveCompetencies,
-    ].slice(0, 5);
-
-    response.status(200).json(topFiveDevelopmentGoals);
+    response.status(200).json(topFiveDevelopmentalGoals);
   } catch (error) {
     console.log(error);
     if (error.errors) {

--- a/services/backend/src/router/admin/admin.js
+++ b/services/backend/src/router/admin/admin.js
@@ -1,6 +1,7 @@
 const { Router } = require("express");
 const { keycloak } = require("../../auth/keycloak");
 const admin = require("../../core/admin/admin");
+const { langValidator, updateUserStatusValidator } = require("./validator");
 
 function catchAdminCheck(token) {
   try {
@@ -15,6 +16,7 @@ const adminRouter = Router();
 adminRouter.get(
   "/users",
   keycloak.protect("view-admin-console"),
+  langValidator,
   admin.getUsers
 );
 
@@ -23,6 +25,7 @@ adminRouter.get("/check", keycloak.protect(catchAdminCheck), admin.checkAdmin);
 adminRouter.put(
   "/userStatuses",
   keycloak.protect("manage-users"),
+  updateUserStatusValidator,
   admin.updateUserStatuses
 );
 

--- a/services/backend/src/router/admin/validator.js
+++ b/services/backend/src/router/admin/validator.js
@@ -10,12 +10,15 @@ const langValidator = [
 
 const updateUserStatusValidator = [
   body()
-    .isJSON()
-    .custom((value) => {
-      return Object.keys(value).every((i) => {
-        return isUUID(i) && isIn(value[i], ["ACTIVE", "INACTIVE", "HIDDEN"]);
-      });
-    }),
+    .custom((object) => {
+      return Object.keys(object).every(
+        (key) =>
+          isUUID(key) && isIn(object[key], ["ACTIVE", "INACTIVE", "HIDDEN"])
+      );
+    })
+    .withMessage(
+      "must be a JSON object with user UUIDs as keys and it's value must be 'ACTIVE' or 'INACTIVE' or 'HIDDEN'"
+    ),
 ];
 
 module.exports = {

--- a/services/backend/src/router/admin/validator.js
+++ b/services/backend/src/router/admin/validator.js
@@ -1,0 +1,24 @@
+const { query, body } = require("express-validator");
+const { isUUID, isIn } = require("validator");
+
+const langValidator = [
+  query("language")
+    .trim()
+    .isIn(["ENGLISH", "FRENCH"])
+    .withMessage("must be 'ENGLISH' or 'FRENCH'"),
+];
+
+const updateUserStatusValidator = [
+  body()
+    .isJSON()
+    .custom((value) => {
+      return Object.keys(value).every((i) => {
+        return isUUID(i) && isIn(value[i], ["ACTIVE", "INACTIVE", "HIDDEN"]);
+      });
+    }),
+];
+
+module.exports = {
+  langValidator,
+  updateUserStatusValidator,
+};

--- a/services/backend/src/router/statistics/statistics.js
+++ b/services/backend/src/router/statistics/statistics.js
@@ -6,6 +6,7 @@ const {
   growthRate,
   topFive,
 } = require("../../core/statistics");
+const { langValidator } = require("./validator");
 
 const statsRouter = Router();
 
@@ -55,18 +56,21 @@ statsRouter.get(
 statsRouter.get(
   "/topFiveCompetencies",
   keycloak.protect("view-admin-console"),
+  langValidator,
   topFive.getTopFiveCompetencies
 );
 
 statsRouter.get(
   "/topFiveSkills",
   keycloak.protect("view-admin-console"),
+  langValidator,
   topFive.getTopFiveSkills
 );
 
 statsRouter.get(
   "/topFiveDevelopmentalGoals",
   keycloak.protect("view-admin-console"),
+  langValidator,
   topFive.getTopFiveDevelopmentalGoals
 );
 

--- a/services/backend/src/router/statistics/validator.js
+++ b/services/backend/src/router/statistics/validator.js
@@ -1,0 +1,12 @@
+const { query } = require("express-validator");
+
+const langValidator = [
+  query("language")
+    .trim()
+    .isIn(["ENGLISH", "FRENCH"])
+    .withMessage("must be 'ENGLISH' or 'FRENCH'"),
+];
+
+module.exports = {
+  langValidator,
+};


### PR DESCRIPTION
### Changes
- Added console.log to the errors in catch
- `getUsers`: added language validation and cleaned up response 
- `updateUserStatuses`: added body validation (keys are UUIDs and its value is a profile status enum value)
- `growthRateByMonth`: fixed infinite loop and if statements
- `topFive*`: added language validation and added awaits for it to actually return something