### PR TITLE
[Fix] Reverted triggers for tooltips to hover

### DIFF
--- a/services/frontend-v3/src/components/formLabelTooltip/FormLabelTooltipView.jsx
+++ b/services/frontend-v3/src/components/formLabelTooltip/FormLabelTooltipView.jsx
@@ -15,7 +15,7 @@ const FormLabelTooltipView = ({ labelText, tooltipText }) => {
   return (
     <div style={{ display: "inline", marginRight: "10px" }}>
       {labelText}
-      <Tooltip trigger="click" title={tooltipText}>
+      <Tooltip title={tooltipText}>
         <InfoCircleOutlined style={styles.tooltipIcon} />
       </Tooltip>
     </div>

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -124,7 +124,6 @@ const ProfileCardsView = ({
 
             <Col>
               <Tooltip
-                trigger="click"
                 placement="top"
                 title={<FormattedMessage id="profile.edit" />}
               >

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
@@ -145,7 +145,6 @@ const EducationFormView = ({
           <FormattedMessage id="setup.education" />
           {`: ${field.name + 1}`}
           <Tooltip
-            trigger="click"
             placement="top"
             title={<FormattedMessage id="admin.delete" />}
           >

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/experienceForm/ExperienceFormView.jsx
@@ -137,7 +137,6 @@ const ExperienceFormView = ({
           <FormattedMessage id="setup.experience" />
           {`: ${field.name + 1}`}
           <Tooltip
-            trigger="click"
             placement="top"
             title={<FormattedMessage id="admin.delete" />}
           >


### PR DESCRIPTION
- Removed select 'trigger="click" ' from tooltips
- Kept some clickable tooltips when needed