### PR TITLE
[Feat] Specified config for sessions

### DIFF
--- a/services/backend/src/auth/keycloak.js
+++ b/services/backend/src/auth/keycloak.js
@@ -22,11 +22,22 @@ const keycloak = new KeycloakConnect(
   }
 );
 
+const expiryDate = new Date(Date.now() + 60 * 60 * 1000);
+
 const sessionInstance = session({
+  name: config.SESSION_NAME,
   secret: config.KEYCLOAK_SECRET,
   resave: false,
   saveUninitialized: true,
   store,
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    domain: config.COOKIE_DOMAIN,
+    path: config.COOKIE_PATH,
+    expires: expiryDate,
+    sameSite: config.ENV === "production",
+  },
 });
 
 module.exports = { keycloak, sessionInstance };

--- a/services/backend/src/config.js
+++ b/services/backend/src/config.js
@@ -14,6 +14,9 @@ const {
   GEDSAPIKEY,
   REDIS_HOST,
   REDIS_PASSWORD,
+  COOKIE_DOMAIN,
+  COOKIE_PATH,
+  SESSION_NAME,
 } = process.env;
 
 const production = {
@@ -30,6 +33,9 @@ const production = {
   GEDSAPIKEY,
   REDIS_HOST,
   REDIS_PASSWORD,
+  COOKIE_DOMAIN,
+  COOKIE_PATH,
+  SESSION_NAME,
 };
 
 const test = {
@@ -73,6 +79,9 @@ const development = {
   GEDSAPIKEY: GEDSAPIKEY || "",
   REDIS_HOST: REDIS_HOST || "redis",
   REDIS_PASSWORD: REDIS_PASSWORD || "",
+  COOKIE_DOMAIN: COOKIE_DOMAIN || undefined,
+  COOKIE_PATH: COOKIE_PATH || undefined,
+  SESSION_NAME: SESSION_NAME || undefined,
 };
 
 const config = () => {


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- sets the following to our cookie session management
  - **name** - sets the name of the cookie, we should just change the default one so people wouldn't know we're using express (Environment variable: `SESSION_NAME`)
  - **secure**
  - **httpOnly**
  - **expires** - one hour after creation
  - **domain** - should be specified to the domain of the application (Environment variable: `COOKIE_DOMAIN`)
  - **path** - can be anything, from my understanding (Environment variable: `COOKIE_PATH`)
  - **sameSite** - should be true (I think), since in our case both are from the same domain (true if production - on servers)

> __Note:__ the envs only need to be set on the server

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
cookies part #836