### PR TITLE
[Fix] fix search in UAT

### DIFF
--- a/services/backend/src/core/search/util/getAllProfiles.js
+++ b/services/backend/src/core/search/util/getAllProfiles.js
@@ -15,8 +15,8 @@ async function getAllUsers(language, userId, request) {
     where: viewPrivateProfile(request)
       ? undefined
       : {
-        status: "ACTIVE",
-      },
+          status: "ACTIVE",
+        },
   });
 
   let visibleCards = await Promise.all(

--- a/services/backend/src/core/search/util/getAllProfiles.js
+++ b/services/backend/src/core/search/util/getAllProfiles.js
@@ -15,8 +15,8 @@ async function getAllUsers(language, userId, request) {
     where: viewPrivateProfile(request)
       ? undefined
       : {
-          status: "ACTIVE",
-        },
+        status: "ACTIVE",
+      },
   });
 
   let visibleCards = await Promise.all(
@@ -296,12 +296,14 @@ async function getAllUsers(language, userId, request) {
       const employment = info.employmentInfo.translations[0];
       info.branch = {};
       info.branch.name = employment ? employment.branch : undefined;
-      info.branch.acronym = employment
-        ? employment.branch
-            .split(" ")
-            .map((word) => word[0])
-            .join("")
-        : undefined;
+      if (employment && employment.branch) {
+        info.branch.acronym = employment.branch
+          .split(" ")
+          .map((word) => word[0])
+          .join("");
+      } else {
+        info.branch.acronym = undefined;
+      }
       info.jobTitle = employment ? employment.jobTitle : undefined;
       delete info.employmentInfo;
     }


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
It looks like this is what was causing the issue. This is an attempt to fix it since I am unable to create the issue locally. 
![image](https://user-images.githubusercontent.com/21133129/106815011-431fd880-6641-11eb-9b53-935f27e4bb4c.png)


#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #1229 
#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
