### PR TITLE
[Feat] Pretty print axios errors

### DIFF
--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -1,6 +1,7 @@
 const axios = require("axios");
 const prisma = require("../../database");
 const config = require("../../config");
+const { handleAxiosErrors } = require("../../utils/handleErrors");
 
 async function getGedsSetup(request, response) {
   const { id } = request.params;
@@ -100,7 +101,7 @@ async function getGedsSetup(request, response) {
       }
     })
     .catch((error) => {
-      console.log(error);
+      handleAxiosErrors(error);
       response.status(500).json("Unable to get geds Profile");
     });
 }

--- a/services/backend/src/core/keycloak/keycloak.js
+++ b/services/backend/src/core/keycloak/keycloak.js
@@ -4,53 +4,45 @@ const config = require("../../config");
 const { handleAxiosErrors } = require("../../utils/handleErrors");
 
 const getAccessToken = async () => {
-  try {
-    const data = qs.stringify({
-      grant_type: "client_credentials",
-      client_secret: config.KEYCLOAK_SECRET,
-      client_id: "upskill-api",
-    });
+  const data = qs.stringify({
+    grant_type: "client_credentials",
+    client_secret: config.KEYCLOAK_SECRET,
+    client_id: "upskill-api",
+  });
 
-    const response = await axios({
-      method: "post",
-      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-      url: "/realms/individual/protocol/openid-connect/token",
-      headers: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      data: data,
-      timeout: 2000,
-    });
+  const response = await axios({
+    method: "post",
+    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+    url: "/realms/individual/protocol/openid-connect/token",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    data: data,
+    timeout: 2000,
+  });
 
-    return response.data.access_token;
-  } catch (error) {
-    handleAxiosErrors(error);
-  }
+  return response.data.access_token;
 };
 
 const getGroupIds = async (accessToken) => {
-  try {
-    const groups = await axios({
-      method: "get",
-      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-      url: "/admin/realms/individual/groups?search=upskill",
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-      timeout: 2000,
-    });
+  const groups = await axios({
+    method: "get",
+    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+    url: "/admin/realms/individual/groups?search=upskill",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    timeout: 2000,
+  });
 
-    const groupIds = groups.data[0].subGroups.map(({ id, name }) => {
-      return {
-        id,
-        name,
-      };
-    });
+  const groupIds = groups.data[0].subGroups.map(({ id, name }) => {
+    return {
+      id,
+      name,
+    };
+  });
 
-    return groupIds;
-  } catch (error) {
-    handleAxiosErrors(error);
-  }
+  return groupIds;
 };
 
 const filterName = (name) => {
@@ -66,24 +58,20 @@ const filterName = (name) => {
 };
 
 const getMembers = async (accessToken, id, name) => {
-  try {
-    const members = await axios({
-      method: "get",
-      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-      url: `/admin/realms/individual/groups/${id}/members`,
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
-      timeout: 2000,
-    });
+  const members = await axios({
+    method: "get",
+    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+    url: `/admin/realms/individual/groups/${id}/members`,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    timeout: 2000,
+  });
 
-    return {
-      name: filterName(name),
-      ids: members.data.map((member) => member.id),
-    };
-  } catch (error) {
-    handleAxiosErrors(error);
-  }
+  return {
+    name: filterName(name),
+    ids: members.data.map((member) => member.id),
+  };
 };
 
 const getUsers = async (request, response) => {
@@ -102,7 +90,7 @@ const getUsers = async (request, response) => {
 
     response.status(200).send(cleanedData);
   } catch (error) {
-    console.log(error);
+    handleAxiosErrors(error);
     response.status(500);
   }
 };

--- a/services/backend/src/core/keycloak/keycloak.js
+++ b/services/backend/src/core/keycloak/keycloak.js
@@ -1,47 +1,56 @@
 const axios = require("axios");
 const qs = require("querystring");
 const config = require("../../config");
+const { handleAxiosErrors } = require("../../utils/handleErrors");
 
 const getAccessToken = async () => {
-  const data = qs.stringify({
-    grant_type: "client_credentials",
-    client_secret: config.KEYCLOAK_SECRET,
-    client_id: "upskill-api",
-  });
+  try {
+    const data = qs.stringify({
+      grant_type: "client_credentials",
+      client_secret: config.KEYCLOAK_SECRET,
+      client_id: "upskill-api",
+    });
 
-  const response = await axios({
-    method: "post",
-    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-    url: "/realms/individual/protocol/openid-connect/token",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
-    data: data,
-    timeout: 2000,
-  });
+    const response = await axios({
+      method: "post",
+      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+      url: "/realms/individual/protocol/openid-connect/token",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      data: data,
+      timeout: 2000,
+    });
 
-  return response.data.access_token;
+    return response.data.access_token;
+  } catch (error) {
+    handleAxiosErrors(error);
+  }
 };
 
 const getGroupIds = async (accessToken) => {
-  const groups = await axios({
-    method: "get",
-    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-    url: "/admin/realms/individual/groups?search=upskill",
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-    timeout: 2000,
-  });
+  try {
+    const groups = await axios({
+      method: "get",
+      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+      url: "/admin/realms/individual/groups?search=upskill",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      timeout: 2000,
+    });
 
-  const groupIds = groups.data[0].subGroups.map(({ id, name }) => {
-    return {
-      id,
-      name,
-    };
-  });
+    const groupIds = groups.data[0].subGroups.map(({ id, name }) => {
+      return {
+        id,
+        name,
+      };
+    });
 
-  return groupIds;
+    return groupIds;
+  } catch (error) {
+    handleAxiosErrors(error);
+  }
 };
 
 const filterName = (name) => {
@@ -57,20 +66,24 @@ const filterName = (name) => {
 };
 
 const getMembers = async (accessToken, id, name) => {
-  const members = await axios({
-    method: "get",
-    baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
-    url: `/admin/realms/individual/groups/${id}/members`,
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-    timeout: 2000,
-  });
+  try {
+    const members = await axios({
+      method: "get",
+      baseURL: config.KEYCLOAK_AUTH_SERVER_URL,
+      url: `/admin/realms/individual/groups/${id}/members`,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      timeout: 2000,
+    });
 
-  return {
-    name: filterName(name),
-    ids: members.data.map((member) => member.id),
-  };
+    return {
+      name: filterName(name),
+      ids: members.data.map((member) => member.id),
+    };
+  } catch (error) {
+    handleAxiosErrors(error);
+  }
 };
 
 const getUsers = async (request, response) => {

--- a/services/backend/src/utils/handleErrors.js
+++ b/services/backend/src/utils/handleErrors.js
@@ -1,0 +1,13 @@
+const handleAxiosErrors = (error) => {
+  if (error.response) {
+    console.log(
+      error.response.status,
+      error.response.statusText,
+      error.response.data
+    );
+    console.log("Config", error.response.config);
+    console.log("Headers", error.response.headers);
+  }
+};
+
+module.exports = { handleAxiosErrors };


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
Created function to display axios errors

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #789

#### Screenshots (if aplicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
![image](https://user-images.githubusercontent.com/22248828/90816109-c058ca80-e2f9-11ea-9522-2463f6ae4031.png)

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
