### PR TITLE
[Fix] Url field lag

### DIFF
--- a/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -69,7 +69,7 @@ const EmploymentDataFormView = ({
   /* Component Styles */
   const styles = {
     skeleton: {
-      minHeight: "400px",
+      minHeight: "658px",
       maxWidth: "900px",
       background: "#fff",
       padding: "30px 30px",
@@ -669,7 +669,7 @@ const EmploymentDataFormView = ({
               {getTempRoleForm(displayActingRoleForm)}
             </Col>
           </Row>
-          
+
           <Divider style={styles.headerDiv} />
           <Row
             justify="space-between"

--- a/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -70,7 +70,7 @@ const LangProficiencyFormView = ({
     skeleton: {
       width: "100%",
       maxWidth: "900px",
-      minHeight: "400px",
+      minHeight: "311px",
       background: "#fff",
       padding: "30px 30px",
     },

--- a/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/personalGrowthForm/PersonalGrowthFormView.jsx
@@ -80,7 +80,7 @@ const PersonalGrowthFormView = ({
     skeleton: {
       width: "100%",
       maxWidth: "900px",
-      minHeight: "400px",
+      minHeight: "324px",
       background: "#fff",
       padding: "30px 30px",
     },

--- a/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -70,7 +70,7 @@ const PrimaryInfoFormView = ({
   /* Component Styles */
   const styles = {
     skeleton: {
-      minHeight: "400px",
+      minHeight: "621px",
       maxWidth: "900px",
       background: "#fff",
       padding: "30px 30px",

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -367,9 +367,7 @@ const QualificationsFormView = ({
                             <Button
                               type="dashed"
                               disabled={fields.length === 3}
-                              onClick={() => {
-                                add();
-                              }}
+                              onClick={add}
                               style={{ width: "100%" }}
                             >
                               <PlusOutlined />
@@ -417,9 +415,7 @@ const QualificationsFormView = ({
                             <Button
                               type="dashed"
                               disabled={fields.length === 3}
-                              onClick={() => {
-                                add();
-                              }}
+                              onClick={add}
                               style={{ width: "100%" }}
                             >
                               <PlusOutlined />

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -171,8 +171,9 @@ const QualificationsFormView = ({
     );
   };
 
-  const onFieldsChange = () => {
+  const onValuesChange = () => {
     findErrorTabs();
+    checkIfFormValuesChanged();
   };
 
   /*
@@ -329,8 +330,7 @@ const QualificationsFormView = ({
           form={form}
           initialValues={savedValues || initialValues}
           layout="vertical"
-          onValuesChange={checkIfFormValuesChanged}
-          onFieldsChange={onFieldsChange}
+          onValuesChange={onValuesChange}
         >
           <Tabs type="card" defaultActiveKey={currentTab}>
             <TabPane

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.scss
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/QualificationsFormView.scss
@@ -1,10 +1,11 @@
 .skeleton {
   width: 100%;
   max-width: 900px;
-  min-height: 400px;
+  min-height: 324px;
   background: #fff;
   padding: 30px 30px;
 }
+
 .content {
   text-align: left;
   width: 100%;
@@ -15,7 +16,7 @@
 
 .formTitle {
   font-size: 1.2em !important;
-  margin: 0;
+  margin: 0 !important;
 }
 
 .sectionHeader {
@@ -23,7 +24,7 @@
 }
 
 .headerDiv {
-  margin: 15px 0 15px 0;
+  margin: 15px 0 15px 0 !important;
 }
 
 .finishAndSaveBtn {

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/educationForm/EducationFormView.jsx
@@ -270,15 +270,13 @@ const EducationFormView = ({
                     key={field.fieldKey}
                     fieldElement={field}
                     removeElement={remove}
-                    NameOptions={attachmentNames}
+                    nameOptions={attachmentNames}
                   />
                 ))}
                 <Form.Item>
                   <Button
                     type="dashed"
-                    onClick={() => {
-                      add();
-                    }}
+                    onClick={add}
                     disabled={fields.length === 3}
                     style={{ width: "100%" }}
                   >

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachment.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachment.jsx
@@ -6,12 +6,12 @@ import {
   KeyNameOptionsPropType,
 } from "../../../../utils/customPropTypes";
 
-const LinkAttachment = ({ fieldElement, removeElement, NameOptions }) => {
+const LinkAttachment = ({ fieldElement, removeElement, nameOptions }) => {
   return (
     <LinkAttachmentView
       fieldElement={fieldElement}
       removeElement={removeElement}
-      NameOptions={NameOptions}
+      nameOptions={nameOptions}
     />
   );
 };
@@ -19,7 +19,7 @@ const LinkAttachment = ({ fieldElement, removeElement, NameOptions }) => {
 LinkAttachment.propTypes = {
   fieldElement: FieldPropType.isRequired,
   removeElement: PropTypes.func.isRequired,
-  NameOptions: KeyNameOptionsPropType.isRequired,
+  nameOptions: KeyNameOptionsPropType.isRequired,
 };
 
 export default LinkAttachment;

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachmentView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachmentView.jsx
@@ -59,7 +59,6 @@ const LinkAttachmentView = ({
           placeholder={intl.formatMessage({
             id: "attachment.placeholder",
           })}
-          ru
         />
       </Form.Item>
     </Col>

--- a/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachmentView.jsx
+++ b/services/frontend-v3/src/components/profileForms/qualificationsForm/linkAttachment/LinkAttachmentView.jsx
@@ -13,84 +13,80 @@ import "./LinkAttachmentView.scss";
 
 const { Option } = Select;
 
+const Rules = {
+  required: {
+    required: true,
+    message: <FormattedMessage id="profile.rules.required" />,
+  },
+  url: {
+    type: "url",
+    message: <FormattedMessage id="profile.rules.url" />,
+  },
+};
+
 const LinkAttachmentView = ({
   fieldElement,
   removeElement,
-  NameOptions,
+  nameOptions,
   intl,
-}) => {
-  const Rules = {
-    required: {
-      required: true,
-      message: <FormattedMessage id="profile.rules.required" />,
-    },
-    url: {
-      type: "url",
-      message: <FormattedMessage id="profile.rules.url" />,
-    },
-  };
-  return (
-    <Row span={24}>
-      <Col className="gutter-row" span={5}>
-        <Form.Item
-          rules={[Rules.required]}
-          className="formItem"
-          name={[fieldElement.name, "nameId"]}
-          fieldKey={[fieldElement.fieldKey, "nameId"]}
+}) => (
+  <Row span={24}>
+    <Col className="gutter-row" span={5}>
+      <Form.Item
+        rules={[Rules.required]}
+        className="formItem"
+        name={[fieldElement.name, "nameId"]}
+        fieldKey={[fieldElement.fieldKey, "nameId"]}
+      >
+        <Select
+          optionFilterProp="children"
+          placeholder={<FormattedMessage id="admin.select" />}
         >
-          <Select
-            optionFilterProp="children"
-            placeholder={<FormattedMessage id="admin.select" />}
-          >
-            {NameOptions.map((value) => {
-              return <Option key={value.id}>{value.name}</Option>;
-            })}
-          </Select>
-        </Form.Item>
-      </Col>
-      <Col className="gutter-row" span={18}>
-        <Form.Item
-          name={[fieldElement.name, "url"]}
-          fieldKey={[fieldElement.fieldKey, "url"]}
-          className="formItem"
-          rules={[Rules.required, Rules.url]}
-        >
-          <Input
-            placeholder={intl.formatMessage({
-              id: "attachment.placeholder",
-            })}
-            ru
+          {nameOptions.map((value) => {
+            return <Option key={value.id}>{value.name}</Option>;
+          })}
+        </Select>
+      </Form.Item>
+    </Col>
+    <Col className="gutter-row" span={18}>
+      <Form.Item
+        name={[fieldElement.name, "url"]}
+        fieldKey={[fieldElement.fieldKey, "url"]}
+        className="formItem"
+        rules={[Rules.required, Rules.url]}
+      >
+        <Input
+          placeholder={intl.formatMessage({
+            id: "attachment.placeholder",
+          })}
+          ru
+        />
+      </Form.Item>
+    </Col>
+    <Col className="gutter-row" span={1}>
+      <Form.Item>
+        <Tooltip placement="top" title={<FormattedMessage id="admin.delete" />}>
+          <Button
+            type="primary"
+            shape="circle"
+            icon={<DeleteOutlined />}
+            onClick={() => {
+              removeElement(fieldElement.name);
+            }}
+            size="small"
+            className="deleteButton"
           />
-        </Form.Item>
-      </Col>
-      <Col className="gutter-row" span={1}>
-        <Form.Item>
-          <Tooltip
-            placement="top"
-            title={<FormattedMessage id="admin.delete" />}
-          >
-            <Button
-              type="primary"
-              shape="circle"
-              icon={<DeleteOutlined />}
-              onClick={() => {
-                removeElement(fieldElement.name);
-              }}
-              size="small"
-              className="deleteButton"
-            />
-          </Tooltip>
-        </Form.Item>
-      </Col>
-    </Row>
-  );
-};
+        </Tooltip>
+      </Form.Item>
+    </Col>
+  </Row>
+);
 
 LinkAttachmentView.propTypes = {
   intl: IntlPropType,
   fieldElement: FieldPropType.isRequired,
   removeElement: PropTypes.func.isRequired,
-  NameOptions: KeyNameOptionsPropType.isRequired,
+  nameOptions: KeyNameOptionsPropType.isRequired,
 };
 
 LinkAttachmentView.defaultProps = {

--- a/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend-v3/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -71,7 +71,7 @@ const TalentFormView = ({
     skeleton: {
       width: "100%",
       maxWidth: "900px",
-      minHeight: "400px",
+      minHeight: "324px",
       background: "#fff",
       padding: "30px 30px",
     },

--- a/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.scss
+++ b/services/frontend-v3/src/components/profileForms/welcome/WelcomeView.scss
@@ -1,9 +1,9 @@
 .content {
   width: 100%;
-  min-height: 400px;
   background: #fff;
   padding: 80px 10px;
 }
+
 .welcome-content {
   text-align: center !important;
   width: 100%;


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Made skeletons the same height as empty form views
- Renamed `NameOptions` to `nameOptions` for the prop
- Made tab error checking happen onValuesChange instead of onFieldsChange (this makes the error checking seem a bit behind in the qualifications form - but I think its a good trade off for getting the forms/url field running smoothly)

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
patch / fixes #821

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
