### PR TITLE
[Fix] bug that caused personal growth form data to delete when changes were saved

### DIFF
--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -237,7 +237,7 @@ const PersonalGrowthFormView = ({
     form
       .validateFields()
       .then(async () => {
-        let values = form.getFieldValue();
+        const values = form.getFieldValue();
         setFieldsChanged(false);
         setSavedValues(values);
         await saveDataToDB(values);
@@ -262,8 +262,8 @@ const PersonalGrowthFormView = ({
   const onSaveAndNext = async () => {
     form
       .validateFields()
-      .then(async (values) => {
-        let values = form.getFieldValue();
+      .then(async () => {
+        const values = form.getFieldValue();
         await saveDataToDB(values);
         setFieldsChanged(false);
         history.push("/profile/create/step/7");
@@ -296,7 +296,8 @@ const PersonalGrowthFormView = ({
   const onSaveAndFinish = async () => {
     form
       .validateFields()
-      .then(async (values) => {
+      .then(async () => {
+        const values = form.getFieldValue();
         await saveDataToDB(values);
         setFieldsChanged(false);
         if (formType === "create") {

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -236,7 +236,8 @@ const PersonalGrowthFormView = ({
   const onSave = async () => {
     form
       .validateFields()
-      .then(async (values) => {
+      .then(async () => {
+        let values = form.getFieldValue();
         setFieldsChanged(false);
         setSavedValues(values);
         await saveDataToDB(values);
@@ -262,6 +263,7 @@ const PersonalGrowthFormView = ({
     form
       .validateFields()
       .then(async (values) => {
+        let values = form.getFieldValue();
         await saveDataToDB(values);
         setFieldsChanged(false);
         history.push("/profile/create/step/7");


### PR DESCRIPTION
#### Changes introduced
- use "getFieldValue()" to get field data instead of the "value" param from validateFields()
- this resolves the bug that caused forms in other tabs to lose their data when user saved

#### Related issue(s)
closes #831 


#### Screenshots (if applicable)
no applicable


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
