### PR TITLE
[Fix] Removed hover on sorting table columns in admin

### DIFF
--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -543,6 +543,7 @@ const CategoryTableView = ({
       <Row gutter={[0, 8]}>
         <Col span={24}>
           <Table
+            showSorterTooltip={false}
             rowSelection={rowSelection}
             columns={categoryTableColumns()}
             dataSource={data}

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -521,6 +521,7 @@ const CompetencyTableView = ({
       <Row gutter={[0, 8]}>
         <Col span={24}>
           <Table
+            showSorterTooltip={false}
             rowSelection={rowSelection}
             columns={competencyTableColumns()}
             dataSource={data}

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -520,6 +520,7 @@ const DiplomaTableView = ({
       <Row gutter={[0, 8]}>
         <Col span={24}>
           <Table
+            showSorterTooltip={false}
             rowSelection={rowSelection}
             columns={diplomaTableColumns()}
             dataSource={data}

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -587,6 +587,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
       <Row gutter={[0, 8]}>
         <Col span={24}>
           <Table
+            showSorterTooltip={false}
             rowSelection={rowSelection}
             columns={schoolsTableColumns()}
             dataSource={data}

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -618,6 +618,7 @@ const SkillTableView = ({
       <Row gutter={[0, 8]}>
         <Col span={24}>
           <Table
+            showSorterTooltip={false}
             rowSelection={rowSelection}
             columns={skillTableColumns()}
             dataSource={data}

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -375,7 +375,11 @@ const UserTableView = ({
       />
       <Row gutter={[0, 8]}>
         <Col span={24}>
-          <Table columns={userTableColumns()} dataSource={data} />
+          <Table
+            showSorterTooltip={false}
+            columns={userTableColumns()}
+            dataSource={data}
+          />
         </Col>
       </Row>
     </>


### PR DESCRIPTION
- Removed built-in ant design English hovers on column headers for tables on the admin side of I-Talent (on User, Category, Skill, Competency, Diploma, and School tables)