### PR TITLE
[Fix] Empty form save

### DIFF
--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -266,9 +266,6 @@ const EmploymentDataFormView = ({
    */
   const checkIfFormValuesChanged = () => {
     const formValues = _.pickBy(form.getFieldsValue(), _.identity);
-    if (_.isEmpty(formValues)) {
-      return false;
-    }
 
     const dbValues = _.pickBy(
       savedValues || getInitialValues(profileInfo),

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -265,9 +265,6 @@ const LangProficiencyFormView = ({
    */
   const checkIfFormValuesChanged = () => {
     const formValues = _.pickBy(form.getFieldsValue(), _.identity);
-    if (_.isEmpty(formValues)) {
-      return false;
-    }
 
     const dbValues = _.pickBy(
       savedValues || getInitialValues(profileInfo),

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -63,6 +63,7 @@ const LangProficiencyFormView = ({
   const [displaySecondLangForm, setDisplaySecondLangForm] = useState(false);
   const [fieldsChanged, setFieldsChanged] = useState(false);
   const [savedValues, setSavedValues] = useState(null);
+  const [loadedData, setLoadedData] = useState(false);
 
   const { locale } = useSelector((state) => state.settings);
   const dispatch = useDispatch();
@@ -634,14 +635,17 @@ const LangProficiencyFormView = ({
   };
 
   useEffect(() => {
-    if (!displaySecondLangForm) {
+    if (!loadedData && load) {
       /* check if user has a second language */
       const hasSubformData = profileInfo
         ? profileInfo.secondLangProfs.length !== 0
         : false;
       setDisplaySecondLangForm(hasSubformData);
+
+      // Makes the subform not reset on language change
+      setLoadedData(true);
     }
-  }, [displaySecondLangForm, profileInfo]);
+  }, [displaySecondLangForm, load, loadedData, profileInfo]);
 
   /** **********************************
    ********* Render Component *********

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -221,6 +221,7 @@ const TalentFormView = ({
     // Cleans up the object for following comparison
     if (
       formValues.mentorshipSkills === undefined &&
+      dbValues.mentorshipSkills &&
       dbValues.mentorshipSkills.length === 0
     ) {
       delete dbValues.mentorshipSkills;


### PR DESCRIPTION
### Changes
- Fixed empty form saving problem in the Employment and OL form
- Fixed error where selecting skills or competencies without having mentorship skills crashes the app
- Fixed OL subform toggle (after save)

fixes #726