### PR TITLE
[Feat] Simplify ant-design custom styling

### DIFF
--- a/services/frontend/src/antdTheme.js
+++ b/services/frontend/src/antdTheme.js
@@ -19,5 +19,5 @@ module.exports = {
   "@card-actions-background": "transparent",
   "@card-head-height": "55px",
   "@list-item-meta-margin-bottom": "0",
-  "@list-item-meta-title-margin-bottom": "0",
+  "@tag-font-size": "14px",
 };

--- a/services/frontend/src/antdTheme.js
+++ b/services/frontend/src/antdTheme.js
@@ -16,8 +16,8 @@ module.exports = {
   "@border-radius-base": "5px",
   "@layout-header-background": "@body-background",
   "@form-item-margin-bottom": "13px",
-  "@card-shadow": "0 1.4px 1.4px rgba(0, 0, 0, 0.05)",
   "@card-actions-background": "transparent",
+  "@card-head-height": "55px",
   "@list-item-meta-margin-bottom": "0",
   "@list-item-meta-title-margin-bottom": "0",
 };

--- a/services/frontend/src/antdTheme.js
+++ b/services/frontend/src/antdTheme.js
@@ -11,7 +11,13 @@
 module.exports = {
   "@primary-color": "#087472",
   "@link": "#00B9B2",
-  "@success-color": "#00cc00",
   "@warning-color": "#ff661a",
   "@error-color": "#ff3333",
+  "@border-radius-base": "5px",
+  "@layout-header-background": "@body-background",
+  "@form-item-margin-bottom": "13px",
+  "@card-shadow": "0 1.4px 1.4px rgba(0, 0, 0, 0.05)",
+  "@card-actions-background": "transparent",
+  "@list-item-meta-margin-bottom": "0",
+  "@list-item-meta-title-margin-bottom": "0",
 };

--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -54,7 +54,7 @@ const BasicInfoView = ({
   /* Component Styles */
   const styles = {
     avatar: {
-      backgroundColor: "#fff",
+      backgroundColor: "transparent",
       color: "#007471",
       marginRight: "-10px",
     },

--- a/services/frontend/src/components/layouts/appLayout/sideNav/SideNavView.scss
+++ b/services/frontend/src/components/layouts/appLayout/sideNav/SideNavView.scss
@@ -1,4 +1,3 @@
 .app-sider {
-  background: #fff !important;
   height: 100vh;
 }

--- a/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.scss
+++ b/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.scss
@@ -1,5 +1,4 @@
 .header {
-  background-color: white;
   padding: 0 !important;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 0.1rem 0.1rem;
   position: fixed;

--- a/services/frontend/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend/src/components/profileCards/ProfileCardsView.jsx
@@ -114,7 +114,7 @@ const ProfileCardsView = ({
   };
 
   const grayedOut = {
-    backgroundColor: visibility ? "#fff" : "#DCDCDC",
+    backgroundColor: !visibility && "#DCDCDC",
   };
 
   return (

--- a/services/frontend/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend/src/components/searchBar/SearchBarView.jsx
@@ -74,7 +74,6 @@ const SearchBarView = ({
       <div>
         <div className="search-mainSearchField">{getBasicField()}</div>
         <Button
-          shape="round"
           size="large"
           type="primary"
           htmlType="submit"
@@ -85,7 +84,6 @@ const SearchBarView = ({
         </Button>
         <Button
           ghost
-          shape="round"
           size="large"
           className="search-clearBtn"
           onClick={() => {
@@ -275,7 +273,6 @@ const SearchBarView = ({
           }}
         >
           <Button
-            shape="round"
             size="large"
             type="primary"
             htmlType="submit"
@@ -285,7 +282,6 @@ const SearchBarView = ({
             {searchLabel}
           </Button>
           <Button
-            shape="round"
             size="large"
             className="search-clearBtn"
             onClick={() => {

--- a/services/frontend/src/components/searchFilter/SearchFilterView.jsx
+++ b/services/frontend/src/components/searchFilter/SearchFilterView.jsx
@@ -205,7 +205,6 @@ const SearchFilterView = ({
         </Form.Item>
         <Button
           className="search-w100"
-          shape="round"
           size="large"
           type="primary"
           htmlType="submit"

--- a/services/frontend/src/styling/accessibility.scss
+++ b/services/frontend/src/styling/accessibility.scss
@@ -90,7 +90,7 @@ header {
 }
 
 .ant-menu-item {
-   border-radius: $border-radius;
+  border-radius: $border-radius;
 }
 
 .ant-menu-item:active,
@@ -161,7 +161,6 @@ header {
 
 .ant-menu-item:focus {
   background-color: rgba($app-black, 0.2) !important;
-  // border-radius: $border-radius;
 }
 
 .ant-collapse-header:focus {

--- a/services/frontend/src/styling/accessibility.scss
+++ b/services/frontend/src/styling/accessibility.scss
@@ -89,10 +89,13 @@ header {
   }
 }
 
+.ant-menu-item {
+   border-radius: $border-radius;
+}
+
 .ant-menu-item:active,
 .ant-menu-item-selected {
   background-color: $app-gray !important;
-  border-radius: $border-radius;
 }
 
 .ant-card {
@@ -158,7 +161,7 @@ header {
 
 .ant-menu-item:focus {
   background-color: rgba($app-black, 0.2) !important;
-  border-radius: $border-radius;
+  // border-radius: $border-radius;
 }
 
 .ant-collapse-header:focus {

--- a/services/frontend/src/styling/custom_antd.scss
+++ b/services/frontend/src/styling/custom_antd.scss
@@ -1,69 +1,24 @@
 @import "./_variables.scss";
 
-.custom-bubble-select-style .ant-select-selection-item {
-  margin: 3px !important;
-  padding: 1px 10px !important;
-  height: auto !important;
-  border-color: $app-gray !important;
+.no-content-card .ant-card-body {
+  padding: 0px !important;
 }
 
 .experience-item-list .ant-list-item-extra {
-  margin-top: 0px !important;
-  margin-left: 0.25em !important;
+  margin: 0 auto 10px 0;
 }
 
-.results-card-divider
-  .ant-divider
-  .ant-divider-horizontal
-  .ant-divider-with-text-left {
-  &::before {
-    border-top-color: $app-black !important;
-  }
-  &::after {
-    border-top-color: $app-black !important;
-  }
-}
-
-.ant-form-item-control-input-content {
-  width: 100%;
-}
-
-.ant-list-item-meta-title {
-  font-size: 16px !important;
-  line-height: 24px !important;
-}
-
-.ant-list-item-meta-description {
-  font-size: 14px !important;
-  line-height: 22px !important;
-}
-
-.ant-tag.ant-tag-has-color {
-  font-size: 14px !important;
-}
-
-.ant-page-header-heading-title {
-  font-size: 24px !important;
-}
-
-.ant-list-item {
-  font-size: 16px !important;
-}
-
-///////
-
-.no-content-card .ant-card-body {
-  padding: 0px !important;
+.custom-bubble-select-style .ant-select-selection-item {
+  margin: 3px;
+  padding: 1px 10px;
+  height: auto;
+  border-color: $app-gray;
 }
 
 .ant {
   &-layout-sider {
     box-shadow: $box-shadow-side-menu;
     border-right: 1px solid #f0f0f0;
-  }
-
-  &-card-head-wrapper {
-    height: 55px !important;
   }
 
   &-menu {
@@ -80,21 +35,36 @@
     border: none;
   }
 
-  &-table,
-  &-card {
+  &-list-item-meta-title {
+    font-size: 16px;
+    margin: 0px;
+  }
+
+  &-table {
     box-shadow: $box-shadow-card;
   }
 
-  &-card-body {
-    padding-top: 10px !important;
-    padding-bottom: 10px !important;
+  &-card {
+    box-shadow: $box-shadow-card;
+
+    &-body {
+      padding-top: 10px !important;
+      padding-bottom: 10px !important;
+    }
+
+    &-head-wrapper {
+      height: 55px !important;
+    }
   }
 
-  &-form-item-label {
-    padding: 0px !important;
-  }
-  &-form-item-explain {
-    margin: 0;
+  &-form-item {
+    &-label {
+      padding: 0px !important;
+    }
+
+    &-explain {
+      margin: 0;
+    }
   }
 
   &-page-header-heading-title {

--- a/services/frontend/src/styling/custom_antd.scss
+++ b/services/frontend/src/styling/custom_antd.scss
@@ -9,7 +9,6 @@
   margin: 3px !important;
   padding: 1px 10px !important;
   height: auto !important;
-  border-radius: $border-radius !important;
   border-color: $app-gray !important;
 }
 
@@ -35,10 +34,6 @@
   }
 }
 
-.ant-form-item {
-  margin-bottom: 13px !important;
-}
-
 .ant-form-item-label {
   padding: 0px !important;
 }
@@ -50,7 +45,6 @@
 .ant-list-item-meta-title {
   font-size: 16px !important;
   line-height: 24px !important;
-  margin-bottom: 0px !important;
 }
 
 .ant-list-item-meta-description {
@@ -96,7 +90,6 @@
   margin: 3px !important;
   padding: 5px 12px !important;
   height: auto !important;
-  border-radius: $border-radius !important;
   border-width: 0px !important;
   border-color: $app-gray !important;
 }
@@ -107,31 +100,8 @@
   padding-left: 8px;
 }
 
-.ant-card {
-  border-radius: $border-radius;
-  box-shadow: $box-shadow-card;
-}
-
 .ant-table {
-  border-radius: $border-radius;
   box-shadow: $box-shadow-card;
-
-  .ant-table-thead tr th:first-child {
-    border-top-left-radius: $border-radius !important;
-  }
-
-  .ant-table-thead tr th:last-child {
-    border-top-right-radius: $border-radius !important;
-  }
-}
-
-span.searchInput {
-  span.ant-input-group-addon {
-    background: none;
-    button {
-      border-radius: 0 $border-radius $border-radius 0 !important;
-    }
-  }
 }
 
 .ant-layout-sider-children {
@@ -143,48 +113,8 @@ span.searchInput {
   border: none !important;
 }
 
-.ant-btn,
-.ant-form-item input,
-.ant-select-selector,
-.ant-pagination-item,
-.ant-pagination-item-link,
-.ant-input,
-.ant-picker,
-.ant-modal-content,
-.ant-dropdown-menu,
-.ant-notification-notice,
-.ant-popover-inner,
-.ant-collapse,
-.ant-select-dropdown {
-  border-radius: $border-radius !important;
-}
 
-.ant-card-actions,
-.ant-modal-header {
-  background-color: transparent !important;
-}
-
-.ant-radio-group .ant-radio-button-wrapper {
-  &:first-child {
-    border-radius: $border-radius 0 0 $border-radius !important;
-  }
-
-  &:last-child {
-    border-radius: 0 $border-radius $border-radius 0 !important;
-  }
-}
-
-.ant-tabs-tab {
-  border-radius: $border-radius $border-radius 0 0 !important;
-}
-
-.ant-ribbon {
-  border-radius: $border-radius $border-radius 0 $border-radius;
-}
-
-.ant-btn-circle {
-  border-radius: 50% !important;
-}
+// KEEP
 
 .ant-page-header-heading-title {
   padding: 5px 10px;
@@ -196,12 +126,4 @@ span.searchInput {
 
 .ant-page-header-heading-title svg {
   margin-right: 7px;
-}
-
-.ant-alert {
-  border-radius: $border-radius;
-}
-
-.ant-layout-sider-zero-width-trigger-left {
-  border-radius: 0 $border-radius $border-radius 0;
 }

--- a/services/frontend/src/styling/custom_antd.scss
+++ b/services/frontend/src/styling/custom_antd.scss
@@ -1,10 +1,5 @@
 @import "./_variables.scss";
 
-.no-content-card .ant-card-body {
-  padding-top: 0px !important;
-  padding-bottom: 0px !important;
-}
-
 .custom-bubble-select-style .ant-select-selection-item {
   margin: 3px !important;
   padding: 1px 10px !important;
@@ -17,11 +12,6 @@
   margin-left: 0.25em !important;
 }
 
-.ant-layout-sider-trigger {
-  background-color: $app-gray !important;
-  color: rgb(0, 30, 30) !important;
-}
-
 .results-card-divider
   .ant-divider
   .ant-divider-horizontal
@@ -32,10 +22,6 @@
   &::after {
     border-top-color: $app-black !important;
   }
-}
-
-.ant-form-item-label {
-  padding: 0px !important;
 }
 
 .ant-form-item-control-input-content {
@@ -52,28 +38,6 @@
   line-height: 22px !important;
 }
 
-.ant-card-head {
-  height: 55px !important;
-}
-
-.ant-card-small {
-  .ant-card-head {
-    height: 35px !important;
-  }
-  .ant-card-head-wrapper {
-    height: 35px !important;
-  }
-}
-
-.ant-card-head-wrapper {
-  height: 55px !important;
-}
-
-.ant-card-body {
-  padding-top: 10px !important;
-  padding-bottom: 10px !important;
-}
-
 .ant-tag.ant-tag-has-color {
   font-size: 14px !important;
 }
@@ -86,44 +50,62 @@
   font-size: 16px !important;
 }
 
-.ant-tag {
-  margin: 3px !important;
-  padding: 5px 12px !important;
-  height: auto !important;
-  border-width: 0px !important;
-  border-color: $app-gray !important;
+///////
+
+.no-content-card .ant-card-body {
+  padding: 0px !important;
 }
 
-.ant-menu {
-  padding-top: 5px;
-  padding-right: 8px;
-  padding-left: 8px;
-}
+.ant {
+  &-layout-sider {
+    box-shadow: $box-shadow-side-menu;
+    border-right: 1px solid #f0f0f0;
+  }
 
-.ant-table {
-  box-shadow: $box-shadow-card;
-}
+  &-card-head-wrapper {
+    height: 55px !important;
+  }
 
-.ant-layout-sider-children {
-  box-shadow: $box-shadow-side-menu;
-  border-right: 1px solid #f0f0f0;
-}
+  &-menu {
+    padding: 5px 8px;
 
-.ant-menu-vertical {
-  border: none !important;
-}
+    &-vertical {
+      border: none !important;
+    }
+  }
 
+  &-tag {
+    margin: 3px;
+    padding: 5px 12px;
+    border: none;
+  }
 
-// KEEP
+  &-table,
+  &-card {
+    box-shadow: $box-shadow-card;
+  }
 
-.ant-page-header-heading-title {
-  padding: 5px 10px;
-  background-color: $app-green;
-  color: white;
-  font-size: 1.5em !important;
-  border-radius: $border-radius;
-}
+  &-card-body {
+    padding-top: 10px !important;
+    padding-bottom: 10px !important;
+  }
 
-.ant-page-header-heading-title svg {
-  margin-right: 7px;
+  &-form-item-label {
+    padding: 0px !important;
+  }
+  &-form-item-explain {
+    margin: 0;
+  }
+
+  &-page-header-heading-title {
+    padding: 5px 10px;
+    background-color: $app-green;
+    color: white;
+    font-size: 1.5em !important;
+    border-radius: $border-radius;
+
+    svg {
+      margin-right: 7px;
+    }
+  }
 }

--- a/services/frontend/src/styling/index.scss
+++ b/services/frontend/src/styling/index.scss
@@ -31,7 +31,7 @@ body {
 
 span.searchInput {
   input {
-    border-radius: $border-radius 0 0 $border-radius !important;
+    // border-radius: $border-radius 0 0 $border-radius !important;
     background-color: #f0f2f55d;
 
     &:active,

--- a/services/frontend/src/styling/index.scss
+++ b/services/frontend/src/styling/index.scss
@@ -29,16 +29,13 @@ body {
   max-width: 900px;
 }
 
-span.searchInput {
-  input {
-    // border-radius: $border-radius 0 0 $border-radius !important;
-    background-color: #f0f2f55d;
-
-    &:active,
-    &:focus {
-      background-color: white;
-    }
+span.searchInput input {
+  &:active,
+  &:focus {
+    background-color: white;
   }
+
+  background-color: #f0f2f55d;
 }
 
 .org-dropdown {


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
Just figured out that there's theming variables that can be overridden.... (which are these ones https://github.com/ant-design/ant-design/blob/master/components/style/themes/default.less)

- Modify the `ant-design` theme variables instead of creating a big scss override file specifying the ant design css class names

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
NA

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
NA

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
