### PR TITLE
[Fix] Make cookies locally not secure and added defaults env vars

### DIFF
--- a/services/backend/src/auth/keycloak.js
+++ b/services/backend/src/auth/keycloak.js
@@ -31,12 +31,12 @@ const sessionInstance = session({
   saveUninitialized: true,
   store,
   cookie: {
-    secure: true,
+    secure: config.ENV === "production",
     httpOnly: true,
     domain: config.COOKIE_DOMAIN,
     path: config.COOKIE_PATH,
     expires: expiryDate,
-    sameSite: config.ENV === "production",
+    sameSite: true,
   },
 });
 

--- a/services/backend/src/config.js
+++ b/services/backend/src/config.js
@@ -80,8 +80,8 @@ const development = {
   REDIS_HOST: REDIS_HOST || "redis",
   REDIS_PASSWORD: REDIS_PASSWORD || "",
   COOKIE_DOMAIN: COOKIE_DOMAIN || undefined,
-  COOKIE_PATH: COOKIE_PATH || undefined,
-  SESSION_NAME: SESSION_NAME || undefined,
+  COOKIE_PATH: COOKIE_PATH || "/",
+  SESSION_NAME: SESSION_NAME || "local.dev.italent.sid",
 };
 
 const config = () => {


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
I just tried something locally - I reverted the changes made for the cookies for session management and I saw this in the API requests

![image](https://user-images.githubusercontent.com/22248828/94717276-19b31100-031e-11eb-97a2-87da71831068.png)

After putting it how it is now and disabling the secure (since locally the backend is not https - doesn't have a SSL certificate) I see this

![image](https://user-images.githubusercontent.com/22248828/94718532-d9ed2900-031f-11eb-8db2-9c26cb19155f.png)

And when it is secured, I think the name gets encrypted - this is shown in openshift

![image](https://user-images.githubusercontent.com/22248828/94718874-5a138e80-0320-11eb-9877-fc8054fac18a.png)

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #853
