### PR TITLE
[Feat] Added redis connect for session management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   db-postgres:
     container_name: "upskill-database"
-    image: postgres
+    image: "postgres:12-alpine"
     restart: always
     environment:
       POSTGRES_PASSWORD: api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "3000:3000"
     volumes:
       - ./services/frontend-v3:/upskill-frontend
-      - ./upskill-frontend/node_modules
+      - frontend-node-modules:/upskill-backend/node_modules
     env_file:
       - ./env/web.env
 
@@ -19,17 +19,44 @@ services:
       - "5555:5555"
     volumes:
       - ./services/backend:/upskill-backend
-      - ./upskill-backend/node_modules
+      - backend-node-modules:/upskill-backend/node_modules
     env_file:
       - ./env/backend.env
+    networks:
+      - redis-net
+      - postgres-net
+    depends_on:
+      - redis
+      - db-postgres
 
   db-postgres:
     container_name: "upskill-database"
     image: "postgres:12-alpine"
     restart: always
+    hostname: db-postgres
     environment:
       POSTGRES_PASSWORD: api
       POSTGRES_USER: api
       POSTGRES_DB: testdb
-    ports:
-      - "5432:5432"
+    networks:
+      - postgres-net
+
+  redis:
+    container_name: "upskill-redis-session"
+    image: "redis:6-alpine"
+    command: ["redis-server"]
+    hostname: redis
+    restart: always
+    networks:
+      - redis-net
+    volumes:
+      - redis-data:/data
+
+networks:
+  redis-net:
+  postgres-net:
+
+volumes:
+  redis-data:
+  backend-node-modules:
+  frontend-node-modules:

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 
 ENV TZ=America/Toronto
 
@@ -12,7 +12,5 @@ RUN yarn install
 COPY . .
 
 EXPOSE 8080
-
-# CMD ["yarn", "deploy"]
 
 CMD ["yarn", "dev:docker"]

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -23,6 +23,7 @@
     "axios": "^0.19.2",
     "body-parser": "^1.19.0",
     "concurrently": "^5.2.0",
+    "connect-redis": "^4.0.4",
     "cross-env": "^7.0.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
@@ -32,6 +33,7 @@
     "keycloak-connect": "^10.0.2",
     "lodash": "^4.17.15",
     "moment": "^2.27.0",
+    "redis": "^3.0.2",
     "swagger-jsdoc": "^4.0.0",
     "swagger-ui-express": "^4.1.4",
     "validator": "^13.1.1"

--- a/services/backend/src/auth/keycloak.js
+++ b/services/backend/src/auth/keycloak.js
@@ -1,14 +1,15 @@
 require("dotenv").config();
 
+const redis = require("redis");
 const KeycloakConnect = require("keycloak-connect");
 const session = require("express-session");
+const RedisStore = require("connect-redis")(session);
 
-// Configure session to use memoryStore and Setup keycloak middleware to
-// use the session memoryStore.
-const memoryStore = new session.MemoryStore();
+let redisClient = redis.createClient({ host: "redis" });
+const store = new RedisStore({ client: redisClient });
 
 const keycloak = new KeycloakConnect(
-  { store: memoryStore },
+  { store },
   {
     realm: "individual",
     "bearer-only": true,
@@ -23,7 +24,7 @@ const sessionInstance = session({
   secret: process.env.KEYCLOAK_SECRET,
   resave: false,
   saveUninitialized: true,
-  store: memoryStore,
+  store,
 });
 
 module.exports = { keycloak, sessionInstance };

--- a/services/backend/yarn.lock
+++ b/services/backend/yarn.lock
@@ -1536,6 +1536,11 @@ confusing-browser-globals@^1.0.9:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz#72bc13b483c0276801681871d4898516f8f54fdd"
   integrity sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==
 
+connect-redis@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-4.0.4.tgz#b194abe2f3754551f38086e1a28cb9e68d6c3b28"
+  integrity sha512-aXk7btMlG0J5LqtPNRpFKa5fglzlTzukYNx+Fq8cghbUIQHN/gyK9c3+b0XEROMwiSxMoZDADqjp9tdpUoZLAg==
+
 contains-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
@@ -1788,6 +1793,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+denque@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/denque/-/denque-1.4.1.tgz#6744ff7641c148c3f8a69c307e51235c1f4a37cf"
+  integrity sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==
 
 depd@~1.1.2:
   version "1.1.2"
@@ -4865,6 +4875,33 @@ readdirp@~3.4.0:
   integrity sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==
   dependencies:
     picomatch "^2.2.1"
+
+redis-commands@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.5.0.tgz#80d2e20698fe688f227127ff9e5164a7dd17e785"
+  integrity sha512-6KxamqpZ468MeQC3bkWmCB1fp56XL64D4Kf0zJSwDZbVLLm7KFkoIcHrgRvQ+sk8dnhySs7+yBg94yIkAK7aJg==
+
+redis-errors@^1.0.0, redis-errors@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/redis-errors/-/redis-errors-1.2.0.tgz#eb62d2adb15e4eaf4610c04afe1529384250abad"
+  integrity sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=
+
+redis-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-3.0.0.tgz#b66d828cdcafe6b4b8a428a7def4c6bcac31c8b4"
+  integrity sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=
+  dependencies:
+    redis-errors "^1.0.0"
+
+redis@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-3.0.2.tgz#bd47067b8a4a3e6a2e556e57f71cc82c7360150a"
+  integrity sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==
+  dependencies:
+    denque "^1.4.1"
+    redis-commands "^1.5.0"
+    redis-errors "^1.2.0"
+    redis-parser "^3.0.0"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"

--- a/services/frontend-v3/Dockerfile
+++ b/services/frontend-v3/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:12-alpine
 
 ENV TZ=America/Toronto
 
@@ -11,10 +11,6 @@ RUN yarn install
 
 COPY . .
 
-# RUN npm run build
-
 EXPOSE 3000
-
-# CMD ["npm", "run", "deploy"]
 
 CMD ["yarn", "start"]


### PR DESCRIPTION
### Changes
- Changed based docker images to all use the alpine version (which is smaller, and less vulnerable) ex: 
_before_ >
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/22248828/86496922-69993080-bd4d-11ea-8206-40f9de64b0e9.png)
_after_ >
![image](https://user-images.githubusercontent.com/22248828/86496936-761d8900-bd4d-11ea-96b7-2145a78ecd0d.png)
- Added redis session management
- Properly using volumes and networks (instead of needlessly exposing ports)

closes #447