### PR TITLE
[Fix] advance search not behaving as expected with "false" filters

### DIFF
--- a/services/frontend/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend/src/components/searchBar/SearchBar.jsx
@@ -76,6 +76,20 @@ const SearchBar = () => {
 
   // turns search values into query, redirects to results page with query
   const handleSearch = (values) => {
+    const searchFilter = values;
+
+    if (!searchFilter.anyMentorSkills) {
+      delete searchFilter.anyMentorSkills;
+    }
+
+    if (!searchFilter.exFeeder) {
+      delete searchFilter.exFeeder;
+    }
+
+    if (searchFilter.anyMentorSkills) {
+      delete searchFilter.mentorSkills;
+    }
+
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/results?${query}`;
 

--- a/services/frontend/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend/src/components/searchFilter/SearchFilter.jsx
@@ -117,6 +117,20 @@ const SearchFilter = () => {
 
   // page with query
   const handleSearch = (values) => {
+    const searchFilter = values;
+
+    if (!searchFilter.anyMentorSkills) {
+      delete searchFilter.anyMentorSkills;
+    }
+
+    if (!searchFilter.exFeeder) {
+      delete searchFilter.exFeeder;
+    }
+
+    if (searchFilter.anyMentorSkills) {
+      delete searchFilter.mentorSkills;
+    }
+
     const query = queryString.stringify(values, { arrayFormat: "bracket" });
     const url = `/results?${query}`;
     history.push(url);

--- a/services/frontend/src/components/searchFilter/SearchFilterView.jsx
+++ b/services/frontend/src/components/searchFilter/SearchFilterView.jsx
@@ -79,7 +79,6 @@ const SearchFilterView = ({
     intl.formatMessage({ id: "search.filter.exfeeder" }),
   ];
 
-  console.log("branchOptions", branchOptions);
   return (
     <div className="search-searchSideBar">
       <Title level={2} className="search-searchHeader">


### PR DESCRIPTION
🐞 Bug Fixes:
- when "any mentorship skills" check box was set to "on" then "off" the value sent to back end would be false which would return all profiles. Now no query value is sent to backend.
- when "any mentorship skills" check box was set to "on" the selected mentorship skills were still being sent to backend. Now no query value for mentorship skills is sent to backend.
- when "exFeeder" check box was set to "on" then "off" the value sent to back end would be false which would return all profiles. Now no query value is sent to backend.
- These changes make the search filter behavior more predictable for users
