### PR TITLE
[Feat] Developmental goal dropdown

### DIFF
--- a/services/backend/src/core/options/util/developmentalGoals.js
+++ b/services/backend/src/core/options/util/developmentalGoals.js
@@ -26,8 +26,13 @@ async function getDevelopmentalGoals(request, response) {
         language,
       },
       select: {
-        opSkillId: true,
         name: true,
+        opSkill: {
+          select: {
+            id: true,
+            categoryId: true,
+          },
+        },
       },
       orderBy: {
         name: "asc",
@@ -40,8 +45,9 @@ async function getDevelopmentalGoals(request, response) {
     }));
 
     const skills = skillsQuery.map((i) => ({
-      id: i.opSkillId,
+      id: i.opSkill.id,
       name: i.name,
+      categoryId: i.opSkill.categoryId,
     }));
 
     const developmentalGoals = _.sortBy([...competencies, ...skills], "name");

--- a/services/backend/src/router/options/docs.yml
+++ b/services/backend/src/router/options/docs.yml
@@ -63,7 +63,19 @@
       - $ref: "#/definitions/LanguageQuery"
     responses:
       200:
-        $ref: "#/definitions/IdNameArray"
+        schema:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              name:
+                type: string
+              categoryId:
+                type: string
+                format: uuid
       403:
         $ref: "#/definitions/403"
       422:

--- a/services/backend/src/router/options/docs.yml
+++ b/services/backend/src/router/options/docs.yml
@@ -63,6 +63,7 @@
       - $ref: "#/definitions/LanguageQuery"
     responses:
       200:
+        description: Returns a categoryId if the corresponding developmental goal is a skill
         schema:
           type: array
           items:

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -11,6 +11,7 @@ import {
   Checkbox,
   message,
   Popover,
+  TreeSelect,
 } from "antd";
 import {
   RightOutlined,
@@ -37,6 +38,7 @@ import { setSavedFormContent } from "../../../redux/slices/stateSlice";
 
 const { Option } = Select;
 const { Title, Text } = Typography;
+const { SHOW_CHILD } = TreeSelect;
 
 /**
  *  TalentFormView(props)
@@ -487,16 +489,16 @@ const PersonalGrowthFormView = ({
                   </Text>
                 }
               >
-                <Select
-                  mode="multiple"
-                  optionFilterProp="children"
+                <TreeSelect
+                  className="custom-bubble-select-style"
+                  treeData={developmentalGoalOptions}
+                  treeCheckable
+                  showCheckedStrategy={SHOW_CHILD}
                   placeholder={<FormattedMessage id="setup.select" />}
-                  style={{ width: "100%" }}
-                >
-                  {developmentalGoalOptions.map((value) => {
-                    return <Option key={value.id}>{value.name}</Option>;
-                  })}
-                </Select>
+                  treeNodeFilterProp="title"
+                  showSearch
+                  maxTagCount={15}
+                />
               </Form.Item>
             </Col>
           </Row>


### PR DESCRIPTION
### Changes
- `/api/option/developmentalGoals` now returns a categoryId if the corresponding devGoal is a skill
- Developmental goals dropdown in the profile forms is now a `<TreeSelect />` just like the skills one

![image](https://user-images.githubusercontent.com/22248828/89340709-285ab000-d66e-11ea-84a0-6f815192b17c.png)

fixes #497