### PR TITLE
[Fix] API docs authentication

### DIFF
--- a/services/backend/src/docs/oauth2-redirect.html
+++ b/services/backend/src/docs/oauth2-redirect.html
@@ -1,12 +1,17 @@
 <!doctype html>
 <html lang="en-US">
-<title>Swagger UI: OAuth2 Redirect</title>
-<body onload="run()">
+
+<head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+</head>
+
+<body>
 </body>
+
 </html>
 <script>
     'use strict';
-    function run () {
+    function run() {
         var oauth2 = window.opener.swaggerUIRedirectOauth2;
         var sentState = oauth2.state;
         var redirectUrl = oauth2.redirectUrl;
@@ -19,18 +24,18 @@
         }
 
         arr = qp.split("&")
-        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';})
+        arr.forEach(function (v, i, _arr) { _arr[i] = '"' + v.replace('=', '":"') + '"'; })
         qp = qp ? JSON.parse('{' + arr.join() + '}',
-                function (key, value) {
-                    return key === "" ? value : decodeURIComponent(value)
-                }
+            function (key, value) {
+                return key === "" ? value : decodeURIComponent(value)
+            }
         ) : {}
 
         isValid = qp.state === sentState
 
         if ((
-          oauth2.auth.schema.get("flow") === "accessCode"||
-          oauth2.auth.schema.get("flow") === "authorizationCode"
+            oauth2.auth.schema.get("flow") === "accessCode" ||
+            oauth2.auth.schema.get("flow") === "authorizationCode"
         ) && !oauth2.auth.code) {
             if (!isValid) {
                 oauth2.errCb({
@@ -44,13 +49,13 @@
             if (qp.code) {
                 delete oauth2.state;
                 oauth2.auth.code = qp.code;
-                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+                oauth2.callback({ auth: oauth2.auth, redirectUrl: redirectUrl });
             } else {
                 let oauthErrorMsg
                 if (qp.error) {
-                    oauthErrorMsg = "["+qp.error+"]: " +
-                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
-                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                    oauthErrorMsg = "[" + qp.error + "]: " +
+                        (qp.error_description ? qp.error_description + ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: " + qp.error_uri : "");
                 }
 
                 oauth2.errCb({
@@ -61,8 +66,12 @@
                 });
             }
         } else {
-            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+            oauth2.callback({ auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl });
         }
         window.close();
     }
+
+    window.addEventListener('DOMContentLoaded', function () {
+        run();
+    });
 </script>

--- a/services/backend/src/docs/swaggerOptions.js
+++ b/services/backend/src/docs/swaggerOptions.js
@@ -23,9 +23,7 @@ const specs = swaggerJsdoc({
         type: "oauth2",
         authorizationUrl:
           config.KEYCLOAK_AUTH_SERVER_URL + config.DOCS_KEYCLOAK_AUTH_URL,
-        tokenUrl:
-          config.KEYCLOAK_AUTH_SERVER_URL + config.DOCS_KEYCLOAK_TOKEN_URL,
-        flow: "accessCode",
+        flow: "implicit",
       },
     },
   },
@@ -43,7 +41,6 @@ module.exports = swaggerUi.setup(specs, {
   swaggerOptions: {
     oauth: {
       clientId: config.DOCS_KEYCLOAK_CLIENT_ID,
-      clientSecret: config.KEYCLOAK_SECRET,
     },
     defaultModelsExpandDepth: -1,
     filter: true,

--- a/services/backend/src/server.js
+++ b/services/backend/src/server.js
@@ -15,7 +15,9 @@ const app = express();
 
 app.set("trust proxy", true);
 app.use(cors());
-app.use(helmet());
+if (config.ENV !== "development") {
+  app.use(helmet());
+}
 app.use(sessionInstance);
 
 app.use((req, res, next) => {
@@ -36,7 +38,7 @@ if (config.ENV !== "test") {
 }
 app.use("/api", router);
 app.get("/oauth2-redirect.html", function (req, res) {
-  res.sendfile("src/docs/oauth2-redirect.html");
+  res.sendFile(`${__dirname}/docs/oauth2-redirect.html`);
 });
 app.use("/api-docs", swaggerUi.serve, swaggerOptions);
 app.use(keycloak.middleware({ logout: "/" }));


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->


#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
fixes #913

#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
- Updated swagger oauth2 redirect (from github)
- Address CSP errors locally, by disabling helmet when the ENV is development
- Address CSP errors from ISED, by doing `implicit` authentication instead of `accessCode`

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
