### PR TITLE
[Fix] Remove redundant fuzzy search logic for skills

### DIFF
--- a/services/backend/src/core/search/search.js
+++ b/services/backend/src/core/search/search.js
@@ -32,17 +32,14 @@ async function filterSearch(request, response) {
     anyMentorSkills,
   } = request.query;
 
+  console.log(language);
+
   let skillSearchValue = "";
   if (skills) {
     skillSearchValue = await utils.getSkillNames(skills);
   }
 
-  let results = await utils.getAllProfiles(
-    skillSearchValue,
-    language,
-    userId,
-    request
-  );
+  let results = await utils.getAllProfiles(language, userId, request);
 
   if (skills) {
     results = await utils.skillSearch(results, skills);

--- a/services/backend/src/core/search/search.js
+++ b/services/backend/src/core/search/search.js
@@ -8,7 +8,7 @@ async function fuzzySearch(request, response) {
 
   const value = searchValue || "";
 
-  const profiles = await utils.getAllProfiles(value, language, userId, request);
+  const profiles = await utils.getAllProfiles(language, userId, request);
 
   const results = await utils.fuzzySearch(profiles, value);
 

--- a/services/backend/src/core/search/search.js
+++ b/services/backend/src/core/search/search.js
@@ -32,11 +32,6 @@ async function filterSearch(request, response) {
     anyMentorSkills,
   } = request.query;
 
-  let skillSearchValue = "";
-  if (skills) {
-    skillSearchValue = await utils.getSkillNames(skills);
-  }
-
   let results = await utils.getAllProfiles(language, userId, request);
 
   if (skills) {

--- a/services/backend/src/core/search/search.js
+++ b/services/backend/src/core/search/search.js
@@ -32,8 +32,6 @@ async function filterSearch(request, response) {
     anyMentorSkills,
   } = request.query;
 
-  console.log(language);
-
   let skillSearchValue = "";
   if (skills) {
     skillSearchValue = await utils.getSkillNames(skills);

--- a/services/backend/src/core/search/util/cleanResults.js
+++ b/services/backend/src/core/search/util/cleanResults.js
@@ -1,5 +1,3 @@
-const skillSearch = require("./skillSearch");
-
 function cleanResults(profiles) {
   return profiles.map(
     ({
@@ -12,7 +10,6 @@ function cleanResults(profiles) {
       branch,
       officeLocation,
       skills,
-      matchedSkills,
       groupLevel,
       nameInitials,
       status,

--- a/services/backend/src/core/search/util/cleanResults.js
+++ b/services/backend/src/core/search/util/cleanResults.js
@@ -1,3 +1,5 @@
+const skillSearch = require("./skillSearch");
+
 function cleanResults(profiles) {
   return profiles.map(
     ({
@@ -9,8 +11,8 @@ function cleanResults(profiles) {
       jobTitle,
       branch,
       officeLocation,
-      resultSkills,
-      totalResultSkills,
+      skills,
+      matchedSkills,
       groupLevel,
       nameInitials,
       status,
@@ -24,8 +26,8 @@ function cleanResults(profiles) {
       jobTitle,
       branch,
       officeLocation,
-      resultSkills,
-      totalResultSkills,
+      skills: skills ? skills.slice(0, 3) : [],
+      totalSkillsCount: skills ? skills.length : 0,
       groupLevel,
       nameInitials,
       status,

--- a/services/backend/src/core/search/util/fuzzySearch.js
+++ b/services/backend/src/core/search/util/fuzzySearch.js
@@ -38,9 +38,14 @@ async function fuzzySearch(profiles, searchValue) {
   };
 
   const fuse = new Fuse(profiles, options);
-  const results = fuse
-    .search(searchValue)
-    .map(({ item, matches }) => ({ ...item, matches: matches }));
+  const results = fuse.search(searchValue).map(({ item, matches }) => ({
+    ...item,
+    matches: matches,
+    skills: matches
+      .filter((match) => match.key === "skills.name")
+      .map((match) => ({ name: match.value, id: match.id })),
+  }));
+
   return results;
 }
 

--- a/services/backend/src/core/search/util/getAllProfiles.js
+++ b/services/backend/src/core/search/util/getAllProfiles.js
@@ -6,7 +6,7 @@ const { viewPrivateProfile } = require("../../../utils/keycloak");
 
 const NUMBER_OF_SKILL_RESULT = 4;
 
-async function getAllUsers(searchValue, language, userId, request) {
+async function getAllUsers(language, userId, request) {
   let data = await prisma.user.findMany({
     select: {
       id: true,
@@ -395,20 +395,6 @@ async function getAllUsers(searchValue, language, userId, request) {
         ? info.tenure.translations[0].name
         : undefined;
     }
-
-    const fuse = new Fuse(allSkills, {
-      shouldSort: true,
-      threshold: 0.2,
-      keys: ["name"],
-    });
-
-    const resultSkills = fuse
-      .search(searchValue)
-      .slice(0, NUMBER_OF_SKILL_RESULT)
-      .map(({ item }) => item);
-
-    info.resultSkills = resultSkills;
-    info.totalResultSkills = fuse.search(searchValue).length;
 
     return info;
   });

--- a/services/backend/src/core/search/util/getAllProfiles.js
+++ b/services/backend/src/core/search/util/getAllProfiles.js
@@ -1,10 +1,6 @@
-const Fuse = require("fuse.js");
-
 const _ = require("lodash");
 const prisma = require("../../../database");
 const { viewPrivateProfile } = require("../../../utils/keycloak");
-
-const NUMBER_OF_SKILL_RESULT = 4;
 
 async function getAllUsers(language, userId, request) {
   let data = await prisma.user.findMany({
@@ -396,7 +392,7 @@ async function getAllUsers(language, userId, request) {
         : undefined;
     }
 
-    return info;
+    return { ...info, skills: allSkills };
   });
 
   return cleanedUsers;

--- a/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.jsx
+++ b/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.jsx
@@ -286,7 +286,6 @@ const ResultProfileCardView = ({
               </Col>
 
               <Col span={24}>
-                {console.log(profile)}
                 {profile.totalSkillsCount > 0 ? (
                   <span>
                     {profile.skills.map(({ id, name }) => (

--- a/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.jsx
+++ b/services/frontend/src/components/resultsCard/resultProfileCard/ResultProfileCardView.jsx
@@ -286,16 +286,19 @@ const ResultProfileCardView = ({
               </Col>
 
               <Col span={24}>
-                {profile.resultSkills.length > 0 ? (
+                {console.log(profile)}
+                {profile.totalSkillsCount > 0 ? (
                   <span>
-                    {profile.resultSkills.map(({ id, name }) => (
+                    {profile.skills.map(({ id, name }) => (
                       <Tag className="result-card-tag" key={id}>
                         {name}
                       </Tag>
                     ))}
-                    <Tag className="result-card-tag">
-                      +{profile.totalResultSkills - 4}
-                    </Tag>
+                    {profile.totalSkillsCount > 3 && (
+                      <Tag className="result-card-tag">
+                        +{profile.totalSkillsCount - 3}
+                      </Tag>
+                    )}
                   </span>
                 ) : (
                   <Tag className="result-card-tag">


### PR DESCRIPTION
⭐  **Changes introduced**
- fixes negative skill numbers on profile in result cards (#1128)
- removed extra fuzzy search done on skills when fetching all profiles (should improve performance when we have more users)
- fuzzy search matches results in the modal for skills are now the same as the matches on the card since they now use the same data source (#1131)

✅  **Fixes the following issue(s)**
- closes #1128 
- closes #1131

