### PR TITLE
[Fix] Redirect to correct edit tabs from profile cards

### DIFF
--- a/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
+++ b/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
@@ -40,7 +40,7 @@ const CareerInterests = ({ data, type }) => {
       }
       cardName="careerInterests"
       id="card-profile-career-interests"
-      editUrl="/profile/edit/personal-growth"
+      editUrl="/profile/edit/personal-growth?tab=career-interests"
       data={data}
       type={type}
       visible={data.visibleCards.careerInterests}

--- a/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
+++ b/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
@@ -11,7 +11,7 @@ const Competencies = ({ data, type }) => {
       content={<CompetenciesView competencies={data.competencies} />}
       cardName="competencies"
       id="card-profile-competency"
-      editUrl="/profile/edit/talent"
+      editUrl="/profile/edit/talent?tab=competencies"
       data={data}
       type={type}
       visible={data.visibleCards.competencies}

--- a/services/frontend-v3/src/components/developmentalGoals/DevelopmentalGoals.jsx
+++ b/services/frontend-v3/src/components/developmentalGoals/DevelopmentalGoals.jsx
@@ -11,7 +11,7 @@ const DevelopmentalGoals = ({ data, type }) => {
       content={<DevelopmentalGoalsView devGoals={data.developmentalGoals} />}
       cardName="developmentalGoals"
       id="card-profile-dev-goals"
-      editUrl="/profile/edit/personal-growth"
+      editUrl="/profile/edit/personal-growth?tab=developmental-goals"
       data={data}
       type={type}
       visible={data.visibleCards.developmentalGoals}

--- a/services/frontend-v3/src/components/education/Education.jsx
+++ b/services/frontend-v3/src/components/education/Education.jsx
@@ -45,7 +45,7 @@ const Education = ({ data, type }) => {
       content={<EducationView educationInfo={getEducationInfo(data)} />}
       cardName="education"
       id="card-profile-education"
-      editUrl="/profile/edit/qualifications"
+      editUrl="/profile/edit/qualifications?tab=education"
       data={data}
       type={type}
       visible={data.visibleCards.education}

--- a/services/frontend-v3/src/components/exFeeder/ExFeeder.jsx
+++ b/services/frontend-v3/src/components/exFeeder/ExFeeder.jsx
@@ -9,7 +9,7 @@ const ExFeeder = ({ data, type }) => {
     <ProfileCards
       titleId={<ExFeederView data={data} />}
       cardName="exFeeder"
-      editUrl="/profile/edit/personal-growth"
+      editUrl="/profile/edit/personal-growth?tab=ex-feeder"
       id="card-profile-ex-feeder"
       data={data}
       type={type}

--- a/services/frontend-v3/src/components/experience/Experience.jsx
+++ b/services/frontend-v3/src/components/experience/Experience.jsx
@@ -48,7 +48,7 @@ const Experience = ({ data, type }) => {
       content={<ExperienceView experienceInfo={getExperienceInfo(data)} />}
       cardName="experience"
       id="card-profile-experience"
-      editUrl="/profile/edit/qualifications"
+      editUrl="/profile/edit/qualifications?tab=experience"
       data={data}
       type={type}
       visible={data.visibleCards.experience}

--- a/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
+++ b/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
@@ -74,7 +74,7 @@ const Mentorship = ({ data, type }) => {
       }
       cardName="mentorshipSkills"
       id="card-profile-mentorship-skills"
-      editUrl="/profile/edit/talent"
+      editUrl="/profile/edit/talent?tab=mentorship"
       data={data}
       type={type}
       visible={data.visibleCards.mentorshipSkills}

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthForm.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import _ from "lodash";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import { useIntl } from "react-intl";
 import useAxios from "../../../utils/axios-instance";
 
@@ -19,6 +19,7 @@ const PersonalGrowthForm = ({ formType }) => {
   // Define States
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [currentTab, setCurrentTab] = useState(null);
   const [developmentalGoalOptions, setDevelopmentalGoalOptions] = useState([]);
   const [savedDevelopmentalGoals, setSavedDevelopmentalGoals] = useState([]);
   const [interestedInRemoteOptions, setInterestedInRemoteOptions] = useState(
@@ -44,8 +45,8 @@ const PersonalGrowthForm = ({ formType }) => {
   const { id } = useSelector((state) => state.user);
 
   const history = useHistory();
-
   const intl = useIntl();
+  const location = useLocation();
 
   /**
    * Get saved Developmental Goals
@@ -187,6 +188,21 @@ const PersonalGrowthForm = ({ formType }) => {
     setTalentMatrixResultOptions(result.data);
   }, [locale]);
 
+  /**
+   * Get default form tab
+   *
+   * get the default selected form tab based on url query params
+   */
+  const getDefaultFormTab = () => {
+    const searchParams = new URLSearchParams(location.search);
+    setCurrentTab(searchParams.get("tab"));
+  };
+
+  // useEffect when url path is updated
+  useEffect(() => {
+    getDefaultFormTab();
+  }, [location]);
+
   // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
     if (profileInfo) {
@@ -255,6 +271,7 @@ const PersonalGrowthForm = ({ formType }) => {
       savedTalentMatrixResult={savedTalentMatrixResult}
       savedExFeederBool={savedExFeederBool}
       formType={formType}
+      currentTab={currentTab}
       load={load}
       history={history}
       userId={id}

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -62,6 +62,7 @@ const PersonalGrowthFormView = ({
   savedTalentMatrixResult,
   savedExFeederBool,
   formType,
+  currentTab,
   load,
   intl,
   history,
@@ -482,10 +483,10 @@ const PersonalGrowthFormView = ({
           layout="vertical"
           onValuesChange={checkIfFormValuesChanged}
         >
-          <Tabs type="card">
+          <Tabs type="card" defaultActiveKey={currentTab}>
             <TabPane
               tab={<FormattedMessage id="setup.developmental.goals" />}
-              key="1"
+              key="developmental-goals"
             >
               {/* *************** Developmental ************** */}
               {getSectionHeader(
@@ -514,7 +515,7 @@ const PersonalGrowthFormView = ({
             </TabPane>
             <TabPane
               tab={<FormattedMessage id="setup.career.interests" />}
-              key="2"
+              key="career-interests"
             >
               {/* *************** Career Interest ************** */}
 
@@ -598,7 +599,7 @@ const PersonalGrowthFormView = ({
             </TabPane>
             <TabPane
               tab={<FormattedMessage id="setup.talent.management.title" />}
-              key="3"
+              key="talent-management"
             >
               {/* *************** Talent Management ************** */}
 
@@ -681,7 +682,7 @@ const PersonalGrowthFormView = ({
 
             <TabPane
               tab={<FormattedMessage id="profile.ex.feeder.title" />}
-              key="4"
+              key="ex-feeder"
             >
               {/* Form Row Three: ex feeder */}
               {getSectionHeader("profile.ex.feeder.title", "exFeeder")}
@@ -721,6 +722,7 @@ PersonalGrowthFormView.propTypes = {
   savedTalentMatrixResult: PropTypes.string,
   savedExFeederBool: PropTypes.bool,
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
+  currentTab: PropTypes.string.isRequired,
   load: PropTypes.bool.isRequired,
   intl: IntlPropType,
   history: HistoryPropType.isRequired,

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { useSelector } from "react-redux";
 import moment from "moment";
 import PropTypes from "prop-types";
-import { useHistory } from "react-router-dom";
+import { useHistory, useLocation } from "react-router-dom";
 import useAxios from "../../../utils/axios-instance";
 import handleError from "../../../functions/handleError";
 import QualificationsFormView from "./QualificationsFormView";
@@ -17,14 +17,16 @@ const QualificationsForm = ({ formType }) => {
   // Define States
   const [profileInfo, setProfileInfo] = useState(null);
   const [load, setLoad] = useState(false);
+  const [currentTab, setCurrentTab] = useState(null);
   const [savedEducation, setSavedEducation] = useState();
   const [savedExperience, setSavedExperience] = useState();
   const [savedProjects, setSavedProjects] = useState();
 
   const { id } = useSelector((state) => state.user);
   const { locale } = useSelector((state) => state.settings);
-  const axios = useAxios();
 
+  const axios = useAxios();
+  const location = useLocation();
   const history = useHistory();
 
   /**
@@ -87,6 +89,21 @@ const QualificationsForm = ({ formType }) => {
     setSavedProjects(profileInfo.projects);
   };
 
+  /**
+   * Get default form tab
+   *
+   * get the default selected form tab based on url query params
+   */
+  const getDefaultFormTab = () => {
+    const searchParams = new URLSearchParams(location.search);
+    setCurrentTab(searchParams.get("tab"));
+  };
+
+  // useEffect when url path is updated
+  useEffect(() => {
+    getDefaultFormTab();
+  }, [location]);
+
   // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
     if (profileInfo) {
@@ -110,6 +127,7 @@ const QualificationsForm = ({ formType }) => {
       savedExperience={savedExperience}
       savedProjects={savedProjects}
       formType={formType}
+      currentTab={currentTab}
       load={load}
       history={history}
       userId={id}

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -44,6 +44,7 @@ const QualificationsFormView = ({
   savedExperience,
   savedProjects,
   formType,
+  currentTab,
   load,
   intl,
   history,
@@ -438,8 +439,11 @@ const QualificationsFormView = ({
           layout="vertical"
           onValuesChange={checkIfFormValuesChanged}
         >
-          <Tabs type="card">
-            <TabPane tab={<FormattedMessage id="setup.education" />} key="1">
+          <Tabs type="card" defaultActiveKey={currentTab}>
+            <TabPane
+              tab={<FormattedMessage id="setup.education" />}
+              key="education"
+            >
               {getSectionHeader("setup.education", "education")}
               <Row gutter={24}>
                 <Col className="gutter-row" xs={24} md={24} lg={24} xl={24}>
@@ -481,7 +485,10 @@ const QualificationsFormView = ({
                 </Col>
               </Row>
             </TabPane>
-            <TabPane tab={<FormattedMessage id="setup.experience" />} key="2">
+            <TabPane
+              tab={<FormattedMessage id="setup.experience" />}
+              key="experience"
+            >
               {getSectionHeader("setup.experience", "experience")}
               {/* Form Row One: Remote Work */}
               <Row gutter={24}>
@@ -575,6 +582,7 @@ QualificationsFormView.propTypes = {
   ),
   savedProjects: PropTypes.arrayOf(PropTypes.string),
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
+  currentTab: PropTypes.string.isRequired,
   load: PropTypes.bool.isRequired,
   intl: IntlPropType,
   history: HistoryPropType.isRequired,

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentForm.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
+import { useLocation } from "react-router-dom";
 import useAxios from "../../../utils/axios-instance";
 import TalentFormView from "./TalentFormView";
 import handleError from "../../../functions/handleError";
@@ -16,6 +17,7 @@ const TalentForm = ({ formType }) => {
   const [skillOptions, setSkillOptions] = useState([]);
   const [competencyOptions, setCompetencyOptions] = useState([]);
   const [load, setLoad] = useState(false);
+  const [currentTab, setCurrentTab] = useState(null);
   const [savedCompetencies, setSavedCompetencies] = useState([]);
   const [savedSkills, setSavedSkills] = useState([]);
   const [savedMentorshipSkills, setSavedMentorshipSkills] = useState([]);
@@ -24,6 +26,7 @@ const TalentForm = ({ formType }) => {
   const { locale } = useSelector((state) => state.settings);
   const { id } = useSelector((state) => state.user);
   const axios = useAxios();
+  const location = useLocation();
 
   /**
    * Get user profile
@@ -114,6 +117,21 @@ const TalentForm = ({ formType }) => {
     setSavedMentorshipSkills(selected);
   };
 
+  /**
+   * Get default form tab
+   *
+   * get the default selected form tab based on url query params
+   */
+  const getDefaultFormTab = () => {
+    const searchParams = new URLSearchParams(location.search);
+    setCurrentTab(searchParams.get("tab"));
+  };
+
+  // useEffect when url path is updated
+  useEffect(() => {
+    getDefaultFormTab();
+  }, [location]);
+
   // useEffect when profileInfo changes (extracts info from the profileInfo object)
   useEffect(() => {
     if (profileInfo) {
@@ -146,6 +164,7 @@ const TalentForm = ({ formType }) => {
       savedSkills={savedSkills}
       savedMentorshipSkills={savedMentorshipSkills}
       formType={formType}
+      currentTab={currentTab}
       load={load}
       userId={id}
     />

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -53,6 +53,7 @@ const TalentFormView = ({
   savedSkills,
   savedMentorshipSkills,
   formType,
+  currentTab,
   load,
   intl,
   userId,
@@ -663,8 +664,8 @@ const TalentFormView = ({
           layout="vertical"
           onValuesChange={updateIfFormValuesChanged}
         >
-          <Tabs type="card">
-            <TabPane tab={<FormattedMessage id="setup.skills" />} key="1">
+          <Tabs type="card" defaultActiveKey={currentTab}>
+            <TabPane tab={<FormattedMessage id="setup.skills" />} key="skills">
               {/* Form Row Two: skills */}
               <Row gutter={24}>
                 <Col className="gutter-row" xs={24} md={24} lg={24} xl={24}>
@@ -687,7 +688,7 @@ const TalentFormView = ({
             </TabPane>
             <TabPane
               tab={<FormattedMessage id="profile.mentorship.skills" />}
-              key="2"
+              key="mentorship"
             >
               {/* Form Row Two: skills */}
               <Row gutter={24}>
@@ -713,7 +714,10 @@ const TalentFormView = ({
                 </Col>
               </Row>
             </TabPane>
-            <TabPane tab={<FormattedMessage id="setup.competencies" />} key="3">
+            <TabPane
+              tab={<FormattedMessage id="setup.competencies" />}
+              key="competencies"
+            >
               {/* Form Row Three: competencies */}
               <Row gutter={24}>
                 <Col className="gutter-row" xs={24} md={24} lg={24} xl={24}>
@@ -764,6 +768,7 @@ TalentFormView.propTypes = {
   savedSkills: PropTypes.arrayOf(PropTypes.string),
   savedMentorshipSkills: PropTypes.arrayOf(PropTypes.string),
   formType: PropTypes.oneOf(["create", "edit"]).isRequired,
+  currentTab: PropTypes.string.isRequired,
   load: PropTypes.bool.isRequired,
   intl: IntlPropType,
   userId: PropTypes.string.isRequired,

--- a/services/frontend-v3/src/components/projects/Projects.jsx
+++ b/services/frontend-v3/src/components/projects/Projects.jsx
@@ -11,7 +11,7 @@ const Projects = ({ data, type }) => {
       content={<ProjectsView projectsInfo={data.projects} />}
       cardName="projects"
       id="card-profile-projects"
-      editUrl="/profile/edit/qualifications"
+      editUrl="/profile/edit/qualifications?tab=experience"
       data={data}
       type={type}
       visible={data.visibleCards.projects}

--- a/services/frontend-v3/src/components/skillsCard/Skills.jsx
+++ b/services/frontend-v3/src/components/skillsCard/Skills.jsx
@@ -75,7 +75,7 @@ const Skills = ({ data, type }) => {
       }
       cardName="skills"
       id="card-profile-skills"
-      editUrl="/profile/edit/talent"
+      editUrl="/profile/edit/talent?tab=skills"
       data={data}
       type={type}
       visible={data.visibleCards.skills}

--- a/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
@@ -11,7 +11,7 @@ const TalentManagement = ({ data, type }) => {
       content={<TalentManagementView data={data} />}
       cardName="talentManagement"
       id="card-profile-talent-management"
-      editUrl="/profile/edit/personal-growth"
+      editUrl="/profile/edit/personal-growth?tab=talent-management"
       data={data}
       type={type}
       visible={data.visibleCards.talentManagement}


### PR DESCRIPTION
- when using the pencil on the profile cards it now navigates to the correct tab in the "edit profile" forms
- uses URL query param to read "tab" value 
- closes #717 