### PR TITLE
[Fix] Moved back to visible prop

### DIFF
--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -112,8 +112,8 @@ const CategoryTableView = ({
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visibility) => {
-      if (visibility) {
+    onFilterDropdownVisibleChange: (visible) => {
+      if (visible) {
         setTimeout(() => searchInput.select());
       }
     },

--- a/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend-v3/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -197,7 +197,7 @@ const CategoryTableView = ({
   const addCategoryButton = () => {
     return (
       <Modal
-        visibility={addVisible}
+        visible={addVisible}
         title={<FormattedMessage id="admin.add.category" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}
@@ -264,7 +264,7 @@ const CategoryTableView = ({
   const editCategoryButton = () => {
     return (
       <Modal
-        visibility={editVisible}
+        visible={editVisible}
         title={<FormattedMessage id="admin.edit.category" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -217,7 +217,7 @@ const CompetencyTableView = ({
   const addCompetencyModal = () => {
     return (
       <Modal
-        visibility={addVisible}
+        visible={addVisible}
         title={<FormattedMessage id="admin.add.competency" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}
@@ -284,7 +284,7 @@ const CompetencyTableView = ({
   const editCompetencyModal = () => {
     return (
       <Modal
-        visibility={editVisible}
+        visible={editVisible}
         title={<FormattedMessage id="admin.edit.competency" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}

--- a/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend-v3/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -112,8 +112,8 @@ const CompetencyTableView = ({
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visibility) => {
-      if (visibility) {
+    onFilterDropdownVisibleChange: (visible) => {
+      if (visible) {
         setTimeout(() => searchInput.select());
       }
     },

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -218,7 +218,7 @@ const DiplomaTableView = ({
   const addDiplomaModal = () => {
     return (
       <Modal
-        visibility={addVisible}
+        visible={addVisible}
         title={<FormattedMessage id="admin.add.diploma" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}
@@ -285,7 +285,7 @@ const DiplomaTableView = ({
   const editDiplomaModal = () => {
     return (
       <Modal
-        visibility={editVisible}
+        visible={editVisible}
         title={<FormattedMessage id="admin.edit.diploma" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}

--- a/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend-v3/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -113,8 +113,8 @@ const DiplomaTableView = ({
         .toString()
         .toLowerCase()
         .includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visibility) => {
-      if (visibility) {
+    onFilterDropdownVisibleChange: (visible) => {
+      if (visible) {
         setTimeout(() => searchInput.select());
       }
     },

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -132,8 +132,8 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
           .toLowerCase()
           .includes(_value.toLowerCase());
       },
-      onFilterDropdownVisibleChange: (visibility) => {
-        if (visibility) {
+      onFilterDropdownVisibleChange: (visible) => {
+        if (visible) {
           setTimeout(() => searchInput.select());
         }
       },

--- a/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend-v3/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -247,7 +247,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
   const addSchoolModal = () => {
     return (
       <Modal
-        visibility={addVisible}
+        visible={addVisible}
         title={<FormattedMessage id="admin.add.school" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}
@@ -360,7 +360,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
   const editSchoolModal = () => {
     return (
       <Modal
-        visibility={editVisible}
+        visible={editVisible}
         title={<FormattedMessage id="admin.edit.school" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -237,7 +237,7 @@ const SkillTableView = ({
   const editSkillButton = () => {
     return (
       <Modal
-        visibility={editVisible}
+        visible={editVisible}
         title={<FormattedMessage id="admin.edit.skill" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}
@@ -394,7 +394,7 @@ const SkillTableView = ({
   const addSkillButton = () => {
     return (
       <Modal
-        visibility={addVisible}
+        visible={addVisible}
         title={<FormattedMessage id="admin.add.skill" />}
         okText={<FormattedMessage id="admin.apply" />}
         cancelText={<FormattedMessage id="admin.cancel" />}

--- a/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend-v3/src/components/admin/skillTable/SkillTableView.jsx
@@ -132,8 +132,8 @@ const SkillTableView = ({
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visibility) => {
-      if (visibility) {
+    onFilterDropdownVisibleChange: (visible) => {
+      if (visible) {
         setTimeout(() => searchInput.select());
       }
     },

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -123,8 +123,8 @@ const UserTableView = ({
     ),
     onFilter: (value, record) =>
       record[dataIndex].toString().toLowerCase().includes(value.toLowerCase()),
-    onFilterDropdownVisibleChange: (visibility) => {
-      if (visibility) {
+    onFilterDropdownVisibleChange: (visible) => {
+      if (visible) {
         setTimeout(() => searchInput.select());
       }
     },

--- a/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend-v3/src/components/admin/userTable/UserTableView.jsx
@@ -319,13 +319,13 @@ const UserTableView = ({
       onFilter: (value, record) => record[value],
       render: (record) => (
         <>
-          <Tag visibility={record.isAdmin} color="magenta">
+          <Tag visible={record.isAdmin} color="magenta">
             <FormattedMessage id="admin.roles.admin" />
           </Tag>
-          <Tag visibility={record.isManager} color="geekblue">
+          <Tag visible={record.isManager} color="geekblue">
             <FormattedMessage id="admin.roles.manager" />
           </Tag>
-          <Tag visibility={!record.isManager && !record.isAdmin} color="green">
+          <Tag visible={!record.isManager && !record.isAdmin} color="green">
             <FormattedMessage id="admin.roles.standard" />
           </Tag>
         </>


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Used the `visible` prop instead of `visibility` prop for the `<Tag />` and `<Modal />`

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #843

introduced by #813 (@dynamic11 was there a reason you switched it to `visibility` (visibility sounds less appropriate compared to visible, since its just a boolean)? - Just did a quick diff of that PR, and you also changed the `visible` props for the Modal components which accepts only `visible` and not `visibility` https://ant.design/components/modal/#API - And now the modals in the admin dashboard are also not working)

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
![image](https://user-images.githubusercontent.com/22248828/92743538-a5a0d100-f34e-11ea-93e9-418e8349feb5.png)