### PR TITLE
[Fix] Reverted dayjs

### DIFF
--- a/services/frontend-v3/package.json
+++ b/services/frontend-v3/package.json
@@ -13,7 +13,7 @@
     "axios": "0.20.0",
     "bizcharts": "4.0.14",
     "craco-antd": "1.18.1",
-    "dayjs": "1.9.3",
+    "dayjs": "1.8.35",
     "history": "5.0.0",
     "keycloak-js": "11.0.2",
     "lodash": "4.17.20",

--- a/services/frontend-v3/yarn.lock
+++ b/services/frontend-v3/yarn.lock
@@ -4273,12 +4273,7 @@ date-fns@^2.15.0:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-dayjs@1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.9.3.tgz#b7f94b22ad2a136a4ca02a01ab68ae893fe1a268"
-  integrity sha512-V+1SyIvkS+HmNbN1G7A9+ERbFTV9KTXu6Oor98v2xHmzzpp52OIJhQuJSTywWuBY5pyAEmlwbCi1Me87n/SLOw==
-
-dayjs@^1.8.30:
+dayjs@1.8.35, dayjs@^1.8.30:
   version "1.8.35"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.35.tgz#67118378f15d31623f3ee2992f5244b887606888"
   integrity sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ==


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Reverts dayjs package to version `1.8.35`

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #962 

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
