### PR TITLE
[Fix] Changed term for "teams" on create and edit profile to "Work unit or project team(s)"

### DIFF
--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -256,7 +256,7 @@
   "profile.talent.management.tooltip": "To determine your talent management results, contact your manager to fill out the ",
   "profile.talent.management.link": "Talent Management Tool",
   "profile.talent.matrix.result": "Talent matrix result",
-  "profile.teams": "Teams",
+  "profile.teams": "Work unit or project team(s)",
   "profile.telephone": "Work telephone",
   "profile.temporary.role": "Are you presently Acting?",
   "profile.tenure": "Substantive",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -256,7 +256,7 @@
   "profile.talent.management.tooltip": "Pour déterminer vos résultats en matière de gestion des talents, contactez votre gestionnaire et remplissez le formulaire ",
   "profile.talent.management.link": "Outil de gestion des talents",
   "profile.talent.matrix.result": "Résultat de la matrice de talents",
-  "profile.teams": "Nom des équipes",
+  "profile.teams": "Unité de travail ou équipe(s) de projet",
   "profile.telephone": "Téléphone du travail",
   "profile.temporary.role": "Avez-vous un rôle intérimaire présentement?",
   "profile.tenure": "Substantielle",


### PR DESCRIPTION
- Added FR and EN translations for "teams" headers on edit and create profile forms as well as profile