### PR TITLE
[Feat] Update Prisma to 2.11

### DIFF
--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -19,7 +19,7 @@
     "snyk-protect": "snyk protect"
   },
   "dependencies": {
-    "@prisma/client": "2.10.0",
+    "@prisma/client": "2.11.0",
     "axios": "^0.20.0",
     "body-parser": "^1.19.0",
     "concurrently": "^5.3.0",
@@ -43,7 +43,7 @@
     "validator": "^13.1.17"
   },
   "devDependencies": {
-    "@prisma/cli": "2.10.0",
+    "@prisma/cli": "2.11.0",
     "eslint": "7.10.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-node": "^4.1.0",

--- a/services/backend/yarn.lock
+++ b/services/backend/yarn.lock
@@ -543,17 +543,35 @@
   resolved "https://registry.yarnpkg.com/@octetstream/promisify/-/promisify-2.0.2.tgz#29ac3bd7aefba646db670227f895d812c1a19615"
   integrity sha512-7XHoRB61hxsz8lBQrjC1tq/3OEIgpvGWg6DKAdwi7WRzruwkmsdwmOoUXbU4Dtd4RSOMDwed0SkP3y8UlMt1Bg==
 
-"@prisma/cli@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.9.0.tgz#c6f6652890783b899f266537e90e69c3481f5474"
-  integrity sha512-wPk4ehyTtVM7ZarWs16MhOc6kwLV/gZFardMvUeh46rlBwrklMdKtNChzzPa3wurrUPQ5KTbuRBz5Mgf7AdD/w==
+"@prisma/bar@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@prisma/bar/-/bar-0.0.1.tgz#088c4fbbb79c588391437ade9fd3a85527e753b3"
+  integrity sha512-FVLhwVkbfhXlBhroWfIXMLi+3Jh9IEzYp+9z+MUUiw3ZsbcoAil7CN9/QIjHc4/TcCRyRfuSmT7qCnn4O+TjJw==
 
-"@prisma/client@2.9.0":
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.9.0.tgz#acfaca0c5695d7f439e5af54b7cd0f7fb5926340"
-  integrity sha512-VLXw6s13xakIrV9Z8Ftw0j+mbXuvbRkxYv3X5hRZdPN1NAwgeXJmrrTK9MS2HDvW8eGZL7P8OaUSNQ3Sfgvr/Q==
+"@prisma/cli@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/cli/-/cli-2.11.0.tgz#34bdc5573ac40edae336b65fa73a164cae437622"
+  integrity sha512-RphW+1SPrEKgpuE5RFM0mv3BeVTF8MCRIyBt35Z9Z/E4YI30qgEWfZu6VfsNDarHRsFiJRKC73wx/aMQ2rLp4g==
   dependencies:
-    pkg-up "^3.1.0"
+    "@prisma/bar" "0.0.1"
+    "@prisma/engines" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+
+"@prisma/client@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@prisma/client/-/client-2.11.0.tgz#574c1aa3b571ea01c0fa8dca348c6ba5db41dcc9"
+  integrity sha512-BF7K/yi5fAnrt7MelQqUueJyl06IGmIxf+7f5RxFSvyO6xZMbOYxhW21kV2wt10mOIS0khQbo0xY6w/8jViJuQ==
+  dependencies:
+    "@prisma/engines-version" "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+
+"@prisma/engines-version@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
+  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+  resolved "https://registry.yarnpkg.com/@prisma/engines-version/-/engines-version-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#840bb5ca8707ed3b852d250c1bac9c75098682ee"
+  integrity sha512-qlkW4dKoW1dUnperWPuhFriZ/NTHlsKLhBbebxRa8qMuD3o37SvWIDGLjFOQx1N0Eb4H04rI3XxgjkWLFVlZCw==
+
+"@prisma/engines@2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918":
+  version "2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-2.11.0-10.58369335532e47bdcec77a2f1e7c1fb83a463918.tgz#5f02f311ce48297ef3fa9861dcab5ec3e52f1371"
+  integrity sha512-0WaUybWM7J5zQuG/zYLbV+ZKx9/nzS7Ruu7Y0K2lXJKy3Z9koeVttq+Xt7tVmUX9TLgI1Rwhb9R2e1JMNDWbsw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -5699,13 +5717,6 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
-
-pkg-up@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
-  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
-  dependencies:
-    find-up "^3.0.0"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
🩹 update Prisma client and cli to 2.11 to resolve migration issue in openshift


#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->


#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->
this was the error that this change should resolve
![image](https://user-images.githubusercontent.com/11470442/98906879-e1a9fc80-248b-11eb-9e71-6165a9889089.png)

#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
