### PR TITLE
[fix] re-add db-postgres port mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,8 @@ services:
       POSTGRES_DB: testdb
     networks:
       - postgres-net
+    ports:
+      - "5432:5432"
 
   redis:
     container_name: "upskill-redis-session"


### PR DESCRIPTION
Reads the port mapping needed for the postgres container to allow it to be accessed by PgAdmin