### PR TITLE
[Fix] Missing Vertical Paddings Between Cards

### DIFF
--- a/services/frontend/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
+++ b/services/frontend/src/components/admin/dashboardGraphs/DashboardGraphsView.jsx
@@ -78,7 +78,7 @@ const DashboardGraphsView = ({
 
   return (
     <>
-      <Row gutter={[8, 8]}>
+      <Row gutter={[15, 15]}>
         <Col xs={24} sm={24} md={12} xl={8}>
           <Card
             title={<FormattedMessage id="dashboard.popular.skills" />}

--- a/services/frontend/src/components/admin/statCards/StatCardsView.jsx
+++ b/services/frontend/src/components/admin/statCards/StatCardsView.jsx
@@ -25,7 +25,7 @@ const StatCardsView = ({
   growthRatePrevMonth,
   intl,
 }) => (
-  <Row gutter={[8, 8]} type="flex">
+  <Row gutter={[15, 15]} type="flex">
     <Col xs={12} sm={8} xl={4}>
       <Card style={{ height: "100%" }} loading={countUsers === "-"}>
         <Statistic

--- a/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.jsx
+++ b/services/frontend/src/components/layouts/profileLayout/ProfileLayoutView.jsx
@@ -93,8 +93,6 @@ const ProfileLayoutView = ({
           <Col span={24}>
             <EmployeeSummary data={data} editableCardBool={privateProfile} />
           </Col>
-        </Row>
-        <Row>
           <Col span={24}>
             <EmploymentEquity data={data} editableCardBool={privateProfile} />
           </Col>

--- a/services/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/services/frontend/src/pages/admin/AdminDashboard.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useCallback } from "react";
+import { Row, Col } from "antd";
 import { injectIntl, FormattedMessage } from "react-intl";
 import { useSelector, useDispatch } from "react-redux";
 import { AreaChartOutlined } from "@ant-design/icons";
@@ -92,8 +93,14 @@ const AdminDashboard = ({ intl }) => {
         title={<FormattedMessage id="admin.dashboard.title" />}
         icon={<AreaChartOutlined />}
       />
-      <StatCards />
-      <DashboardGraphs />
+      <Row gutter={[15, 15]} type="flex">
+        <Col span={24}>
+          <StatCards />
+        </Col>
+        <Col span={24}>
+          <DashboardGraphs />
+        </Col>
+      </Row>
     </AdminLayout>
   );
 };


### PR DESCRIPTION
⭐  Changes introduced
- fixed missing vertical Paddings between cards on the profile page and the admin dash
- increased padding between cards on admin dash

ℹ️  Related issue(s)
closes #1320 
closes #1297  

📸  Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/115443723-971e7000-a1e1-11eb-919f-6bf99903b62d.png)
![image](https://user-images.githubusercontent.com/11470442/115443762-a9001300-a1e1-11eb-9ea3-97a2951772d0.png)


