### PR TITLE
[Fix] Removed "Landing" and "Page" props on h1 tag of Landing Page

### DIFF
--- a/services/frontend-v3/src/components/layouts/landingLayout/LandingLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/landingLayout/LandingLayoutView.jsx
@@ -60,7 +60,7 @@ const LandingLayoutView = () => {
 
   return (
     <AppLayout displaySideBar={false} displaySearch={false} displayLogo={false}>
-      <h1 className="hidden" Landing Page>
+      <h1 className="hidden">
         <FormattedMessage id="landing.login.and.enter" />
       </h1>
       <Row justify="center" style={{ marginTop: "120px" }}>


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Removed Landing and Page props from the h1 tag on line 63 of LandingLayoutView.jsx.

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #872 

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [x] The modifications are tab friendly
- [x] It is accessible
