### PR TITLE
[Fix] Subform toggles

### DIFF
--- a/services/backend/src/core/profile/profile.js
+++ b/services/backend/src/core/profile/profile.js
@@ -4,6 +4,10 @@ const _ = require("lodash");
 const prisma = require("../../database");
 
 function normalizeDate(date, startOf) {
+  if (date === null) {
+    return date;
+  }
+
   return date ? moment.utc(date).startOf(startOf).toISOString() : undefined;
 }
 

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -379,16 +379,18 @@ const EmploymentDataFormView = (props) => {
               label={<FormattedMessage id="profile.acting.period.end.date" />}
               rules={enableEndDate ? [Rules.required] : undefined}
             >
-              <DatePicker
-                style={styles.datePicker}
-                disabledDate={disabledDatesBeforeStart}
-                disabled={!enableEndDate}
+              {enableEndDate && (
+                <DatePicker
+                  style={styles.datePicker}
+                  disabledDate={disabledDatesBeforeStart}
+                  disabled={!enableEndDate}
                   placeholder={intl.formatMessage({
                     id: "profile.select.date",
                   })}
                 />
+              )}
             </Form.Item>
-            <div style={{ marginTop: "-10px" }}>
+            <div style={{ marginTop: !enableEndDate ? "-38px" : "-10px" }}>
               <Checkbox
                 tabIndex="0"
                 onChange={toggleTempEndDate}

--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -367,6 +367,9 @@ const EmploymentDataFormView = (props) => {
               <DatePicker
                 disabledDate={disabledDatesAfterEnd}
                 style={styles.datePicker}
+                placeholder={intl.formatMessage({
+                  id: "profile.select.date",
+                })}
               />
             </Form.Item>
           </Col>
@@ -380,8 +383,10 @@ const EmploymentDataFormView = (props) => {
                 style={styles.datePicker}
                 disabledDate={disabledDatesBeforeStart}
                 disabled={!enableEndDate}
-                placeholder="unknown"
-              />
+                  placeholder={intl.formatMessage({
+                    id: "profile.select.date",
+                  })}
+                />
             </Form.Item>
             <div style={{ marginTop: "-10px" }}>
               <Checkbox

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -233,13 +233,7 @@ const LangProficiencyFormView = ({
 
   /* toggle temporary role form */
   const toggleSecLangForm = () => {
-    setDisplayMentorshipForm((prev) => {
-      const data = savedValues || getInitialValues(profileInfo);
-      setFieldsChanged(
-        (!data.oralProficiency && !prev) || (data.oralProficiency && prev)
-      );
-      return !prev;
-    });
+    setDisplayMentorshipForm((prev) => !prev);
   };
 
   /**
@@ -249,12 +243,20 @@ const LangProficiencyFormView = ({
    */
   const checkIfFormValuesChanged = () => {
     const formValues = _.pickBy(form.getFieldsValue(), _.identity);
+    if (_.isEmpty(formValues)) {
+      return false;
+    }
+
     const dbValues = _.pickBy(
       savedValues || getInitialValues(profileInfo),
       _.identity
     );
 
-    setFieldsChanged(!_.isEqual(formValues, dbValues));
+    return !_.isEqual(formValues, dbValues);
+  };
+
+  const updateIfFormValuesChanged = () => {
+    setFieldsChanged(checkIfFormValuesChanged());
   };
 
   /* save and show success notification */
@@ -328,6 +330,16 @@ const LangProficiencyFormView = ({
     setDisplayMentorshipForm(data.oralProficiency);
     setFieldsChanged(false);
   };
+
+  // Updates the unsaved indicator based on the toggle and form values
+  useEffect(() => {
+    const data = savedValues || getInitialValues(profileInfo);
+    const oppositeInitialToggle =
+      !!data.oralProficiency !== displayMentorshipForm;
+
+    setFieldsChanged(oppositeInitialToggle || checkIfFormValuesChanged());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayMentorshipForm]);
 
   /*
    * Get Form Control Buttons
@@ -583,7 +595,7 @@ const LangProficiencyFormView = ({
         form={form}
         initialValues={savedValues || getInitialValues(profileInfo)}
         layout="vertical"
-        onValuesChange={checkIfFormValuesChanged}
+        onValuesChange={updateIfFormValuesChanged}
       >
         {/* Form Row One */}
         <Row gutter={24}>

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -133,7 +133,7 @@ const TalentFormView = ({
    * toggle state that controls mentorship form visibility
    */
   const toggleMentorshipForm = () => {
-    setDisplayMentorshipForm(!displayMentorshipForm);
+    setDisplayMentorshipForm((prev) => !prev);
   };
 
   /*
@@ -198,12 +198,28 @@ const TalentFormView = ({
    */
   const checkIfFormValuesChanged = () => {
     const formValues = _.pickBy(form.getFieldsValue(), _.identity);
+    if (_.isEmpty(formValues)) {
+      return false;
+    }
+
     const dbValues = _.pickBy(
       savedValues || getInitialValues(profileInfo),
       _.identity
     );
 
-    setFieldsChanged(!_.isEqual(formValues, dbValues));
+    // Cleans up the object for following comparison
+    if (
+      formValues.mentorshipSkills === undefined &&
+      dbValues.mentorshipSkills.length === 0
+    ) {
+      delete dbValues.mentorshipSkills;
+    }
+
+    return !_.isEqual(formValues, dbValues);
+  };
+
+  const updateIfFormValuesChanged = () => {
+    setFieldsChanged(checkIfFormValuesChanged());
   };
 
   /* save and show success notification */
@@ -287,7 +303,7 @@ const TalentFormView = ({
     // reset mentorship toggle switch
     setDisplayMentorshipForm(savedMentorshipSkills.length > 0);
     message.info(intl.formatMessage({ id: "profile.form.clear" }));
-    checkIfFormValuesChanged();
+    updateIfFormValuesChanged();
   };
 
   /*
@@ -480,6 +496,15 @@ const TalentFormView = ({
     }
   }, [load, form, savedMentorshipSkills, skillOptions, savedSkills]);
 
+  // Updates the unsaved indicator based on the toggle and form values
+  useEffect(() => {
+    const oppositeInitialToggle =
+      savedMentorshipSkills.length > 0 !== displayMentorshipForm;
+
+    setFieldsChanged(oppositeInitialToggle || checkIfFormValuesChanged());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayMentorshipForm]);
+
   /*
    * Get Form Control Buttons
    *
@@ -585,7 +610,7 @@ const TalentFormView = ({
         form={form}
         initialValues={savedValues || getInitialValues(profileInfo)}
         layout="vertical"
-        onValuesChange={checkIfFormValuesChanged}
+        onValuesChange={updateIfFormValuesChanged}
       >
         {/* Form Row One:competencies */}
         <Row gutter={24}>

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -354,6 +354,7 @@
   "profile.form.clear": "Changes cleared",
   "profile.form.unsaved": "unsaved",
   "profile.qualifications.select.month": "Select month",
+  "profile.select.date": "Select date",
 
   "profile.career.interests": "Job mobility",
 

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -329,6 +329,7 @@
   "profile.form.clear": "Changements effacé",
   "profile.form.unsaved": "non enregistré",
   "profile.qualifications.select.month": "Sélectionner un mois",
+  "profile.select.date": "Sélectionner une date",
 
   "profile.visibility.show.confirm": "Êtes-vous certain de vouloir rendre cette carte visible sur votre profil public?",
   "profile.visibility.hide.confirm": "Êtes-vous certain de masquer cette carte de votre profil public? (Sera aussi visible pour les ressources humaines)",


### PR DESCRIPTION
- Fixed subforms unsaved indicator toggle for mentorship skills, acting, and OL forms (just needed to update the indicator based on the switch)
- Fixed removing actingEndDate and actingStartDate if removed in the frontend
- Made datepicker in acting subform act like the ones in experience and education (see below)

Before
![image](https://user-images.githubusercontent.com/22248828/87306844-9f28e100-c4e6-11ea-9a84-b1a5b4b115de.png)
After
![image](https://user-images.githubusercontent.com/22248828/87306781-86203000-c4e6-11ea-8491-27631964a144.png)

fixes #418