### PR TITLE
[Fix] Changed 'select' placeholder on select dropdowns to 'search' placeholder

### DIFF
--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -195,7 +195,7 @@
   "setup.projects": "Projects",
   "setup.projects.placeholder": "press enter to add",
   "setup.teams.placeholder": "press enter to add",
-  "setup.select": "Select",
+  "setup.select": "Search",
   "setup.career.interests": "Job mobility",
   "setup.save.and.finish": "Save and finish",
   "setup.save.and.next": "Save and next",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -204,7 +204,7 @@
   "setup.projects": "Projets",
   "setup.projects.placeholder": "appuyez sur la touche d'entrée pour ajouter",
   "setup.teams.placeholder": "appuyez sur la touche d'entrée pour ajouter",
-  "setup.select": "Sélectionner",
+  "setup.select": "Rechercher",
   "setup.career.interests": "Mobilité de l'emploi",
   "setup.save.and.finish": "Enregistrer et terminer",
   "setup.save.and.next": "Enregistrer et suivant",


### PR DESCRIPTION
- Changed French and English translations for placeholders in Select dropdowns to say "search" or "rechercher" instead of "select" or "selectionner".