### PR TITLE
[Feat] - Detailed backend openshift logs

### DIFF
--- a/services/backend/src/server.js
+++ b/services/backend/src/server.js
@@ -28,7 +28,13 @@ app.use(timeout("5s"));
 app.use(keycloak.middleware());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(morgan("dev"));
+app.use(
+  morgan(
+    config.ENV === "development"
+      ? "dev"
+      : ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"'
+  )
+);
 app.use("/api", router);
 app.get("/oauth2-redirect.html", function (req, res) {
   res.sendfile("src/docs/oauth2-redirect.html");

--- a/services/backend/src/server.js
+++ b/services/backend/src/server.js
@@ -28,13 +28,7 @@ app.use(timeout("5s"));
 app.use(keycloak.middleware());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
-app.use(
-  morgan(
-    config.ENV === "development"
-      ? "dev"
-      : ':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"'
-  )
-);
+app.use(morgan(config.ENV === "development" ? "dev" : "combined"));
 app.use("/api", router);
 app.get("/oauth2-redirect.html", function (req, res) {
   res.sendfile("src/docs/oauth2-redirect.html");


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
Make logs more detailed in openshift - for backend

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
NA

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
Example screenshots with the same requests

Server logs
![image](https://user-images.githubusercontent.com/22248828/92528651-1df47e80-f1f7-11ea-8759-e1643fb908c4.png)
`:remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"`

Local logs
![image](https://user-images.githubusercontent.com/22248828/92528695-2f3d8b00-f1f7-11ea-8124-ef5cf36c05ac.png)
`:method :url :status :response-time ms - :res[content-length]`

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
