### PR TITLE
Fix scrollbar missing after sync geds

### DIFF
--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -575,11 +575,16 @@ const PrimaryInfoFormView = ({
       }
     }
 
+    // Fixes scrollbar disabling after pressing ok button
+    if (!(gatheringGedsData || newGedsValues)) {
+      return undefined;
+    }
+
     return (
       <Modal
         title={<FormattedMessage id="profile.geds.changes" />}
         visible={gatheringGedsData || newGedsValues}
-        onOk={handleGedsConfirm && handleGedsConfirm}
+        onOk={handleGedsConfirm}
         onCancel={() => {
           setNewGedsValues(null);
           setGatheringGedsData(null);


### PR DESCRIPTION
Prevents the scrollbar from disappearing after the user applies syncing geds data