### PR TITLE
[Fix] remove duplicate education and experience cards

### DIFF
--- a/services/frontend-v3/src/components/education/Education.jsx
+++ b/services/frontend-v3/src/components/education/Education.jsx
@@ -53,6 +53,7 @@ const Education = ({ data, editableCardBool }) => {
       })
     );
   };
+
   return (
     <ProfileCards
       titleId="profile.education"
@@ -69,11 +70,12 @@ const Education = ({ data, editableCardBool }) => {
 };
 
 Education.propTypes = {
-  data: ProfileInfoPropType.isRequired,
+  data: ProfileInfoPropType,
   editableCardBool: PropTypes.bool,
 };
 
 Education.defaultProps = {
+  data: null,
   editableCardBool: false,
 };
 

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -232,25 +232,7 @@ const ProfileLayoutView = ({
             <CareerInterests data={data} editableCardBool={privateProfile} />
           </Col>
         </Row>
-        {/** ********** Qualifications *********** */}
-        <Title
-          level={2}
-          style={styles.sectionHeader}
-          id="divider-qualifications"
-        >
-          <TrophyOutlined twoToneColor="#3CBAB3" style={styles.sectionIcon} />
-          <FormattedMessage id="profile.employee.qualifications" />
-        </Title>
-        <Row style={styles.row}>
-          <Col span={24}>
-            <Education data={data} type={privateProfile} />
-          </Col>
-        </Row>
-        <Row style={styles.row}>
-          <Col span={24}>
-            <Experience data={data} type={privateProfile} />
-          </Col>
-        </Row>
+
         {/** ********** Connections *********** */}
         {privateProfile && (
           <div>


### PR DESCRIPTION
#### Changes introduced
- remove repeated "Education" and "Experience" cards
- set data prop default to null for consistency with other cards


#### Related issue(s)
closes #842 

