### PR TITLE
[Fix] Handling of non-existent routes

### DIFF
--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
@@ -1,7 +1,7 @@
 import React from "react";
-import {  Steps } from "antd";
+import { Steps } from "antd";
 import { FormattedMessage } from "react-intl";
-import { useHistory } from "react-router-dom";
+import { useHistory, Redirect } from "react-router-dom";
 import PropTypes from "prop-types";
 import AppLayout from "../appLayout/AppLayout";
 import {
@@ -83,7 +83,7 @@ const CreateProfileLayoutView = ({ formStep, highestStep }) => {
       case 8:
         return <DoneSetup formType="create" />;
       default:
-        return <div>Hello</div>;
+        return <Redirect to={`/profile/create/step/${highestStep}`} />;
     }
   };
 

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
@@ -3,6 +3,7 @@ import { Menu } from "antd";
 import { RightOutlined } from "@ant-design/icons";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
+import { Redirect } from "react-router";
 import AppLayout from "../appLayout/AppLayout";
 import { HistoryPropType } from "../../../utils/customPropTypes";
 import {
@@ -40,7 +41,7 @@ const EditProfileLayoutView = ({ formStep, history }) => {
       case "qualifications":
         return <QualificationsForm formType="edit" />;
       default:
-        return <div>Hello</div>;
+        return <Redirect to="/profile/edit/primary-info" />;
     }
   };
 

--- a/services/frontend-v3/src/routes/Admin.jsx
+++ b/services/frontend-v3/src/routes/Admin.jsx
@@ -49,11 +49,6 @@ const Admin = () => {
 
   return (
     <>
-      <Route
-        exact
-        path="/admin/"
-        render={() => <Redirect to="/admin/dashboard" />}
-      />
       <Route exact path="/admin/dashboard" render={() => <AdminDashboard />} />
       <Route exact path="/admin/users" render={() => <AdminUser />} />
       <Route exact path="/admin/skills" render={() => <AdminSkill />} />
@@ -65,6 +60,7 @@ const Admin = () => {
       />
       <Route exact path="/admin/diplomas" render={() => <AdminDiploma />} />
       <Route exact path="/admin/schools" render={() => <AdminSchool />} />
+      <Route path="/admin/" render={() => <Redirect to="/admin/dashboard" />} />
     </>
   );
 };

--- a/services/frontend-v3/src/routes/Secured.jsx
+++ b/services/frontend-v3/src/routes/Secured.jsx
@@ -50,16 +50,38 @@ const Secured = ({ location }) => {
         <Route exact path="/results" render={() => <Results />} />
         <Route
           path="/profile/create/step/:step"
-          render={({ match }) => <ProfileCreate match={match} />}
+          render={({ match }) => {
+            const { step } = match.params;
+
+            if (
+              !Number.isNaN(step) &&
+              parseInt(step, 10) > 0 &&
+              parseInt(step, 10) < 9
+            ) {
+              return <ProfileCreate match={match} />;
+            }
+
+            return <Redirect to={`/profile/create/step/${signupStep}`} />;
+          }}
         />
         <Route
           path="/profile/edit/:step"
           render={({ match }) => <ProfileEdit match={match} />}
         />
         <Route
+          path="/profile/create"
+          render={() => <Redirect to={`/profile/create/step/${signupStep}`} />}
+        />
+        <Route
           path="/profile/:id?"
           render={({ match, history }) => (
             <Profile match={match} history={history} />
+          )}
+        />
+        <Route
+          path="/results"
+          render={({ location }) => (
+            <Redirect to={{ search: location.search, pathname: "/results" }} />
           )}
         />
         <Route render={() => <NotFound />} />

--- a/services/frontend-v3/src/routes/Secured.jsx
+++ b/services/frontend-v3/src/routes/Secured.jsx
@@ -80,8 +80,8 @@ const Secured = ({ location }) => {
         />
         <Route
           path="/results"
-          render={({ location }) => (
-            <Redirect to={{ search: location.search, pathname: "/results" }} />
+          render={({ location: { search } }) => (
+            <Redirect to={{ search, pathname: "/results" }} />
           )}
         />
         <Route render={() => <NotFound />} />


### PR DESCRIPTION
### Changes
- Redirect to `/results` if url starts with results (and keep querystrings)
- Redirect to the proper step if the user is at `/profile/create` or `/profile/create/asdsdas` or `/profile/create/step` or `/profile/create/step/asdfsaf`
- Redirect to `/admin/dashboard` if the user is at `/admin/asdfasfas`
- Redirect to `/profile/edit/primary-info` if user is at `/profile/edit/asdfasfdsa`
- Redirect to `/profile/${userId}` if user is at `/profile` or `/profile/asdfadsf`

fixes #622