### PR TITLE
[New] Added confirmation message for visibility toggle on profile card

### DIFF
--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -80,11 +80,11 @@ const ProfileCardsView = ({
    * Get title of pop confirm based on current toggle position
    */
   const getPopConfirmTitle = (visibilityBool) => {
+    // if user wants to hide profile
     if (visibilityBool) {
       return <FormattedMessage id="profile.visibility.hide.confirm" />;
-    } else {
-      return <FormattedMessage id="profile.visibility.show.confirm" />;
     }
+    return <FormattedMessage id="profile.visibility.show.confirm" />;
   };
 
   /*

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -5,7 +5,7 @@ import {
   EyeOutlined,
   EyeInvisibleOutlined,
   EditOutlined,
-  QuestionCircleOutlined,
+  WarningOutlined,
 } from "@ant-design/icons";
 import { Card, Switch, Button, Row, Col, Tooltip, Popconfirm } from "antd";
 import { FormattedMessage } from "react-intl";
@@ -106,7 +106,7 @@ const ProfileCardsView = ({
                 title={getPopConfirmTitle(disabled)}
                 okText={<FormattedMessage id="profile.yes" />}
                 cancelText={<FormattedMessage id="profile.no" />}
-                icon={<QuestionCircleOutlined />}
+                icon={<WarningOutlined style={{ color: "orange" }} />}
                 onConfirm={handleVisibilityToggle}
                 placement="topRight"
               >

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -5,8 +5,9 @@ import {
   EyeOutlined,
   EyeInvisibleOutlined,
   EditOutlined,
+  QuestionCircleOutlined,
 } from "@ant-design/icons";
-import { Card, Switch, Button, Row, Col, Tooltip } from "antd";
+import { Card, Switch, Button, Row, Col, Tooltip, Popconfirm } from "antd";
 import { FormattedMessage } from "react-intl";
 import { useSelector } from "react-redux";
 
@@ -74,6 +75,19 @@ const ProfileCardsView = ({
   };
 
   /*
+   * Get Pop Confirm Title
+   *
+   * Get title of pop confirm based on current toggle position
+   */
+  const getPopConfirmTitle = (visibilityBool) => {
+    if (visibilityBool) {
+      return <FormattedMessage id="profile.visibility.hide.confirm" />;
+    } else {
+      return <FormattedMessage id="profile.visibility.show.confirm" />;
+    }
+  };
+
+  /*
    * Generate Switch Button
    *
    * Generate visibility switch and edit button
@@ -88,21 +102,23 @@ const ProfileCardsView = ({
         <div style={{ marginTop: "15px" }}>
           <Row type="flex" gutter={[16, 16]}>
             <Col>
-              <Tooltip
-                trigger="click"
-                placement="top"
-                title={<FormattedMessage id="profile.toggle.card.visibility" />}
+              <Popconfirm
+                title={getPopConfirmTitle(disabled)}
+                okText={<FormattedMessage id="profile.yes" />}
+                cancelText={<FormattedMessage id="profile.no" />}
+                icon={<QuestionCircleOutlined />}
+                onConfirm={handleVisibilityToggle}
+                placement="topRight"
               >
                 <Switch
                   aria-label="visibility toggle"
                   checkedChildren={<EyeOutlined />}
                   unCheckedChildren={<EyeInvisibleOutlined />}
                   checked={disabled && !forceDisabled}
-                  onChange={handleVisibilityToggle}
                   style={{ marginTop: "5px" }}
                   disabled={forceDisabled}
                 />
-              </Tooltip>
+              </Popconfirm>
             </Col>
 
             <Col>
@@ -112,7 +128,7 @@ const ProfileCardsView = ({
                 title={<FormattedMessage id="profile.edit" />}
               >
                 <Button
-                  aria-label="visibility toggle"
+                  aria-label="edit card"
                   type="default"
                   shape="circle"
                   icon={<EditOutlined />}

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -109,6 +109,7 @@ const ProfileCardsView = ({
                 icon={<WarningOutlined style={{ color: "orange" }} />}
                 onConfirm={handleVisibilityToggle}
                 placement="topRight"
+                disabled={forceDisabled}
               >
                 <Switch
                   aria-label="visibility toggle"

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -337,6 +337,9 @@
 
   "profile.career.interests": "Job mobility",
 
+  "profile.visibility.show.confirm": "Are you sure you want to make this card visible to everyone?",
+  "profile.visibility.hide.confirm": "Are you sure you want to make hide this card from your public profile? (Will be only visible to you and HR)",
+
   "profile.gathering.profile.info": "Gathering profile info...",
   "profile.settings.and.privacy": "Settings & Privacy",
   "profile.preview.public.view": "Preview public view",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -311,6 +311,9 @@
   "profile.form.clear": "Changements effacé",
   "profile.qualifications.select.month": "Sélectionner un mois",
 
+  "profile.visibility.show.confirm": "Etes-vous certain de vouloir rendre cette carte visible sur votre profil public?",
+  "profile.visibility.hide.confirm": "Êtes-vous certain de masquer cette carte de votre profil public? (Ne sera visible que pour vous et les RH)",
+
   "lang": "English",
   "lang.code": "en",
   "language.code": "fr",


### PR DESCRIPTION
- when user toggles profile card visibility they are prompted with confirmation message
- only once they provide confirmation the visibility of card is changed
- confirmation message is disabled if toggle is disabled
- closes #373 