### PR TITLE
[Fix] Admin delete disabled button and overlay size

### DIFF
--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -333,6 +333,7 @@ const CategoryTableView = ({
           checkDelete().catch((error) => handleError(error, "message"));
         }}
         onCancel={popUpCancel}
+        disabled={selectedRowKeys.length === 0}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -334,6 +334,7 @@ const CategoryTableView = ({
         }}
         onCancel={popUpCancel}
         disabled={selectedRowKeys.length === 0}
+        overlayStyle={{ maxWidth: 350 }}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -165,6 +165,7 @@ const CompetencyTableView = ({
           popUpCancel();
         }}
         disabled={selectedRowKeys.length === 0}
+        overlayStyle={{ maxWidth: 350 }}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -164,6 +164,7 @@ const CompetencyTableView = ({
         onCancel={() => {
           popUpCancel();
         }}
+        disabled={selectedRowKeys.length === 0}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -165,6 +165,7 @@ const DiplomaTableView = ({
         onCancel={() => {
           popUpCancel();
         }}
+        disabled={selectedRowKeys.length === 0}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -166,6 +166,7 @@ const DiplomaTableView = ({
           popUpCancel();
         }}
         disabled={selectedRowKeys.length === 0}
+        overlayStyle={{ maxWidth: 350 }}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -194,6 +194,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
         onCancel={() => {
           popUpCancel();
         }}
+        disabled={selectedRowKeys.length === 0}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -195,6 +195,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
           popUpCancel();
         }}
         disabled={selectedRowKeys.length === 0}
+        overlayStyle={{ maxWidth: 350 }}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -222,6 +222,7 @@ const SkillTableView = ({
           popUpCancel();
         }}
         disabled={selectedRowKeys.length === 0}
+        overlayStyle={{ maxWidth: 350 }}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -221,6 +221,7 @@ const SkillTableView = ({
         onCancel={() => {
           popUpCancel();
         }}
+        disabled={selectedRowKeys.length === 0}
       >
         <Button type="primary" disabled={selectedRowKeys.length === 0}>
           <DeleteOutlined style={{ marginRight: 10 }} />

--- a/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTable.jsx
@@ -20,6 +20,7 @@ function UserTable({ intl }) {
   const [statuses, setStatuses] = useState({});
   const [searchText, setSearchText] = useState("");
   const [searchedColumn, setSearchedColumn] = useState("");
+  const [modifiedStatus, setModifiedStatus] = useState(false);
   const axios = useAxios();
 
   const { locale } = useSelector((state) => state.settings);
@@ -91,7 +92,13 @@ function UserTable({ intl }) {
   const handleDropdownChange = (status, id) => {
     const addStatus = statuses;
 
-    addStatus[id] = status;
+    if (status) {
+      addStatus[id] = status;
+    } else {
+      delete addStatus[id];
+    }
+
+    setModifiedStatus(Object.keys(addStatus).length > 0);
 
     setStatuses(addStatus);
   };
@@ -141,6 +148,7 @@ function UserTable({ intl }) {
       profileStatusValue={profileStatusValue}
       handleSearch={handleSearch}
       handleReset={handleReset}
+      modifiedStatus={modifiedStatus}
     />
   );
 }

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -40,6 +40,7 @@ const UserTableView = ({
   profileStatusValue,
   handleSearch,
   handleReset,
+  modifiedStatus,
 }) => {
   let searchInput;
 
@@ -125,7 +126,9 @@ const UserTableView = ({
           defaultValue={profileStatusValue(status)}
           style={{ width: 120 }}
           onChange={(value) => {
-            handleDropdownChange(value, id);
+            const user = data.find(({ key }) => key === id);
+            const valueToBeSaved = value === user.status ? undefined : value;
+            handleDropdownChange(valueToBeSaved, id);
           }}
         >
           <Option key="active" value="ACTIVE">
@@ -176,8 +179,9 @@ const UserTableView = ({
         onCancel={() => {
           popUpCancel();
         }}
+        disabled={!modifiedStatus}
       >
-        <Button type="primary">
+        <Button type="primary" disabled={!modifiedStatus}>
           <CheckCircleOutlined style={{ marginRight: 10 }} />
           <FormattedMessage id="admin.apply" />
         </Button>
@@ -365,6 +369,7 @@ UserTableView.propTypes = {
   profileStatusValue: PropTypes.func.isRequired,
   searchedColumn: PropTypes.string.isRequired,
   searchText: PropTypes.string.isRequired,
+  modifiedStatus: PropTypes.bool.isRequired,
 };
 
 UserTableView.defaultProps = {


### PR DESCRIPTION
Added a disabled prop to the delete button popover and a max width to its overlay
Disabled apply button in the user table if the statuses has not been modified
fixes #610
