### PR TITLE
[Feat] Reduce bizchart import size

### DIFF
--- a/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
+++ b/services/frontend-v3/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
@@ -2,10 +2,16 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Card, Row, Col } from "antd";
 import { FormattedMessage, injectIntl } from "react-intl";
-import { IntlPropType } from "../../../utils/customPropTypes";
+import Chart from "bizcharts/lib/components/Chart";
+import Axis from "bizcharts/lib/components/Axis";
+import Tooltip from "bizcharts/lib/components/Tooltip";
+import Coord from "bizcharts/lib/components/Coordinate";
+import Legend from "bizcharts/lib/components/Legend";
+import Point from "bizcharts/lib/geometry/Point";
+import Line from "bizcharts/lib/geometry/Line";
+import Interval from "bizcharts/lib/geometry/Interval";
 
-const { Chart, Geom, Axis, Tooltip, Coord, Legend } =
-  typeof document === "undefined" ? {} : require("bizcharts");
+import { IntlPropType } from "../../../utils/customPropTypes";
 
 /**
  *  DashboardGraphsView(props)
@@ -76,7 +82,7 @@ const DashboardGraphsView = ({
               <Coord scale={[0.7, 0.9]} />
               <Legend position="top" flipPage={false} />
               <Tooltip />
-              <Geom type="interval" position="name*count" color="name" />
+              <Interval position="name*count" color="name" />
             </Chart>
           </Card>
         </Col>
@@ -98,7 +104,7 @@ const DashboardGraphsView = ({
               <Coord scale={[0.7, 0.9]} />
               <Legend position="top" flipPage={false} />
               <Tooltip />
-              <Geom type="interval" position="name*count" color="name" />
+              <Interval position="name*count" color="name" />
             </Chart>
           </Card>
         </Col>
@@ -120,7 +126,7 @@ const DashboardGraphsView = ({
               <Coord scale={[0.7, 0.9]} />
               <Legend position="top" flipPage={false} />
               <Tooltip />
-              <Geom type="interval" position="name*count" color="name" />
+              <Interval position="name*count" color="name" />
             </Chart>
           </Card>
         </Col>
@@ -144,14 +150,8 @@ const DashboardGraphsView = ({
                 <Axis name="monthName" />
                 <Axis name="count" />
                 <Tooltip crosshairs={{ type: "y" }} />
-                <Geom
-                  type="line"
-                  position="monthName*count"
-                  size={2}
-                  color="year"
-                />
-                <Geom
-                  type="point"
+                <Line position="monthName*count" size={2} color="year" />
+                <Point
                   position="monthName*count"
                   size={4}
                   shape="circle"


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Removed `<Geom />` components and used their respected geometry components, alongside with the other chart components
- Importing them like that also removes the old "hacky" way of importing them since bizchart does not support SSR (razzle)

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
https://github.com/CDH-Studio/UpSkill/pull/905


#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
Before (size of bizchart in our bundle):
![Screenshot from 2020-09-27 23-19-39](https://user-images.githubusercontent.com/22248828/94387553-780ea280-0118-11eb-92c3-050e8b3c5b40.png)

After (size of bizchart in our bundle):
![Screenshot from 2020-09-27 23-18-05](https://user-images.githubusercontent.com/22248828/94387559-7a70fc80-0118-11eb-9559-43474163b87a.png)
