### PR TITLE
[Feat] Show fuzzy search match items

### DIFF
--- a/services/backend/src/core/search/util/cleanResults.js
+++ b/services/backend/src/core/search/util/cleanResults.js
@@ -14,6 +14,7 @@ function cleanResults(profiles) {
       groupLevel,
       nameInitials,
       status,
+      matches,
     }) => ({
       id,
       avatarColor,
@@ -28,6 +29,7 @@ function cleanResults(profiles) {
       groupLevel,
       nameInitials,
       status,
+      matches,
     })
   );
 }

--- a/services/backend/src/core/search/util/fuzzySearch.js
+++ b/services/backend/src/core/search/util/fuzzySearch.js
@@ -4,6 +4,7 @@ async function fuzzySearch(profiles, searchValue) {
   const options = {
     shouldSort: true,
     threshold: 0.5,
+    includeMatches: true,
     keys: [
       "actingLevel.name",
       "branch",
@@ -37,7 +38,9 @@ async function fuzzySearch(profiles, searchValue) {
   };
 
   const fuse = new Fuse(profiles, options);
-  const results = fuse.search(searchValue).map(({ item }) => item);
+  const results = fuse
+    .search(searchValue)
+    .map(({ item, matches }) => ({ ...item, matches: matches }));
   return results;
 }
 

--- a/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.less
+++ b/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.less
@@ -4,6 +4,14 @@
   width: 180px;
 }
 
+.match-term-list {
+  margin-top: 10px;
+}
+
+.match-modal-description svg {
+  margin-right: 6px;
+}
+
 .result-card {
   height: 100%;
   overflow-x: hidden;
@@ -28,6 +36,13 @@
   &-meta {
     margin: 0px;
     margin-right: 20px;
+    margin-top: 15px !important;
+    margin-bottom: 12px !important;
+  }
+  @media (max-width: 500px) {
+    &-meta {
+      margin-top: 45px !important;
+    }
   }
   &-avatar-text {
     font-size: 20px;
@@ -50,5 +65,10 @@
   }
   &-footer-icon {
     margin-right: 3px;
+  }
+  .fuzzy-match-modal-btn {
+    position: absolute;
+    top: 10px;
+    right: 190px;
   }
 }

--- a/services/frontend/src/components/resultsCard/resultProfileCard/fuzzyMatchItem/FuzzyMatchItem.jsx
+++ b/services/frontend/src/components/resultsCard/resultProfileCard/fuzzyMatchItem/FuzzyMatchItem.jsx
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+import FuzzyMatchItemView from "./FuzzyMatchItemView";
+
+const FuzzyMatchItem = ({ matchItemName, matchItemString }) => {
+  return (
+    <FuzzyMatchItemView
+      matchItemName={matchItemName}
+      matchItemString={matchItemString}
+    />
+  );
+};
+
+FuzzyMatchItem.propTypes = {
+  matchItemName: PropTypes.string.isRequired,
+  matchItemString: PropTypes.string.isRequired,
+};
+
+export default FuzzyMatchItem;

--- a/services/frontend/src/components/resultsCard/resultProfileCard/fuzzyMatchItem/FuzzyMatchItemView.jsx
+++ b/services/frontend/src/components/resultsCard/resultProfileCard/fuzzyMatchItem/FuzzyMatchItemView.jsx
@@ -1,0 +1,76 @@
+import PropTypes from "prop-types";
+import { FormattedMessage } from "react-intl";
+import { Typography } from "antd";
+import { indexOf } from "lodash";
+
+const { Text } = Typography;
+
+const FuzzyMatchItemView = ({ matchItemName, matchItemString }) => {
+  /**
+   * Only grab string up to first "."
+   * @param {itemName} string - string to clean
+   */
+  const cleanItemNameString = ({ itemName }) => {
+    const locationOfChar = indexOf(itemName, ".");
+    if (locationOfChar > 0) {
+      return itemName.slice(0, locationOfChar);
+    }
+    return itemName;
+  };
+
+  /**
+   * Find translated result name based on key
+   * @param {itemName} string - item key used to identify it
+   */
+  const getMatchTranslatedName = ({ itemName }) => {
+    const cleanString = cleanItemNameString({ itemName });
+    switch (cleanString) {
+      case "firstName":
+        return <FormattedMessage id="profile.first.name" />;
+      case "lastName":
+        return <FormattedMessage id="profile.last.name" />;
+      case "email":
+        return <FormattedMessage id="profile.email" />;
+      case "officeLocation":
+        return <FormattedMessage id="profile.location" />;
+      case "manager":
+        return <FormattedMessage id="profile.manager" />;
+      case "branch":
+        return <FormattedMessage id="profile.branch" />;
+      case "organizations":
+        return <FormattedMessage id="profile.org.tree" />;
+      case "experiences":
+        return <FormattedMessage id="profile.experience" />;
+      case "competencies":
+        return <FormattedMessage id="profile.competencies" />;
+      case "skills":
+        return <FormattedMessage id="profile.skills" />;
+      case "teams":
+        return <FormattedMessage id="profile.teams" />;
+      case "groupLevel":
+        return <FormattedMessage id="profile.classification" />;
+      case "tenure":
+        return <FormattedMessage id="profile.substantive" />;
+      case "jobTitle":
+        return <FormattedMessage id="profile.career.header.name" />;
+      default:
+        return itemName;
+    }
+  };
+
+  return (
+    <div style={{ textAlign: "left" }}>
+      <Text strong>
+        {getMatchTranslatedName({ itemName: matchItemName })}:{" "}
+      </Text>
+      <Text>{matchItemString}</Text>
+    </div>
+  );
+};
+
+FuzzyMatchItemView.propTypes = {
+  matchItemName: PropTypes.string.isRequired,
+  matchItemString: PropTypes.string.isRequired,
+};
+
+export default FuzzyMatchItemView;

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -353,6 +353,8 @@
   "search.results.cards.remove.connection": "Remove connection",
   "search.results.cards.skills.not.found": "No matching skills found",
   "search.results.found": "found",
+  "search.fuzzy.results": "General search matches",
+  "search.fuzzy.description": "Here are all the matches for your search term on profile: {name}",
   "select.any.mentors": "Any mentors",
   "settings.delete.button": "Delete account",
   "settings.delete.description": "This will delete everything related to your account. Performing this action is irreversable!",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -353,6 +353,8 @@
   "search.results.cards.remove.connection": "Déconnecter",
   "search.results.cards.skills.not.found": "Aucunes habiltés correspondantes trouvées",
   "search.results.found": "trouvés",
+  "search.fuzzy.results": "Correspondances de recherche générale",
+  "search.fuzzy.description": "Voici tous les résultats de votre recherche sur le profil: {name}",
   "select.any.mentors": "Tous les mentors",
   "settings.delete.button": "Supprimer le compte",
   "settings.delete.description": "Toute information reliée à votre compte sera supprimé. Cette action est irréversible!",


### PR DESCRIPTION
⭐ Changes introduced
- when user uses fuzzy search they can now view all the items that matched on the user's profile
- new button on search result card to open modal (only visible when fuzzy search used)
-  modal opens to show matches

📸  Screenshots (if applicable)
**new button only visible when using fuzzy search**
![image](https://user-images.githubusercontent.com/11470442/101412808-3c7b1c00-38b1-11eb-958d-7029321a610b.png)

**modal to show all matches**
![image](https://user-images.githubusercontent.com/11470442/101412888-5caadb00-38b1-11eb-9d90-125d6718e864.png)

**add padding to top of avatar and name only on small screens**
![image](https://user-images.githubusercontent.com/11470442/101412755-21a8a780-38b1-11eb-9015-76e1cf3f7e95.png)

