### PR TITLE
[Fix] Cleaned up profile layout

### DIFF
--- a/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -79,124 +79,85 @@ const ProfileLayoutView = ({
 
   const displayAllProfileCards = () => {
     return (
-      <div>
-        {/* Employee summary */}
-        <Row
-          gutter={[
-            { xs: 8, sm: 12 },
-            { xs: 15, sm: 15, xl: 0 },
-          ]}
-          type="flex"
-        >
-          <Col xs={24} xl={14}>
-            <BasicInfo
-              data={data}
-              connectionStatus={connectionStatus}
-              changeConnection={changeConnection}
-            />
-          </Col>
-          <Col xs={24} xl={10}>
-            <Row type="flex" gutter={[{ xs: 8, sm: 12 }, 15]}>
-              <Col span={24}>
-                <EmployeeSummary
-                  data={data}
-                  editableCardBool={privateProfile}
-                />
-              </Col>
-            </Row>
-            <Row>
-              <Col span={24}>
-                <EmploymentEquity
-                  data={data}
-                  editableCardBool={privateProfile}
-                />
-              </Col>
-            </Row>
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <DescriptionCard data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <OfficialLanguage data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
+      <Row gutter={[15, 15]}>
+        {/* Summary */}
+        <Col xs={24} xl={14}>
+          <BasicInfo
+            data={data}
+            connectionStatus={connectionStatus}
+            changeConnection={changeConnection}
+          />
+        </Col>
+        <Col xs={24} xl={10}>
+          <Row gutter={[0, 15]}>
+            <Col span={24}>
+              <EmployeeSummary data={data} editableCardBool={privateProfile} />
+            </Col>
+          </Row>
+          <Row>
+            <Col span={24}>
+              <EmploymentEquity data={data} editableCardBool={privateProfile} />
+            </Col>
+          </Row>
+        </Col>
+        <Col span={24}>
+          <DescriptionCard data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col span={24}>
+          <OfficialLanguage data={data} editableCardBool={privateProfile} />
+        </Col>
+
         {/** ********** Skills and competencies *********** */}
         <Title level={2} className="sectionHeader" id="divider-skills-and-comp">
           <TagsTwoTone twoToneColor="#3CBAB3" className="sectionIcon" />
           <FormattedMessage id="profile.employee.skills.competencies" />
         </Title>
-        <Row className="app-row">
-          <Col span={24}>
-            <Skills data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <Mentorship data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <Col span={24}>
-              <Competencies data={data} editableCardBool={privateProfile} />
-            </Col>
-          </Col>
-        </Row>
+        <Col span={24}>
+          <Skills data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col span={24}>
+          <Mentorship data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col span={24}>
+          <Competencies data={data} editableCardBool={privateProfile} />
+        </Col>
 
         {/** ********** Qualifications *********** */}
         <Title level={2} className="sectionHeader" id="divider-qualifications">
           <TrophyOutlined twoToneColor="#3CBAB3" className="sectionIcon" />
           <FormattedMessage id="profile.employee.qualifications" />
         </Title>
-        <Row className="app-row">
-          <Col span={24}>
-            <Education data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <Experience data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
+        <Col span={24}>
+          <Education data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col span={24}>
+          <Experience data={data} editableCardBool={privateProfile} />
+        </Col>
 
         {/** ********** Personal Growth *********** */}
         <Title level={2} className="sectionHeader" id="divider-employee-growth">
           <RiseOutlined twoToneColor="#3CBAB3" className="sectionIcon" />
           <FormattedMessage id="profile.employee.growth.interests" />
         </Title>
-        <Row className="app-row">
-          <Col span={24}>
-            <LearningDevelopment
-              editableCardBool={privateProfile}
-              data={data}
-            />
-          </Col>
-        </Row>
-        <Row className="app-row">
-          <Col span={24}>
-            <QualifiedPools data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
-
-        <Row className="app-row" gutter={[{ xs: 8, sm: 16 }, 20]} type="flex">
-          <Col xs={24} xl={12}>
-            <TalentManagement data={data} editableCardBool={privateProfile} />
-            <div style={{ paddingTop: "16px" }}>
-              <ExFeeder data={data} editableCardBool={privateProfile} />
-            </div>
-          </Col>
-          <Col xs={24} xl={12}>
-            <CareerInterests data={data} editableCardBool={privateProfile} />
-          </Col>
-        </Row>
+        <Col span={24}>
+          <LearningDevelopment editableCardBool={privateProfile} data={data} />
+        </Col>
+        <Col span={24}>
+          <QualifiedPools data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col xs={24} xl={12}>
+          <TalentManagement data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col xs={24} xl={12}>
+          <CareerInterests data={data} editableCardBool={privateProfile} />
+        </Col>
+        <Col span={24}>
+          <ExFeeder data={data} editableCardBool={privateProfile} />
+        </Col>
 
         {/** ********** Connections *********** */}
         {privateProfile && (
-          <div>
+          <>
             <Title
               level={2}
               className="sectionHeader"
@@ -220,14 +181,12 @@ const ProfileLayoutView = ({
                 </Popover>
               </div>
             </Title>
-            <Row className="app-row">
-              <Col span={24}>
-                <Connections data={data} />
-              </Col>
-            </Row>
-          </div>
+            <Col span={24}>
+              <Connections data={data} />
+            </Col>
+          </>
         )}
-      </div>
+      </Row>
     );
   };
   const generateProfileSidebarContent = () => {

--- a/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.less
+++ b/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.less
@@ -1,6 +1,3 @@
-.app-row {
-  margin-top: 15px !important;
-}
 .app-sideBarRow {
   padding: 0 10px !important;
 }


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
- Fixes inconsistent padding/margins in the profile layout view on mobile and on desktop
- This makes the ex-feeder full screen width, or else there is side effects, but I think its not a bad tradeoff for this cleanup

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->


#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
