### PR TITLE
[Feat] responsive admin

### DIFF
--- a/services/frontend/src/components/admin/categoryTable/CategoryTable.jsx
+++ b/services/frontend/src/components/admin/categoryTable/CategoryTable.jsx
@@ -110,6 +110,7 @@ const CategoryTable = ({ intl }) => {
     onChange: (_selectedRowKeys) => {
       onSelectChange(_selectedRowKeys);
     },
+    fixed: "left",
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/admin/categoryTable/CategoryTableView.jsx
+++ b/services/frontend/src/components/admin/categoryTable/CategoryTableView.jsx
@@ -382,6 +382,8 @@ const CategoryTableView = ({
     {
       title: <FormattedMessage id="admin.edit" />,
       key: "edit",
+      fixed: "right",
+      width: 70,
       render: (record) => (
         <div>
           <Button
@@ -431,6 +433,7 @@ const CategoryTableView = ({
             columns={categoryTableColumns()}
             dataSource={sortedData}
             loading={loading}
+            scroll={{ x: 500 }}
           />
         </Col>
       </Row>

--- a/services/frontend/src/components/admin/competencyTable/CompetencyTable.jsx
+++ b/services/frontend/src/components/admin/competencyTable/CompetencyTable.jsx
@@ -100,6 +100,7 @@ const CompetencyTable = ({ intl }) => {
     onChange: (_selectedRowKeys) => {
       setSelectedRowKeys(_selectedRowKeys);
     },
+    fixed: "left",
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/admin/competencyTable/CompetencyTableView.jsx
+++ b/services/frontend/src/components/admin/competencyTable/CompetencyTableView.jsx
@@ -379,6 +379,8 @@ const CompetencyTableView = ({
     {
       title: <FormattedMessage id="admin.edit" />,
       key: "edit",
+      fixed: "right",
+      width: 70,
       render: (record) => (
         <div>
           <Button
@@ -428,6 +430,7 @@ const CompetencyTableView = ({
             columns={competencyTableColumns()}
             dataSource={sortedData}
             loading={loading}
+            scroll={{ x: 500 }}
           />
         </Col>
       </Row>

--- a/services/frontend/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
+++ b/services/frontend/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
@@ -66,7 +66,7 @@ const DashboardGraphsView = ({
   return (
     <>
       <Row gutter={[8, 8]}>
-        <Col span={8}>
+        <Col xs={24} sm={24} md={12} xl={8}>
           <Card
             title={<FormattedMessage id="admin.dashboard.popular.skills" />}
             loading={topFiveSkills.length === 0}
@@ -86,7 +86,7 @@ const DashboardGraphsView = ({
             </Chart>
           </Card>
         </Col>
-        <Col span={8}>
+        <Col xs={24} sm={24} md={12} xl={8}>
           <Card
             title={
               <FormattedMessage id="admin.dashboard.popular.competencies" />
@@ -108,7 +108,7 @@ const DashboardGraphsView = ({
             </Chart>
           </Card>
         </Col>
-        <Col span={8}>
+        <Col xs={24} sm={24} md={12} xl={8}>
           <Card
             title={
               <FormattedMessage id="admin.dashboard.popular.development.goals" />
@@ -130,10 +130,8 @@ const DashboardGraphsView = ({
             </Chart>
           </Card>
         </Col>
-      </Row>
-      {monthlyGrowth && (
-        <Row gutter={[8, 8]}>
-          <Col span={24}>
+        {monthlyGrowth && (
+          <Col span={24} md={12} xl={24}>
             <Card
               title={
                 <FormattedMessage id="admin.dashboard.growth.rate.by.month" />
@@ -164,8 +162,8 @@ const DashboardGraphsView = ({
               </Chart>
             </Card>
           </Col>
-        </Row>
-      )}
+        )}
+      </Row>
     </>
   );
 };

--- a/services/frontend/src/components/admin/diplomaTable/DiplomaTable.jsx
+++ b/services/frontend/src/components/admin/diplomaTable/DiplomaTable.jsx
@@ -107,6 +107,7 @@ const DiplomaTable = ({ intl }) => {
     onChange: (modifiedSelectedRowKeys) => {
       onSelectChange(modifiedSelectedRowKeys);
     },
+    fixed: "left",
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/admin/diplomaTable/DiplomaTableView.jsx
+++ b/services/frontend/src/components/admin/diplomaTable/DiplomaTableView.jsx
@@ -381,6 +381,8 @@ const DiplomaTableView = ({
     {
       title: <FormattedMessage id="admin.edit" />,
       key: "edit",
+      fixed: "right",
+      width: 70,
       render: (item) => (
         <div>
           <Button
@@ -430,6 +432,7 @@ const DiplomaTableView = ({
             columns={diplomaTableColumns()}
             dataSource={sortedData}
             loading={loading}
+            scroll={{ x: 500 }}
           />
         </Col>
       </Row>

--- a/services/frontend/src/components/admin/schoolTable/SchoolTable.jsx
+++ b/services/frontend/src/components/admin/schoolTable/SchoolTable.jsx
@@ -111,6 +111,7 @@ const SchoolTable = ({ intl }) => {
     onChange: (_selectedRowKeys) => {
       onSelectChange(_selectedRowKeys);
     },
+    fixed: "left",
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/admin/schoolTable/SchoolTableView.jsx
+++ b/services/frontend/src/components/admin/schoolTable/SchoolTableView.jsx
@@ -520,6 +520,8 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
     {
       title: <FormattedMessage id="admin.edit" />,
       key: "edit",
+      fixed: "right",
+      width: 70,
       render: (item) => (
         <div>
           <Button
@@ -571,6 +573,7 @@ setSelectedKeys: ƒ setSelectedKeys(selectedKeys)
             columns={schoolsTableColumns()}
             dataSource={sortedData}
             loading={loading}
+            scroll={{ x: 700 }}
           />
         </Col>
       </Row>

--- a/services/frontend/src/components/admin/skillTable/SkillTable.jsx
+++ b/services/frontend/src/components/admin/skillTable/SkillTable.jsx
@@ -131,6 +131,7 @@ const SkillTable = ({ intl }) => {
     onChange: (_selectedRowKeys) => {
       onSelectChange(_selectedRowKeys);
     },
+    fixed: "left",
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/admin/skillTable/SkillTableView.jsx
+++ b/services/frontend/src/components/admin/skillTable/SkillTableView.jsx
@@ -369,6 +369,8 @@ const SkillTableView = ({
     {
       title: <FormattedMessage id="admin.edit" />,
       key: "edit",
+      fixed: "right",
+      width: 70,
       render: (record) => (
         <div>
           <Button
@@ -519,6 +521,7 @@ const SkillTableView = ({
             columns={skillTableColumns()}
             dataSource={data}
             loading={skills.loading || categories.loading}
+            scroll={{ x: 800 }}
           />
         </Col>
       </Row>

--- a/services/frontend/src/components/admin/statCards/StatCardsView.jsx
+++ b/services/frontend/src/components/admin/statCards/StatCardsView.jsx
@@ -28,7 +28,7 @@ const StatCardsView = ({
 }) => {
   return (
     <Row gutter={[8, 8]} type="flex">
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={countUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.total.users" />}
@@ -38,7 +38,7 @@ const StatCardsView = ({
           />
         </Card>
       </Col>
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={countInactiveUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.inactive.users" />}
@@ -48,7 +48,7 @@ const StatCardsView = ({
           />
         </Card>
       </Col>
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={countHiddenUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.flagged.profiles" />}
@@ -58,7 +58,7 @@ const StatCardsView = ({
           />
         </Card>
       </Col>
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={countExFeederUsers === "-"}>
           <Statistic
             title={<FormattedMessage id="admin.dashboard.ex.feeders" />}
@@ -68,7 +68,7 @@ const StatCardsView = ({
           />
         </Card>
       </Col>
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={newUsers === "-"}>
           <Statistic
             title={`${intl.formatMessage({
@@ -80,7 +80,7 @@ const StatCardsView = ({
           />
         </Card>
       </Col>
-      <Col span={4}>
+      <Col xs={12} sm={8} xl={4}>
         <Card style={{ height: "100%" }} loading={growthRatePrevMonth === "-"}>
           <Statistic
             title={`${intl.formatMessage({

--- a/services/frontend/src/components/admin/userTable/UserTableView.jsx
+++ b/services/frontend/src/components/admin/userTable/UserTableView.jsx
@@ -323,6 +323,8 @@ const UserTableView = ({
     },
     {
       title: <FormattedMessage id="admin.profileStatus" />,
+      fixed: "right",
+      width: 150,
       filters: [
         {
           text: <FormattedMessage id="admin.active" />,
@@ -344,6 +346,8 @@ const UserTableView = ({
     },
     {
       title: <FormattedMessage id="admin.delete" />,
+      fixed: "right",
+      width: 80,
       render: (record) => (
         <Popconfirm
           placement="left"
@@ -412,6 +416,7 @@ const UserTableView = ({
             columns={userTableColumns()}
             dataSource={data}
             loading={loading && locale !== dataLocale}
+            scroll={{ x: 900 }}
             pagination={{
               hideOnSinglePage: true,
             }}

--- a/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.jsx
@@ -153,18 +153,23 @@ const TopNavView = ({ isAdmin, loading, displaySearch, displayLogo, intl }) => {
     showMenu &&
     menu(
       false,
-      <Menu.Item className="dropDownItem">
-        <Link tabIndex={0} to="/">
-          <HomeOutlined className="menuIcon" />
-          <FormattedMessage id="home" />
-        </Link>
-      </Menu.Item>
+      <>
+        <Menu.Divider />
+        <Menu.Item className="dropDownItem">
+          <Link tabIndex={0} to="/">
+            <HomeOutlined className="menuIcon" />
+            <FormattedMessage id="home" />
+          </Link>
+        </Menu.Item>
+      </>
     );
+
+  const toggleHamburgerMenu = () => setShowMenu((prev) => !prev);
 
   const hamburgerButton = (userName) => {
     if (userName) {
       return (
-        <Button type="default" onClick={() => setShowMenu((prev) => !prev)}>
+        <Button type="default" onClick={toggleHamburgerMenu}>
           <MenuOutlined />
         </Button>
       );
@@ -228,6 +233,9 @@ const TopNavView = ({ isAdmin, loading, displaySearch, displayLogo, intl }) => {
         </div>
         {hamburgerMenu()}
       </Header>
+      {showMenu && (
+        <div className="hamburgerOverlay" onClick={toggleHamburgerMenu} />
+      )}
     </>
   );
 };

--- a/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.scss
+++ b/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.scss
@@ -3,7 +3,7 @@
   padding: 0 !important;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 0.1rem 0.1rem;
   position: fixed;
-  z-index: 100;
+  z-index: 9999;
   width: 100%;
   border-bottom: 1px solid #f0f0f0;
 }
@@ -35,8 +35,9 @@
 }
 
 .hamburgerMenu {
-  padding-bottom: 23px !important;
-  box-shadow: rgba(0, 0, 0, 0.05) 0px 0.1rem 0.1rem;
+  padding-top: 0px !important;
+  padding-bottom: 5px !important;
+  box-shadow: rgba(0, 0, 0, 0.05) 0px 0.1rem 0.1rem !important;
 }
 .hamburgerHeader {
   justify-content: space-between;
@@ -44,6 +45,13 @@
   align-items: center;
   height: 100% !important;
   margin: 0 20px !important;
+}
+.hamburgerOverlay {
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(0,0,0,0.5);
+  z-index: 99;
 }
 .divider {
   margin: 0;

--- a/services/frontend/src/styling/custom_antd.scss
+++ b/services/frontend/src/styling/custom_antd.scss
@@ -201,3 +201,7 @@ span.searchInput {
 .ant-alert {
   border-radius: $border-radius;
 }
+
+.ant-layout-sider-zero-width-trigger-left {
+  border-radius: 0 $border-radius $border-radius 0;
+}


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Made the cards in admin dashboard responsive
- Made the tables in admin responsive
- Updated the hamburger menu for the re-design

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #998

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
![Peek 2020-10-24 16-37](https://user-images.githubusercontent.com/22248828/97093095-4efa0880-1617-11eb-8391-399aaa540653.gif)

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
