### PR TITLE
Revert "[New] Added confirmation message for visibility toggle on profile card"

### DIFF
--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -5,9 +5,8 @@ import {
   EyeOutlined,
   EyeInvisibleOutlined,
   EditOutlined,
-  WarningOutlined,
 } from "@ant-design/icons";
-import { Card, Switch, Button, Row, Col, Tooltip, Popconfirm } from "antd";
+import { Card, Switch, Button, Row, Col, Tooltip } from "antd";
 import { FormattedMessage } from "react-intl";
 import { useSelector } from "react-redux";
 
@@ -75,19 +74,6 @@ const ProfileCardsView = ({
   };
 
   /*
-   * Get Pop Confirm Title
-   *
-   * Get title of pop confirm based on current toggle position
-   */
-  const getPopConfirmTitle = (visibilityBool) => {
-    // if user wants to hide profile
-    if (visibilityBool) {
-      return <FormattedMessage id="profile.visibility.hide.confirm" />;
-    }
-    return <FormattedMessage id="profile.visibility.show.confirm" />;
-  };
-
-  /*
    * Generate Switch Button
    *
    * Generate visibility switch and edit button
@@ -102,24 +88,21 @@ const ProfileCardsView = ({
         <div style={{ marginTop: "15px" }}>
           <Row type="flex" gutter={[16, 16]}>
             <Col>
-              <Popconfirm
-                title={getPopConfirmTitle(disabled)}
-                okText={<FormattedMessage id="profile.yes" />}
-                cancelText={<FormattedMessage id="profile.no" />}
-                icon={<WarningOutlined style={{ color: "orange" }} />}
-                onConfirm={handleVisibilityToggle}
-                placement="topRight"
-                disabled={forceDisabled}
+              <Tooltip
+                trigger="click"
+                placement="top"
+                title={<FormattedMessage id="profile.toggle.card.visibility" />}
               >
                 <Switch
                   aria-label="visibility toggle"
                   checkedChildren={<EyeOutlined />}
                   unCheckedChildren={<EyeInvisibleOutlined />}
                   checked={disabled && !forceDisabled}
+                  onChange={handleVisibilityToggle}
                   style={{ marginTop: "5px" }}
                   disabled={forceDisabled}
                 />
-              </Popconfirm>
+              </Tooltip>
             </Col>
 
             <Col>
@@ -129,7 +112,7 @@ const ProfileCardsView = ({
                 title={<FormattedMessage id="profile.edit" />}
               >
                 <Button
-                  aria-label="edit card"
+                  aria-label="visibility toggle"
                   type="default"
                   shape="circle"
                   icon={<EditOutlined />}

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -338,9 +338,6 @@
 
   "profile.career.interests": "Job mobility",
 
-  "profile.visibility.show.confirm": "Are you sure you want to make this card visible to everyone?",
-  "profile.visibility.hide.confirm": "Are you sure you want to make hide this card from your public profile? (Will be only visible to you and HR)",
-
   "profile.gathering.profile.info": "Gathering profile info...",
   "profile.settings.and.privacy": "Settings & Privacy",
   "profile.preview.public.view": "Preview public view",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -312,9 +312,6 @@
   "profile.form.clear": "Changements effacé",
   "profile.qualifications.select.month": "Sélectionner un mois",
 
-  "profile.visibility.show.confirm": "Etes-vous certain de vouloir rendre cette carte visible sur votre profil public?",
-  "profile.visibility.hide.confirm": "Êtes-vous certain de masquer cette carte de votre profil public? (Ne sera visible que pour vous et les RH)",
-
   "lang": "English",
   "lang.code": "en",
   "language.code": "fr",


### PR DESCRIPTION
Reverting to investigate issue of the confirmation message over-lapping nav bar.
Reverts CDH-Studio/UpSkill#401