### PR TITLE
[Fix] Removed hover from admin dashboard stats/graph cards 

### DIFF
--- a/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
+++ b/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
@@ -24,7 +24,7 @@ const DashboardGraphsView = ({
       alias: intl.formatMessage({
         id: "admin.dashboard.number.of.occurrences",
       }),
-      tickInterval:1,
+      tickInterval: 1,
     },
   };
 
@@ -33,7 +33,7 @@ const DashboardGraphsView = ({
       alias: intl.formatMessage({
         id: "admin.dashboard.number.of.occurrences",
       }),
-      tickInterval:1,
+      tickInterval: 1,
     },
   };
 
@@ -42,7 +42,7 @@ const DashboardGraphsView = ({
       alias: intl.formatMessage({
         id: "admin.dashboard.number.of.occurrences",
       }),
-      tickInterval:1,
+      tickInterval: 1,
     },
   };
 
@@ -60,7 +60,6 @@ const DashboardGraphsView = ({
       <Row gutter={[8, 8]}>
         <Col span={8}>
           <Card
-            hoverable
             title={<FormattedMessage id="admin.dashboard.popular.skills" />}
             loading={topFiveSkills.length === 0}
           >
@@ -81,7 +80,6 @@ const DashboardGraphsView = ({
         </Col>
         <Col span={8}>
           <Card
-            hoverable
             title={
               <FormattedMessage id="admin.dashboard.popular.competencies" />
             }
@@ -104,7 +102,6 @@ const DashboardGraphsView = ({
         </Col>
         <Col span={8}>
           <Card
-            hoverable
             title={
               <FormattedMessage id="admin.dashboard.popular.development.goals" />
             }
@@ -129,7 +126,6 @@ const DashboardGraphsView = ({
       <Row gutter={[8, 8]}>
         <Col span={24}>
           <Card
-            hoverable
             title={
               <FormattedMessage id="admin.dashboard.growth.rate.by.month" />
             }

--- a/services/frontend-v3/src/components/admin/statCards/StatCardsView.jsx
+++ b/services/frontend-v3/src/components/admin/statCards/StatCardsView.jsx
@@ -29,7 +29,7 @@ const StatCardsView = ({
   return (
     <Row gutter={[8, 8]} type="flex">
       <Col span={4}>
-        <Card hoverable style={{ height: "100%" }} loading={countUsers === "-"}>
+        <Card style={{ height: "100%" }} loading={countUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.total.users" />}
             value={countUsers}
@@ -39,11 +39,7 @@ const StatCardsView = ({
         </Card>
       </Col>
       <Col span={4}>
-        <Card
-          hoverable
-          style={{ height: "100%" }}
-          loading={countInactiveUsers === "-"}
-        >
+        <Card style={{ height: "100%" }} loading={countInactiveUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.inactive.users" />}
             value={countInactiveUsers}
@@ -53,11 +49,7 @@ const StatCardsView = ({
         </Card>
       </Col>
       <Col span={4}>
-        <Card
-          hoverable
-          style={{ height: "100%" }}
-          loading={countHiddenUsers === "-"}
-        >
+        <Card style={{ height: "100%" }} loading={countHiddenUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.flagged.profiles" />}
             value={countHiddenUsers}
@@ -67,11 +59,7 @@ const StatCardsView = ({
         </Card>
       </Col>
       <Col span={4}>
-        <Card
-          hoverable
-          style={{ height: "100%" }}
-          loading={countExFeederUsers === "-"}
-        >
+        <Card style={{ height: "100%" }} loading={countExFeederUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.ex.feeders" />}
             value={countExFeederUsers}
@@ -81,7 +69,7 @@ const StatCardsView = ({
         </Card>
       </Col>
       <Col span={4}>
-        <Card hoverable style={{ height: "100%" }} loading={newUsers === "-"}>
+        <Card style={{ height: "100%" }} loading={newUsers === "-"}>
           <Statistic
             title={`${intl.formatMessage({
               id: "admin.dashboard.monthly.added",
@@ -93,11 +81,7 @@ const StatCardsView = ({
         </Card>
       </Col>
       <Col span={4}>
-        <Card
-          hoverable
-          style={{ height: "100%" }}
-          loading={growthRatePrevMonth === "-"}
-        >
+        <Card style={{ height: "100%" }} loading={growthRatePrevMonth === "-"}>
           <Statistic
             title={`${intl.formatMessage({
               id: "admin.dashboard.growth.rate.percentage",


### PR DESCRIPTION
- Removed "hoverable" attrbitute from cards on admin dashboard since they were confusing users with a clickable card