### PR TITLE
[Feat] Improve loading screens

### DIFF
--- a/services/frontend-v3/src/components/layouts/appLayout/AppLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/AppLayout.jsx
@@ -2,11 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import AppLayoutView from "./AppLayoutView";
 
-const AppLayout = ({ displaySideBar, sideBarContent, children }) => {
+const AppLayout = ({ displaySideBar, sideBarContent, children, loading }) => {
   return (
     <AppLayoutView
       displaySideBar={displaySideBar}
       sideBarContent={sideBarContent}
+      loading={loading}
     >
       {children}
     </AppLayoutView>
@@ -17,10 +18,12 @@ AppLayout.propTypes = {
   children: PropTypes.node.isRequired,
   sideBarContent: PropTypes.node,
   displaySideBar: PropTypes.bool.isRequired,
+  loading: PropTypes.bool,
 };
 
 AppLayout.defaultProps = {
   sideBarContent: undefined,
+  loading: false,
 };
 
 export default AppLayout;

--- a/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.jsx
@@ -1,12 +1,17 @@
 import React from "react";
-import { Layout } from "antd";
+import { Layout, Skeleton, Card } from "antd";
 import PropTypes from "prop-types";
 import TopNav from "./topNav/TopNav";
 import SideNav from "../../sideNav/SideNav";
 
 const { Content } = Layout;
 
-const AppLayoutView = ({ sideBarContent, displaySideBar, children }) => {
+const AppLayoutView = ({
+  sideBarContent,
+  displaySideBar,
+  children,
+  loading,
+}) => {
   const styles = {
     contentLayout: {
       marginTop: "64px",
@@ -21,16 +26,25 @@ const AppLayoutView = ({ sideBarContent, displaySideBar, children }) => {
   return (
     <Layout style={{ minHeight: "100vh" }}>
       {/* Render Top Navigation Bar */}
-      <TopNav />
+      <TopNav loading={loading} />
       <Layout style={{ marginTop: 64 }}>
         {/* Render Side Navigation Bar */}
         <SideNav
           sideBarContent={sideBarContent}
           displaySideBar={displaySideBar}
+          loading={loading}
         />
         {/* Render content */}
         <Layout>
-          <Content style={styles.content}>{children}</Content>
+          <Content style={styles.content}>
+            {loading ? (
+              <Card>
+                <Skeleton />
+              </Card>
+            ) : (
+              children
+            )}
+          </Content>
         </Layout>
       </Layout>
     </Layout>
@@ -41,6 +55,7 @@ AppLayoutView.propTypes = {
   sideBarContent: PropTypes.node,
   displaySideBar: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 AppLayoutView.defaultProps = {

--- a/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNav.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNav.jsx
@@ -1,11 +1,16 @@
 import React from "react";
+import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 import TopNavView from "./TopNavView";
 
-const TopNav = () => {
+const TopNav = ({ loading }) => {
   const { isAdmin } = useSelector((state) => state.user);
 
-  return <TopNavView isAdmin={isAdmin}/>;
+  return <TopNavView isAdmin={isAdmin} loading={loading} />;
+};
+
+TopNav.propTypes = {
+  loading: PropTypes.bool.isRequired,
 };
 
 export default TopNav;

--- a/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
+++ b/services/frontend-v3/src/components/layouts/appLayout/topNav/TopNavView.jsx
@@ -8,17 +8,17 @@ import {
   MenuOutlined,
   HomeOutlined,
 } from "@ant-design/icons";
+import PropTypes from "prop-types";
 import { Layout, Dropdown, Menu, Button } from "antd";
 import { FormattedMessage } from "react-intl";
 import { useSelector } from "react-redux";
-import PropTypes from "prop-types";
 import ChangeLanguage from "../../../changeLanguage/ChangeLanguage";
 import CustomAvatar from "../../../customAvatar/CustomAvatar";
 import Logo from "../../../../assets/MyTalent-Logo-Full-v2.svg";
 
 const { Header } = Layout;
 
-const TopNavView = ({ isAdmin }) => {
+const TopNavView = ({ isAdmin, loading }) => {
   /* Component Styles */
   const styles = {
     header: {
@@ -169,6 +169,16 @@ const TopNavView = ({ isAdmin }) => {
     );
   };
 
+  if (loading) {
+    return (
+      <Header style={styles.header}>
+        <div style={styles.aroundNavContent}>
+          <img src={Logo} alt="I-Talent Logo" style={styles.navBrand} />
+        </div>
+      </Header>
+    );
+  }
+
   if (windowWidth > 400) {
     return (
       <Header style={styles.header}>
@@ -205,6 +215,7 @@ const TopNavView = ({ isAdmin }) => {
 
 TopNavView.propTypes = {
   isAdmin: PropTypes.bool.isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 export default TopNavView;

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayout.jsx
@@ -1,18 +1,21 @@
 import React from "react";
+import PropTypes from "prop-types";
 import ProfileLayoutView from "./ProfileLayoutView";
 
 import { ProfileInfoPropType } from "../../../customPropTypes";
 
-const ProfileLayout = ({ data }) => {
-  return <ProfileLayoutView data={data} />;
+const ProfileLayout = ({ data, loading }) => {
+  return <ProfileLayoutView data={data} loading={loading} />;
 };
 
 ProfileLayout.propTypes = {
   data: ProfileInfoPropType,
+  loading: PropTypes.bool,
 };
 
 ProfileLayout.defaultProps = {
   data: null,
+  loading: null,
 };
 
 export default ProfileLayout;

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -18,6 +18,7 @@ import {
   TeamOutlined,
 } from "@ant-design/icons";
 import { useSelector } from "react-redux";
+import PropTypes from "prop-types";
 import axios from "../../../axios-instance";
 import AppLayout from "../appLayout/AppLayout";
 import { ProfileInfoPropType } from "../../../customPropTypes";
@@ -43,7 +44,7 @@ import handleError from "../../../functions/handleError";
 const { Link } = Anchor;
 const { Title, Text } = Typography;
 
-const ProfileLayoutView = ({ data }) => {
+const ProfileLayoutView = ({ data, loading }) => {
   const [friends, setFriends] = useState(true);
 
   // useParams returns an object of key/value pairs from URL parameters
@@ -773,7 +774,11 @@ const ProfileLayoutView = ({ data }) => {
   };
 
   return (
-    <AppLayout sideBarContent={generateProfileSidebarContent()} displaySideBar>
+    <AppLayout
+      sideBarContent={generateProfileSidebarContent()}
+      displaySideBar
+      loading={loading}
+    >
       <PageHeader
         style={{
           padding: "0 0 15px 7px",
@@ -792,10 +797,12 @@ const ProfileLayoutView = ({ data }) => {
 
 ProfileLayoutView.propTypes = {
   data: ProfileInfoPropType,
+  loading: PropTypes.bool,
 };
 
 ProfileLayoutView.defaultProps = {
   data: null,
+  loading: null,
 };
 
 export default ProfileLayoutView;

--- a/services/frontend-v3/src/components/profileSkeleton/ProfileSkeleton.jsx
+++ b/services/frontend-v3/src/components/profileSkeleton/ProfileSkeleton.jsx
@@ -1,8 +1,0 @@
-import React from "react";
-import ProfileSkeletonView from "./profileSkeletonView";
-
-const ProfileSkeleton = () => {
-  return <ProfileSkeletonView active />;
-}
-
-export default ProfileSkeleton;

--- a/services/frontend-v3/src/components/profileSkeleton/profileSkeletonView.jsx
+++ b/services/frontend-v3/src/components/profileSkeleton/profileSkeletonView.jsx
@@ -1,8 +1,0 @@
-import React from "react";
-import { Skeleton } from "antd";
-
-const ProfileSkeletonView = () => {
-  return <Skeleton active />;
-}
-
-export default ProfileSkeletonView;

--- a/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCard.jsx
@@ -6,14 +6,13 @@ import { useHistory } from "react-router-dom";
 import { FormattedMessage } from "react-intl";
 import { Row } from "antd";
 import axios from "../../axios-instance";
-import ProfileSkeleton from "../profileSkeleton/ProfileSkeleton";
 
 import ResultsCardView from "./ResultsCardView";
 import handleError from "../../functions/handleError";
 import { ReactComponent as YourSvg } from "./online_team_meeting_.svg";
 
 const ResultsCard = () => {
-  const [results, setResults] = useState(null);
+  const [results, setResults] = useState(undefined);
   const { locale } = useSelector((state) => state.settings);
   const [emptyQuery, setEmptyQuery] = useState(false);
 
@@ -41,10 +40,6 @@ const ResultsCard = () => {
     }
   }, [locale]);
 
-  if (!results && !emptyQuery) {
-    return <ProfileSkeleton />;
-  }
-
   if (emptyQuery) {
     return (
       <>
@@ -53,7 +48,7 @@ const ResultsCard = () => {
         </Row>
         <Row align="middle" justify="center" style={{ marginTop: 20 }}>
           <p style={{ textAlign: "center", maxWidth: 250 }}>
-            <FormattedMessage id="search.empty.query"/>
+            <FormattedMessage id="search.empty.query" />
           </p>
         </Row>
       </>
@@ -61,7 +56,12 @@ const ResultsCard = () => {
   }
 
   return (
-    <ResultsCardView history={history} results={results} locale={locale} />
+    <ResultsCardView
+      history={history}
+      results={results}
+      locale={locale}
+      loading={!results && !emptyQuery}
+    />
   );
 };
 

--- a/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
+++ b/services/frontend-v3/src/components/resultsCard/ResultsCardView.jsx
@@ -1,14 +1,24 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { FormattedMessage } from "react-intl";
-import { Row, Col, Tag, Card, Divider, Avatar, Typography, Empty } from "antd";
+import {
+  Row,
+  Col,
+  Tag,
+  Card,
+  Divider,
+  Avatar,
+  Typography,
+  Empty,
+  Skeleton,
+} from "antd";
 import { HistoryPropType, ProfileInfoPropType } from "../../customPropTypes";
 import prepareInfo from "../../functions/prepareInfo";
 
 const { Meta } = Card;
 const { Text } = Typography;
 
-const ResultsCardView = ({ history, results, locale }) => {
+const ResultsCardView = ({ history, results, locale, loading }) => {
   const styles = {
     smallP: {
       lineHeight: "4px",
@@ -92,7 +102,7 @@ const ResultsCardView = ({ history, results, locale }) => {
   };
 
   const renderResultCards = (dataSource) => {
-    if (dataSource.length === 0) {
+    if (!loading && dataSource.length === 0) {
       return (
         <Empty description={<FormattedMessage id="search.no.results" />} />
       );
@@ -105,13 +115,18 @@ const ResultsCardView = ({ history, results, locale }) => {
 
   return (
     <div>
+      {loading && (
+        <Card>
+          <Skeleton />
+        </Card>
+      )}
       <Row
-        gutter={[16, 16]}
+        gutter={[32, 32]}
         type="flex"
         justify="left"
         align={results.length === 0 ? "center" : "top"}
       >
-        {renderResultCards(results)}
+        {!loading && renderResultCards(results)}
       </Row>
     </div>
   );
@@ -121,10 +136,11 @@ ResultsCardView.propTypes = {
   history: HistoryPropType.isRequired,
   results: PropTypes.arrayOf(ProfileInfoPropType),
   locale: PropTypes.oneOf(["FRENCH", "ENGLISH"]).isRequired,
+  loading: PropTypes.bool.isRequired,
 };
 
 ResultsCardView.defaultProps = {
-  results: null,
+  results: [],
 };
 
 export default ResultsCardView;

--- a/services/frontend-v3/src/components/sideNav/SideNav.jsx
+++ b/services/frontend-v3/src/components/sideNav/SideNav.jsx
@@ -2,11 +2,12 @@ import React from "react";
 import PropTypes from "prop-types";
 import SideNavView from "./SideNavView";
 
-const SideNav = ({ sideBarContent, displaySideBar }) => {
+const SideNav = ({ sideBarContent, displaySideBar, loading }) => {
   return (
     <SideNavView
       sideBarContent={sideBarContent}
       displaySideBar={displaySideBar}
+      loading={loading}
     />
   );
 };
@@ -14,6 +15,7 @@ const SideNav = ({ sideBarContent, displaySideBar }) => {
 SideNav.propTypes = {
   displaySideBar: PropTypes.bool.isRequired,
   sideBarContent: PropTypes.node,
+  loading: PropTypes.bool.isRequired,
 };
 
 SideNav.defaultProps = {

--- a/services/frontend-v3/src/components/sideNav/SideNavView.jsx
+++ b/services/frontend-v3/src/components/sideNav/SideNavView.jsx
@@ -1,10 +1,10 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { Affix, Layout } from "antd";
+import { Affix, Layout, Skeleton } from "antd";
 
 const { Sider } = Layout;
 
-const SideNavView = ({ displaySideBar, sideBarContent }) => {
+const SideNavView = ({ displaySideBar, sideBarContent, loading }) => {
   /* Component Styles */
   const styles = {
     siderDiv: {
@@ -31,7 +31,13 @@ const SideNavView = ({ displaySideBar, sideBarContent }) => {
           zeroWidthTriggerStyle={{ backgroundColor: "#192e2f" }}
         >
           {/* render content of side bar */}
-          {sideBarContent}
+          {loading ? (
+            <div style={{ margin: 32 }}>
+              <Skeleton />
+            </div>
+          ) : (
+            sideBarContent
+          )}
         </Sider>
       </Affix>
     );
@@ -42,10 +48,12 @@ const SideNavView = ({ displaySideBar, sideBarContent }) => {
 SideNavView.propTypes = {
   displaySideBar: PropTypes.bool.isRequired,
   sideBarContent: PropTypes.node,
+  loading: PropTypes.bool,
 };
 
 SideNavView.defaultProps = {
   sideBarContent: undefined,
+  loading: false,
 };
 
 export default SideNavView;

--- a/services/frontend-v3/src/pages/Profile.jsx
+++ b/services/frontend-v3/src/pages/Profile.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 import axios from "../axios-instance";
 import handleError from "../functions/handleError";
-import ProfileSkeleton from "../components/profileSkeleton/ProfileSkeleton";
 import ProfileLayout from "../components/layouts/profileLayout/ProfileLayout";
 
 const Profile = ({ history, match }) => {
@@ -69,11 +68,7 @@ const Profile = ({ history, match }) => {
     document.title = `${name} | I-Talent`;
   }, [name]);
 
-  if (!loading) {
-    return <ProfileLayout data={data} />;
-  }
-
-  return <ProfileSkeleton />;
+  return <ProfileLayout data={data} loading={loading} />;
 };
 
 Profile.propTypes = {

--- a/services/frontend-v3/src/routes/Secured.jsx
+++ b/services/frontend-v3/src/routes/Secured.jsx
@@ -16,6 +16,7 @@ import {
 import keycloakConfig from "../keycloak";
 import { setUser, setUserIsAdmin } from "../redux/slices/userSlice";
 import { setLocale } from "../redux/slices/settingsSlice";
+import AppLayout from "../components/layouts/appLayout/AppLayout";
 
 const { keycloakJSONConfig } = keycloakConfig;
 
@@ -115,7 +116,7 @@ const Secured = ({ location }) => {
   }, [dispatch, profileExist]);
 
   if (!keycloak) {
-    return null;
+    return <AppLayout loading/>;
   }
 
   if (!authenticated) {


### PR DESCRIPTION
- AppLayout and NavBar handles the logic for the loading of the page
  - Do not flash the screen white
  - Keep the navbar present (just not clickable)
  - Show card with loading skeleton
  - If AppLayout has a sidebar, show skeleton inside of it

Since AppLayout takes care of loading, ProfileSkeleton is not needed anymore. Also, this is just a generic load/skeleton, in the future, we could make it so that it resembles the actual layout (like we are doing in admin)

Preview:
![Peek 2020-07-10 15-59](https://user-images.githubusercontent.com/22248828/87201637-ff443b00-c2cc-11ea-8869-e229804090c1.gif)

closes #520