### PR TITLE
[Fix] Catch empty search and do not allow user to search

### DIFF
--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -55,10 +55,10 @@ const SearchBar = () => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
     {
-      query !== ""
-        ? history.push(url)
-        : // eslint-disable-next-line no-console
-          console.log("");
+      if (query !== "") {
+        history.push(url);
+        // eslint-disable-next-line no-console
+      } else console.log("");
     }
   };
 

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -55,10 +55,8 @@ const SearchBar = () => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
 
-    {
-      if (query !== "") {
-        history.push(url);
-      }
+    if (query !== "") {
+      history.push(url);
     }
   };
 

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -58,8 +58,7 @@ const SearchBar = () => {
     {
       if (query !== "") {
         history.push(url);
-        // eslint-disable-next-line no-console
-      } else console.log("");
+      }
     }
   };
 

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -54,11 +54,8 @@ const SearchBar = () => {
   const handleSearch = (values) => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
-    {
-      query !== ""
-        ? history.push(url)
-        : // eslint-disable-next-line no-console
-          console.log("");
+    if (query !== "") {
+      history.push(url);
     }
   };
 

--- a/services/frontend-v3/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend-v3/src/components/searchBar/SearchBar.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-lone-blocks */
 import PropTypes from "prop-types";
 import React, { useState, useEffect } from "react";
 import axios from "axios";
@@ -52,7 +54,12 @@ const SearchBar = () => {
   const handleSearch = (values) => {
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/secured/results?${encodeURI(query)}`;
-    history.push(url);
+    {
+      query !== ""
+        ? history.push(url)
+        : // eslint-disable-next-line no-console
+          console.log("");
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
- added ternary operator to catch empty query (no search values entered) and dont push to results page until values have been entered