### PR TITLE
[Fix] fix broken mentorship toggle on load

### DIFF
--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -499,23 +499,23 @@ const TalentFormView = ({
   };
 
   useEffect(() => {
-    /* check if user has a skills to mentor */
-    if (savedMentorshipSkills) {
-      if (!loadedData) {
-        // toggle mentorship switch if there are mentorship skills saved
-        setDisplayMentorshipForm(savedMentorshipSkills.length > 0);
-        setLoadedData(true);
-      }
-
-      // generate a treeData to represent the skills chosen
-      const generatedSelectedSkills = generateMentorshipOptions(
-        skillOptions,
-        form.getFieldsValue().mentorshipSkills || savedSkills
-      );
-
-      setSelectedSkills(generatedSelectedSkills);
+    // set to page loaded if data comes in
+    if (!loadedData) {
+      setLoadedData(true);
     }
-  }, [form, loadedData, savedMentorshipSkills, savedSkills, skillOptions]);
+    // toggle mentorship switch if there are mentorship skills saved
+    setDisplayMentorshipForm(savedMentorshipSkills.length > 0);
+  }, [loadedData, savedMentorshipSkills, savedSkills]);
+
+  useEffect(() => {
+    // generate a treeData to represent the skills chosen
+    const generatedSelectedSkills = generateMentorshipOptions(
+      skillOptions,
+      form.getFieldsValue().mentorshipSkills || savedSkills
+    );
+
+    setSelectedSkills(generatedSelectedSkills);
+  }, [form, savedSkills, skillOptions]);
 
   // Updates the unsaved indicator based on the toggle and form values
   useEffect(() => {


### PR DESCRIPTION
- Mentorship toggle in edit profile would always be set to OFF even if there were mentorship skills save
- since it was set to OFF it would wipe the saved data if user saved other changes
- this PR resolves the issue but correctly detecting if there are mentorship skills saved
- closes #708 