### PR TITLE
[Fix] Increase fuzzy search threshold to improve address search

### DIFF
--- a/services/backend/src/core/search/util/fuzzySearch.js
+++ b/services/backend/src/core/search/util/fuzzySearch.js
@@ -3,7 +3,7 @@ const Fuse = require("fuse.js");
 async function fuzzySearch(profiles, searchValue) {
   const options = {
     shouldSort: true,
-    threshold: 0.3,
+    threshold: 0.5,
     keys: [
       "actingLevel.name",
       "branch",


### PR DESCRIPTION
#### Changes introduced
🩹 Feature fix:
- increase fuzzy search threshold to 0.5 so searching address like "235 queen" will find results
- previously the threshold was 0.3


#### Related issue(s)
✔️ closes #1091 


#### Screenshots (if applicable)
**Here are the result that now show:**
![image](https://user-images.githubusercontent.com/11470442/100407100-881e0200-3035-11eb-8d35-2717bd4d0416.png)

