### PR TITLE
[fix] display team info on basic info card

### DIFF
--- a/services/frontend-v3/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend-v3/src/components/basicInfo/BasicInfoView.jsx
@@ -8,9 +8,10 @@ import {
   BranchesOutlined,
   EnvironmentOutlined,
   UserOutlined,
+  TeamOutlined,
 } from "@ant-design/icons";
 import PropTypes from "prop-types";
-import { Row, Col, Card, Avatar, List, Typography, Button } from "antd";
+import { Row, Col, Card, Avatar, List, Tag, Typography, Button } from "antd";
 import { ProfileInfoPropType } from "../../customPropTypes";
 
 const { Text } = Typography;
@@ -40,6 +41,7 @@ const BasicInfoView = ({
     userAvatar: {
       verticalAlign: "middle",
     },
+    rowTopSplitter: { borderTop: "1px solid #f0f0f0" },
   };
 
   /*
@@ -211,6 +213,27 @@ const BasicInfoView = ({
     return buttons;
   };
 
+  const generateTeamInfo = () => {
+    const teams = {
+      icon: <TeamOutlined />,
+      title: <FormattedMessage id="profile.teams" />,
+      description: data.team ? (
+        <List>
+          {Object.values([data.team]).map((item, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <Tag color="#727272" key={index}>
+              {item}
+            </Tag>
+          ))}
+        </List>
+      ) : (
+        <FormattedMessage id="profile.not.specified" />
+      ),
+    };
+
+    return [teams];
+  };
+
   return (
     <Card
       id="card-profile-basic-info"
@@ -225,6 +248,9 @@ const BasicInfoView = ({
         <Col xs={24} lg={12}>
           {generateInfoList(getLocationInfo())}
         </Col>
+      </Row>
+      <Row style={styles.rowTopSplitter}>
+        {generateInfoList(generateTeamInfo())}
       </Row>
     </Card>
   );

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -288,6 +288,7 @@
   "profile.mentorship.empty": "no mentorship skills provided",
   "profile.temporary.role": "Temporary role?",
   "profile.tenure": "Substantive",
+  "profile.teams": "Teams",
   "profile.talent.management.tooltip": "To determine your talent management results, contact your manager to fill out the following form: ",
   "profile.talent.management": "Recent talent management results",
   "profile.talent.matrix.result": "Talent matrix result",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -290,6 +290,7 @@
   "profile.mentorship.empty": "aucune compétence de mentorat fournie",
   "profile.temporary.role": "Rôle temporaire?",
   "profile.tenure": "Substantielle",
+  "profile.teams": "Équipes",
   "profile.talent.management.tooltip": "Pour déterminer vos résultats en matière de gestion des talents, contactez votre gestionnaire et remplissez le formulaire suivant avec lui: ",
   "profile.talent.management": "Résultats récents de la gestion de talents",
   "profile.talent.matrix.result": "Résultat de la matrice de talents",


### PR DESCRIPTION
Displays team info on the basic info card. Team info is already being stored. The team is displayed using a list in preparation for being able to specify multiple teams. 

_wide view_
![wide security split view 2](https://user-images.githubusercontent.com/30152653/86126061-b1009200-baab-11ea-9c80-92553dcb0340.png)


_narrow view_
![narrow security split view](https://user-images.githubusercontent.com/30152653/86125168-35eaac00-baaa-11ea-870b-5a404337ea41.png)
