### PR TITLE
[Fix] Move content to children prop for ProfileCards

### DIFF
--- a/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
+++ b/services/frontend-v3/src/components/careerInterests/CareerInterests.jsx
@@ -7,20 +7,19 @@ import { ProfileInfoPropType } from "../../utils/customPropTypes";
 const CareerInterests = ({ data, editableCardBool }) => (
   <ProfileCards
     titleId="profile.career.interests"
-    content={
-      <CareerInterestsView
-        lookingJob={data.lookingJob}
-        interestedInRemote={data.interestedInRemote}
-        relocationLocations={data.relocationLocations}
-      />
-    }
     cardName="careerInterests"
     id="card-profile-career-interests"
     editUrl="/profile/edit/personal-growth?tab=career-interests"
     data={data}
     editableCardBool={editableCardBool}
     visibility={data.visibleCards.careerInterests}
-  />
+  >
+    <CareerInterestsView
+      lookingJob={data.lookingJob}
+      interestedInRemote={data.interestedInRemote}
+      relocationLocations={data.relocationLocations}
+    />
+  </ProfileCards>
 );
 
 CareerInterests.propTypes = {

--- a/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
+++ b/services/frontend-v3/src/components/competenciesCard/Competencies.jsx
@@ -4,21 +4,20 @@ import ProfileCards from "../profileCards/ProfileCards";
 import CompetenciesView from "./CompetenciesView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
-const Competencies = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId="profile.competencies"
-      content={<CompetenciesView competencies={data.competencies} />}
-      cardName="competencies"
-      id="card-profile-competency"
-      editUrl="/profile/edit/talent?tab=competencies"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.competencies}
-      lastUpdated={data.competenciesUpdatedAt}
-    />
-  );
-};
+const Competencies = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId="profile.competencies"
+    cardName="competencies"
+    id="card-profile-competency"
+    editUrl="/profile/edit/talent?tab=competencies"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.competencies}
+    lastUpdated={data.competenciesUpdatedAt}
+  >
+    <CompetenciesView competencies={data.competencies} />
+  </ProfileCards>
+);
 
 Competencies.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend-v3/src/components/connections/Connections.jsx
+++ b/services/frontend-v3/src/components/connections/Connections.jsx
@@ -3,20 +3,19 @@ import PropTypes from "prop-types";
 import ConnectionsView from "./ConnectionsView";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const connections = ({ data }) => {
-  return (
-    <ProfileCards
-      titleId="profile.connections"
-      content={<ConnectionsView connections={data.connections} />}
-      cardName="privateGroup"
-      id="card-profile-connections"
-      data={data}
-      editableCardBool={false}
-      displayExtraHeaderContent={false}
-      visibility="PUBLIC"
-    />
-  );
-};
+const connections = ({ data }) => (
+  <ProfileCards
+    titleId="profile.connections"
+    cardName="privateGroup"
+    id="card-profile-connections"
+    data={data}
+    editableCardBool={false}
+    displayExtraHeaderContent={false}
+    visibility="PUBLIC"
+  >
+    <ConnectionsView connections={data.connections} />
+  </ProfileCards>
+);
 
 connections.propTypes = {
   data: PropTypes.shape({

--- a/services/frontend-v3/src/components/descriptionCard/DescriptionCard.jsx
+++ b/services/frontend-v3/src/components/descriptionCard/DescriptionCard.jsx
@@ -4,20 +4,19 @@ import ProfileCards from "../profileCards/ProfileCards";
 import DescriptionCardView from "./DescriptionCardView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
-const DescriptionCard = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId="profile.description"
-      cardName="description"
-      content={<DescriptionCardView data={data.description} />}
-      id="card-profile-description"
-      editUrl="/profile/edit/employment"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.description}
-    />
-  );
-};
+const DescriptionCard = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId="profile.description"
+    cardName="description"
+    id="card-profile-description"
+    editUrl="/profile/edit/employment"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.description}
+  >
+    <DescriptionCardView data={data.description} />
+  </ProfileCards>
+);
 
 DescriptionCard.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend-v3/src/components/education/Education.jsx
+++ b/services/frontend-v3/src/components/education/Education.jsx
@@ -57,7 +57,6 @@ const Education = ({ data, editableCardBool }) => {
   return (
     <ProfileCards
       titleId="profile.education"
-      content={<EducationView educationInfo={getEducationInfo(data)} />}
       cardName="education"
       id="card-profile-education"
       editUrl="/profile/edit/qualifications?tab=education"
@@ -65,7 +64,9 @@ const Education = ({ data, editableCardBool }) => {
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.education}
       lastUpdated={data.educationsUpdatedAt}
-    />
+    >
+      <EducationView educationInfo={getEducationInfo(data)} />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/employeeSummary/EmployeeSummary.jsx
+++ b/services/frontend-v3/src/components/employeeSummary/EmployeeSummary.jsx
@@ -4,20 +4,19 @@ import EmployeeSummaryView from "./EmployeeSummaryView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const EmployeeSummary = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId="profile.employee.status"
-      content={<EmployeeSummaryView data={data} />}
-      cardName="info"
-      id="card-profile-employee-summary"
-      editUrl="/profile/edit/employment"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.info}
-    />
-  );
-};
+const EmployeeSummary = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId="profile.employee.status"
+    cardName="info"
+    id="card-profile-employee-summary"
+    editUrl="/profile/edit/employment"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.info}
+  >
+    <EmployeeSummaryView data={data} />
+  </ProfileCards>
+);
 
 EmployeeSummary.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend-v3/src/components/employmentEquity/EmploymentEquity.jsx
+++ b/services/frontend-v3/src/components/employmentEquity/EmploymentEquity.jsx
@@ -37,14 +37,15 @@ const EmploymentEquity = ({ data, editableCardBool }) => {
   return (
     <ProfileCards
       titleId="profile.employment.equity.groups"
-      content={<EmploymentEquityView groups={employmentEquityData} />}
       cardName="employmentEquityGroup"
       id="card-profile-employment-equity"
       editUrl="/profile/edit/primary-info"
       data={data}
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.employmentEquityGroup}
-    />
+    >
+      <EmploymentEquityView groups={employmentEquityData} />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/exFeeder/ExFeeder.jsx
+++ b/services/frontend-v3/src/components/exFeeder/ExFeeder.jsx
@@ -4,19 +4,18 @@ import ExFeederView from "./ExFeederView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const ExFeeder = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId={<ExFeederView data={data} />}
-      cardName="exFeeder"
-      editUrl="/profile/edit/personal-growth?tab=ex-feeder"
-      id="card-profile-ex-feeder"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.exFeeder}
-    />
-  );
-};
+const ExFeeder = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId={<ExFeederView data={data} />}
+    cardName="exFeeder"
+    editUrl="/profile/edit/personal-growth?tab=ex-feeder"
+    id="card-profile-ex-feeder"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.exFeeder}
+  />
+);
+
 ExFeeder.propTypes = {
   data: ProfileInfoPropType,
   editableCardBool: PropTypes.bool,

--- a/services/frontend-v3/src/components/experience/Experience.jsx
+++ b/services/frontend-v3/src/components/experience/Experience.jsx
@@ -61,7 +61,6 @@ const Experience = ({ data, editableCardBool }) => {
   return (
     <ProfileCards
       titleId="profile.experience"
-      content={<ExperienceView experienceInfo={getExperienceInfo(data)} />}
       cardName="experience"
       id="card-profile-experience"
       editUrl="/profile/edit/qualifications?tab=experience"
@@ -69,7 +68,9 @@ const Experience = ({ data, editableCardBool }) => {
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.experience}
       lastUpdated={data.experiencesUpdatedAt}
-    />
+    >
+      <ExperienceView experienceInfo={getExperienceInfo(data)} />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/learningDevelopment/LearningDevelopment.jsx
+++ b/services/frontend-v3/src/components/learningDevelopment/LearningDevelopment.jsx
@@ -4,26 +4,23 @@ import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 import LearningDevelopmentView from "./LearningDevelopmentView";
 
-const LearningDevelopment = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId="profile.learning.development"
-      content={
-        <LearningDevelopmentView
-          devGoals={data.developmentalGoals}
-          devAttachments={data.developmentalGoalsAttachments}
-        />
-      }
-      cardName="developmentalGoals"
-      id="card-profile-learning-development"
-      editUrl="/profile/edit/personal-growth?tab=learning-development"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.developmentalGoals}
-      lastUpdated={data.developmentalGoalsUpdatedAt}
+const LearningDevelopment = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId="profile.learning.development"
+    cardName="developmentalGoals"
+    id="card-profile-learning-development"
+    editUrl="/profile/edit/personal-growth?tab=learning-development"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.developmentalGoals}
+    lastUpdated={data.developmentalGoalsUpdatedAt}
+  >
+    <LearningDevelopmentView
+      devGoals={data.developmentalGoals}
+      devAttachments={data.developmentalGoalsAttachments}
     />
-  );
-};
+  </ProfileCards>
+);
 
 LearningDevelopment.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
+++ b/services/frontend-v3/src/components/mentorshipCard/Mentorship.jsx
@@ -66,12 +66,6 @@ const Mentorship = ({ data, editableCardBool }) => {
   return (
     <ProfileCards
       titleId="profile.mentorship.skills"
-      content={
-        <MentorshipView
-          mentoring={setUpMentorshipSkills()}
-          mentoringCategories={setUpCategories(data.mentorshipSkills)}
-        />
-      }
       cardName="mentorshipSkills"
       id="card-profile-mentorship-skills"
       editUrl="/profile/edit/talent?tab=mentorship"
@@ -79,7 +73,12 @@ const Mentorship = ({ data, editableCardBool }) => {
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.mentorshipSkills}
       lastUpdated={data.mentorshipSkillsUpdatedAt}
-    />
+    >
+      <MentorshipView
+        mentoring={setUpMentorshipSkills()}
+        mentoringCategories={setUpCategories(data.mentorshipSkills)}
+      />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend-v3/src/components/officialLanguage/OfficialLanguage.jsx
@@ -69,18 +69,17 @@ const OfficialLanguage = ({ data, editableCardBool }) => {
     <ProfileCards
       titleId="profile.official.languages"
       cardName="officialLanguage"
-      content={
-        <OfficialLanguageView
-          firstLanguageInfo={getFirstLanguageInfo(data)}
-          secondLanguageInfo={generateSecondLanguageInfo(data)}
-        />
-      }
       id="card-profile-official-language"
       editUrl="/profile/edit/language-proficiency"
       data={data}
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.officialLanguage}
-    />
+    >
+      <OfficialLanguageView
+        firstLanguageInfo={getFirstLanguageInfo(data)}
+        secondLanguageInfo={generateSecondLanguageInfo(data)}
+      />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCards.jsx
@@ -6,7 +6,7 @@ import { ProfileInfoPropType } from "../../utils/customPropTypes";
 const ProfileCards = ({
   data,
   titleId,
-  content,
+  children,
   editUrl,
   cardName,
   id,
@@ -17,7 +17,6 @@ const ProfileCards = ({
 }) => (
   <ProfileCardsView
     titleId={titleId}
-    content={visibility ? content : null}
     editUrl={editUrl}
     cardName={cardName}
     id={id}
@@ -26,13 +25,15 @@ const ProfileCards = ({
     visibleCards={data.visibleCards}
     lastUpdated={lastUpdated}
     displayExtraHeaderContent={displayExtraHeaderContent}
-  />
+  >
+    {visibility ? children : null}
+  </ProfileCardsView>
 );
 
 ProfileCards.propTypes = {
   data: ProfileInfoPropType,
   titleId: PropTypes.node.isRequired,
-  content: PropTypes.element,
+  children: PropTypes.element,
   editUrl: PropTypes.string,
   cardName: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,
@@ -47,7 +48,7 @@ ProfileCards.propTypes = {
 
 ProfileCards.defaultProps = {
   data: null,
-  content: null,
+  children: null,
   editUrl: null,
   editableCardBool: false,
   displayExtraHeaderContent: true,

--- a/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend-v3/src/components/profileCards/ProfileCardsView.jsx
@@ -15,7 +15,7 @@ const ProfileCardsView = ({
   editUrl,
   titleId,
   id,
-  content,
+  children,
   style,
   editableCardBool,
   displayExtraHeaderContent,
@@ -120,7 +120,7 @@ const ProfileCardsView = ({
   return (
     <div>
       <Card
-        className={content === null ? "no-content-card" : null}
+        className={children === null ? "no-content-card" : null}
         title={
           <>
             {typeof titleId === "string" ? (
@@ -148,7 +148,7 @@ const ProfileCardsView = ({
         extra={generateExtraMenu()}
         style={(style, grayedOut)}
       >
-        {content}
+        {children}
       </Card>
     </div>
   );
@@ -158,7 +158,7 @@ ProfileCardsView.propTypes = {
   editUrl: PropTypes.string,
   titleId: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
-  content: PropTypes.element,
+  children: PropTypes.element,
   style: PropTypes.objectOf(PropTypes.string),
   editableCardBool: PropTypes.bool,
   displayExtraHeaderContent: PropTypes.bool,
@@ -178,7 +178,7 @@ ProfileCardsView.propTypes = {
 
 ProfileCardsView.defaultProps = {
   style: undefined,
-  content: null,
+  children: null,
   editUrl: null,
   editableCardBool: false,
   displayExtraHeaderContent: false,

--- a/services/frontend-v3/src/components/skillsCard/Skills.jsx
+++ b/services/frontend-v3/src/components/skillsCard/Skills.jsx
@@ -67,12 +67,6 @@ const Skills = ({ data, editableCardBool }) => {
   return (
     <ProfileCards
       titleId="profile.skills"
-      content={
-        <SkillsView
-          skills={setUpSkills(data.skills)}
-          categoriesSkills={setUpCategories(data.skills)}
-        />
-      }
       cardName="skills"
       id="card-profile-skills"
       editUrl="/profile/edit/talent?tab=skills"
@@ -80,7 +74,12 @@ const Skills = ({ data, editableCardBool }) => {
       editableCardBool={editableCardBool}
       visibility={data.visibleCards.skills}
       lastUpdated={data.skillsUpdatedAt}
-    />
+    >
+      <SkillsView
+        skills={setUpSkills(data.skills)}
+        categoriesSkills={setUpCategories(data.skills)}
+      />
+    </ProfileCards>
   );
 };
 

--- a/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend-v3/src/components/talentManagement/TalentManagement.jsx
@@ -4,20 +4,19 @@ import TalentManagementView from "./TalentManagementView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const TalentManagement = ({ data, editableCardBool }) => {
-  return (
-    <ProfileCards
-      titleId="profile.talent.management"
-      content={<TalentManagementView data={data} />}
-      cardName="talentManagement"
-      id="card-profile-talent-management"
-      editUrl="/profile/edit/personal-growth?tab=talent-management"
-      data={data}
-      editableCardBool={editableCardBool}
-      visibility={data.visibleCards.talentManagement}
-    />
-  );
-};
+const TalentManagement = ({ data, editableCardBool }) => (
+  <ProfileCards
+    titleId="profile.talent.management"
+    cardName="talentManagement"
+    id="card-profile-talent-management"
+    editUrl="/profile/edit/personal-growth?tab=talent-management"
+    data={data}
+    editableCardBool={editableCardBool}
+    visibility={data.visibleCards.talentManagement}
+  >
+    <TalentManagementView data={data} />
+  </ProfileCards>
+);
 
 TalentManagement.propTypes = {
   data: ProfileInfoPropType,


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Made `<ProfileCards />` component receive a children instead of a "content" prop (https://reactjs.org/docs/composition-vs-inheritance.html)

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #902
