### PR TITLE
[Fix] force the content under the side nav when expanded

### DIFF
--- a/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.scss
+++ b/services/frontend-v3/src/components/layouts/appLayout/AppLayoutView.scss
@@ -3,3 +3,9 @@
   margin: 0;
   margin-top: 64px;
 }
+
+.ant-layout-sider-below {
+  position: fixed;
+  z-index: 999;
+  height: 100%;
+}


### PR DESCRIPTION
#### Changes introduced
- on small screens the sidenav auto collapses.
- when user expand the sidenav it open over top of page content


#### Related issue(s)
closes #964 


#### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/96617305-74161080-12d1-11eb-937b-5b7ae4f68214.png)


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
