### PR TITLE
[Fix] Added Email Overflow for Long Emails

### DIFF
--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -33,8 +33,9 @@ import OrgTree from "../orgTree/OrgTree";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import EditCardButton from "../editCardButton/EditCardButton";
 import "./BasicInfoView.less";
+import EmailLabel from "../customEmail/EmailLabel";
 
-const { Text, Paragraph } = Typography;
+const { Text } = Typography;
 
 const BasicInfoView = ({
   data,
@@ -186,15 +187,7 @@ const BasicInfoView = ({
           <List.Item.Meta
             avatar={<Avatar style={styles.avatar} size={48} icon={item.icon} />}
             title={item.title}
-            description={
-              <Paragraph
-                ellipsis={{
-                  rows: 1,
-                }}
-              >
-                {item.description}
-              </Paragraph>
-            }
+            description={item.description}
           />
         </List.Item>
       )}
@@ -209,7 +202,11 @@ const BasicInfoView = ({
     const email = {
       icon: <MailOutlined />,
       title: <FormattedMessage id="email" />,
-      description: data.email ? data.email : "-",
+      description: data.email ? (
+        <EmailLabel email="ianwilkinsonsdddddddffffffffffffffffffffffffffffffffffffffffffffffffffff@canada.ca" />
+      ) : (
+        "-"
+      ),
     };
 
     const tel = {

--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -34,7 +34,7 @@ import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import EditCardButton from "../editCardButton/EditCardButton";
 import "./BasicInfoView.less";
 
-const { Text } = Typography;
+const { Text, Paragraph } = Typography;
 
 const BasicInfoView = ({
   data,
@@ -186,13 +186,20 @@ const BasicInfoView = ({
           <List.Item.Meta
             avatar={<Avatar style={styles.avatar} size={48} icon={item.icon} />}
             title={item.title}
-            description={item.description}
+            description={
+              <Paragraph
+                ellipsis={{
+                  rows: 1,
+                }}
+              >
+                {item.description}
+              </Paragraph>
+            }
           />
         </List.Item>
       )}
     />
   );
-
   /*
    * Get Contact Info
    *

--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -202,11 +202,7 @@ const BasicInfoView = ({
     const email = {
       icon: <MailOutlined />,
       title: <FormattedMessage id="email" />,
-      description: data.email ? (
-        <EmailLabel email="ianwilkinsonsdddddddffffffffffffffffffffffffffffffffffffffffffffffffffff@canada.ca" />
-      ) : (
-        "-"
-      ),
+      description: data.email ? <EmailLabel email={data.email} /> : "-",
     };
 
     const tel = {

--- a/services/frontend/src/components/customEmail/EmailLabel.jsx
+++ b/services/frontend/src/components/customEmail/EmailLabel.jsx
@@ -1,0 +1,33 @@
+import { Tooltip, Typography } from "antd";
+import PropTypes from "prop-types";
+import { useState } from "react";
+
+const { Paragraph } = Typography;
+
+const EmailLabel = ({ email }) => {
+  const [truncated, setTruncated] = useState(false);
+
+  return (
+    <Tooltip title={truncated ? email : undefined}>
+      <Paragraph
+        /* Hardcoded to match the List.Item.Meta.Description property */
+        style={{
+          color: "rgba(0, 0, 0, 0.45)",
+          "margin-bottom": "0 !important",
+        }}
+        ellipsis={{
+          rows: 1,
+          onEllipsis: setTruncated,
+        }}
+      >
+        <>{email}</>
+      </Paragraph>
+    </Tooltip>
+  );
+};
+
+EmailLabel.propTypes = {
+  email: PropTypes.string.isRequired,
+};
+
+export default EmailLabel;


### PR DESCRIPTION
#### Changes introduced
Fixed the issue where very long email overflows on the Organization icon.


#### Related issue(s)
Closes #1100


#### Screenshots (if applicable)
Before: ![image](https://user-images.githubusercontent.com/29315512/100034383-155d1e80-2dca-11eb-84b8-65762b890ded.png)
After: 
- Normal Length Email
![2021-03-11_10-30-00](https://user-images.githubusercontent.com/47506745/110811530-c93cc980-8254-11eb-8cb9-0a31683a91c5.png)

-Extra Long Email
![2021-03-11_10-31-06](https://user-images.githubusercontent.com/47506745/110811708-e83b5b80-8254-11eb-9e28-5287820ef8e9.png)

If the UI has been modified:
- [n/a] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [no] Has been tested on IE
- [n/a] The modifications are tab friendly
- [no] It is accessible
