### PR TITLE
[Fix] Revert Prisma 2.6 to 2.5

### DIFF
--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -20,7 +20,7 @@
   "author": "I-Talent team",
   "license": "MIT",
   "dependencies": {
-    "@prisma/client": "2.6.0",
+    "@prisma/client": "2.5.0",
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",
     "concurrently": "^5.3.0",

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -43,7 +43,7 @@
     "validator": "^13.1.1"
   },
   "devDependencies": {
-    "@prisma/cli": "2.6.0",
+    "@prisma/cli": "2.5.0",
     "eslint": "^7.8.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-node": "^4.1.0",

--- a/services/backend/yarn.lock
+++ b/services/backend/yarn.lock
@@ -549,10 +549,10 @@
   resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.6.0.tgz#13c0eb640af5c03d6295dcb75befcfcc5a297ff3"
   integrity sha512-zZubTQNI4z2zoJxsjh4ob2FxqZEi7pEpCDHcgNyyX1kmLtDtwwneuW6hJjdJDjPc8oVSOryJIOuWxlLeMyMgUw==
 
-"@prisma/client@2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.6.0.tgz#8b9ab0dc39dfbd2e0253d0177e0f65053a542ad1"
-  integrity sha512-BxYBn8PQ7ACh6p6q9JJNlODV8i50aZA9f+HwPGtff9jhIuoyFdM0eh1Qldib1ngTzt1UnxvacqlpXDHlnL93Pg==
+"@prisma/client@2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.5.0.tgz#dba5ee40497f458dc0f1057fa4a0b6675548e443"
+  integrity sha512-rsgbImSVMBATLSSZEgP7pWpqV2iylDJWM2zjmL980IjTBgy63alDr0RyoOkdt8oVw4OyJW0uYpxAU2Z9bXZU9A==
   dependencies:
     pkg-up "^3.1.0"
 


### PR DESCRIPTION
#### Changes introduced
- Application back end was crashing due to bug in Prisma 2.6
- reverted Prisma to 2.5.0
- the issue is explained here: https://github.com/prisma/prisma/issues/3497


#### Related issue(s)
- this problem was introduced by #822 



#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
