### PR TITLE
[Fix] Added redis password and removed dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REDIS_PASSWORD=[can be anything you want]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - backend-node-modules:/upskill-backend/node_modules
     env_file:
       - ./env/backend.env
+      - .env
     networks:
       - redis-net
       - postgres-net
@@ -44,7 +45,7 @@ services:
   redis:
     container_name: "upskill-redis-session"
     image: "redis:6-alpine"
-    command: ["redis-server"]
+    command: "redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}"
     hostname: redis
     restart: always
     networks:

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -25,7 +25,6 @@
     "concurrently": "^5.2.0",
     "connect-redis": "^4.0.4",
     "cross-env": "^7.0.2",
-    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.1",
     "express-validator": "^6.6.0",

--- a/services/backend/src/auth/keycloak.js
+++ b/services/backend/src/auth/keycloak.js
@@ -1,5 +1,3 @@
-require("dotenv").config();
-
 const redis = require("redis");
 const KeycloakConnect = require("keycloak-connect");
 const session = require("express-session");

--- a/services/backend/src/auth/keycloak.js
+++ b/services/backend/src/auth/keycloak.js
@@ -5,7 +5,10 @@ const KeycloakConnect = require("keycloak-connect");
 const session = require("express-session");
 const RedisStore = require("connect-redis")(session);
 
-let redisClient = redis.createClient({ host: "redis" });
+let redisClient = redis.createClient({
+  host: "redis",
+  auth_pass: process.env.REDIS_PASSWORD,
+});
 const store = new RedisStore({ client: redisClient });
 
 const keycloak = new KeycloakConnect(

--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -1,6 +1,5 @@
 const axios = require("axios");
 const prisma = require("../../database");
-require("dotenv").config();
 
 async function getGedsAssist(request, response) {
   const { id } = request.params;

--- a/services/backend/src/server.js
+++ b/services/backend/src/server.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const bodyParser = require("body-parser");
-const dotenv = require("dotenv");
 const swaggerUi = require("swagger-ui-express");
 const { keycloak, sessionInstance } = require("./auth/keycloak");
 const router = require("./router/router");
@@ -9,8 +8,6 @@ const swaggerOptions = require("./docs/swaggerOptions");
 const app = express();
 
 const port = process.env.PORT || 8080;
-
-dotenv.config();
 
 app.use(sessionInstance);
 

--- a/services/backend/tests/globalSetup.js
+++ b/services/backend/tests/globalSetup.js
@@ -1,3 +1,1 @@
-module.exports = async () => {
-  require("dotenv").config();
-};
+module.exports = async () => {};

--- a/services/backend/yarn.lock
+++ b/services/backend/yarn.lock
@@ -1860,11 +1860,6 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
-
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
- Added redis password for openshift (it needs one), so I also added one locally
- Removed dotenv package since docker-compose already injects the environment variables from the env files into node

related to #447 and #458 

Added new .env file at root level of the project (to have access to the env variable in docker compose file itself)