### PR TITLE
[New] Added "About me" option to sidebar navigation

### DIFF
--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
@@ -128,7 +128,7 @@ const CreateProfileLayoutView = ({ formStep, highestStep }) => {
                   - <FormattedMessage id="setup.step.3.description" />
                 </li>
                 <li>
-                  - <FormattedMessage id="setup.about.me" />
+                  - <FormattedMessage id="profile.description" />
                 </li>
               </ul>
             }

--- a/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/createProfileLayout/CreateProfileLayoutView.jsx
@@ -127,6 +127,9 @@ const CreateProfileLayoutView = ({ formStep, highestStep }) => {
                 <li>
                   - <FormattedMessage id="setup.step.3.description" />
                 </li>
+                <li>
+                  - <FormattedMessage id="setup.about.me" />
+                </li>
               </ul>
             }
           />

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
@@ -115,6 +115,9 @@ const EditProfileLayoutView = ({ formStep, history }) => {
             <li style={styles.menuListItem}>
               - <FormattedMessage id="setup.step.3.description" />
             </li>
+            <li style={styles.menuListItem}>
+              - <FormattedMessage id="setup.about.me" />
+            </li>
           </ul>
         </Menu.Item>
         <Menu.Item

--- a/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/editProfileLayout/EditProfileLayoutView.jsx
@@ -116,7 +116,7 @@ const EditProfileLayoutView = ({ formStep, history }) => {
               - <FormattedMessage id="setup.step.3.description" />
             </li>
             <li style={styles.menuListItem}>
-              - <FormattedMessage id="setup.about.me" />
+              - <FormattedMessage id="profile.description" />
             </li>
           </ul>
         </Menu.Item>

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -335,6 +335,7 @@
   "settings.visibility.description": "Make your profile visibility or hidden to others. If your profile is hidden, other users won't be able to see or search your profile.",
   "settings.visibility.title": "Profile visibility",
   "settings.visibility.toggle": "Make your profile visibility to others",
+  "setup.about.me": "About me",
   "setup.add.attachment": "Add attachment",
   "setup.add.item": "Add item",
   "setup.attachment": "Attachment links",

--- a/services/frontend-v3/src/i18n/en_CA.json
+++ b/services/frontend-v3/src/i18n/en_CA.json
@@ -335,7 +335,6 @@
   "settings.visibility.description": "Make your profile visibility or hidden to others. If your profile is hidden, other users won't be able to see or search your profile.",
   "settings.visibility.title": "Profile visibility",
   "settings.visibility.toggle": "Make your profile visibility to others",
-  "setup.about.me": "About me",
   "setup.add.attachment": "Add attachment",
   "setup.add.item": "Add item",
   "setup.attachment": "Attachment links",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -335,6 +335,7 @@
   "settings.visibility.description": "Rendez votre profil visibility ou caché aux autres. Si votre profil est caché, les autres utilisateurs ne pourront pas voir ou rechercher votre profil.",
   "settings.visibility.title": "Vsibilité du profil",
   "settings.visibility.toggle": "Mettre votre profil visibility aux autres",
+  "setup.about.me": "À mon propos",
   "setup.add.attachment": "Ajouter une pièce jointe",
   "setup.add.item": "Ajouter",
   "setup.attachment": "Pièces jointes",

--- a/services/frontend-v3/src/i18n/fr_CA.json
+++ b/services/frontend-v3/src/i18n/fr_CA.json
@@ -335,7 +335,6 @@
   "settings.visibility.description": "Rendez votre profil visibility ou caché aux autres. Si votre profil est caché, les autres utilisateurs ne pourront pas voir ou rechercher votre profil.",
   "settings.visibility.title": "Vsibilité du profil",
   "settings.visibility.toggle": "Mettre votre profil visibility aux autres",
-  "setup.about.me": "À mon propos",
   "setup.add.attachment": "Ajouter une pièce jointe",
   "setup.add.item": "Ajouter",
   "setup.attachment": "Pièces jointes",


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Added "About me" option to the sidebar nav for create and edit profiles.
- Added "About me" to English and French translation files.

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #907 

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
![Edit Profile About Me Option](https://user-images.githubusercontent.com/35780281/94032205-b52c0b00-fd8d-11ea-99a9-4744a4f43653.jpg)

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [x] The modifications are tab friendly
- [x] It is accessible
