### PR TITLE
[Fix] Gutter padding profile

### DIFF
--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -432,7 +432,7 @@ const ProfileLayoutView = ({
           message={<FormattedMessage id={messageId} />}
           type={isHidden ? "warning" : "error"}
           showIcon
-          style={{ marginBottom: 5 }}
+          style={{ marginBottom: 10 }}
           icon={isHidden ? <EyeInvisibleOutlined /> : <LockOutlined />}
         />
       );

--- a/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend-v3/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -80,7 +80,13 @@ const ProfileLayoutView = ({
     return (
       <div>
         {/* Employee summary */}
-        <Row gutter={[{ xs: 8, sm: 12 }, { lg: 15, xl: 0 }]} type="flex">
+        <Row
+          gutter={[
+            { xs: 8, sm: 12 },
+            { xs: 15, sm: 15, xl: 0 },
+          ]}
+          type="flex"
+        >
           <Col xs={24} xl={14}>
             <BasicInfo
               data={data}
@@ -170,11 +176,7 @@ const ProfileLayoutView = ({
           </Col>
         </Row>
 
-        <Row
-          className="app-row"
-          gutter={[{ xs: 8, sm: 16, md: 16, lg: 16 }, 20]}
-          type="flex"
-        >
+        <Row className="app-row" gutter={[{ xs: 8, sm: 16 }, 20]} type="flex">
           <Col xs={24} xl={12}>
             <TalentManagement data={data} editableCardBool={privateProfile} />
             <div style={{ paddingTop: "16px" }}>

--- a/services/frontend-v3/src/styling/custom_antd.scss
+++ b/services/frontend-v3/src/styling/custom_antd.scss
@@ -197,3 +197,7 @@ span.searchInput {
 .ant-page-header-heading-title svg {
   margin-right: 7px;
 }
+
+.ant-alert {
+  border-radius: $border-radius;
+}


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Improperly used the Grid gutter properties (https://ant.design/components/grid/#Col)
- Made alerts round and added same padding as the rest of the application

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #986

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
Before:
![image](https://user-images.githubusercontent.com/22248828/97041729-ef7bfa00-153d-11eb-8fad-fce9f4edf5c8.png)

After:
![image](https://user-images.githubusercontent.com/22248828/97041695-dd9a5700-153d-11eb-971e-4a857c66d95e.png)

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
