### PR TITLE
[Fix] style tree select bubbles

### DIFF
--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -454,7 +454,7 @@ const TalentFormView = ({
                 }
               >
                 <TreeSelect
-                  className="talent-skill-select"
+                  className="custom-bubble-select-style"
                   treeData={selectedSkills}
                   treeCheckable
                   showCheckedStrategy={SHOW_CHILD}


### PR DESCRIPTION
- mentorship skills in the select menu are now rounded
- closes #712 