### PR TITLE
[Fix] Remove /api from backend calls to simplify the calls and add it to the env variables 

### DIFF
--- a/env/web.env.example
+++ b/env/web.env.example
@@ -1,4 +1,4 @@
-REACT_APP_API_ADDRESS=http://localhost:8080/
+REACT_APP_API_ADDRESS=http://localhost:8080/api/
 REACT_APP_KEYCLOAK_SERVER_URL=[KEYCLOAK_SERVER_URL]
 REACT_APP_KEYCLOAK_CLIENT_ID=upskill-client
 DRUPAL_WEBSITE_URL=https://italent-uat-cms-studioup-dev.apps.dev.ocp-dev.ised-isde.canada.ca/

--- a/services/frontend/src/components/admin/bugsTable/BugsTable.jsx
+++ b/services/frontend/src/components/admin/bugsTable/BugsTable.jsx
@@ -23,14 +23,14 @@ const BugsTable = () => {
       delete values.githubIssue;
     }
 
-    await axios.put(`api/bugs/${id}`, values);
+    await axios.put(`bugs/${id}`, values);
   };
 
   const getBugs = useCallback(async () => {
     try {
       dispatch(setAdminBugsLoading(true));
 
-      const results = await axios.get(`api/bugs`);
+      const results = await axios.get(`bugs`);
 
       // Formats data from backend into viewable data for the table
       const formattedData = results.data.map((bug) => ({

--- a/services/frontend/src/components/admin/categoryTable/CategoryTable.jsx
+++ b/services/frontend/src/components/admin/categoryTable/CategoryTable.jsx
@@ -29,7 +29,7 @@ const CategoryTable = ({ intl }) => {
     try {
       dispatch(setAdminCategoriesLoading(true));
 
-      const results = await axios.get(`api/option/categoriesAllLang`);
+      const results = await axios.get(`option/categoriesAllLang`);
 
       // Formats data from backend into viewable data for the table
       const formattedData = results.data.map((category) => ({
@@ -49,7 +49,7 @@ const CategoryTable = ({ intl }) => {
 
   // Handles the deletion of a category
   const handleSubmitDelete = async () => {
-    const result = await axios.delete(`api/option/categories`, {
+    const result = await axios.delete(`option/categories`, {
       data: {
         ids: selectedRowKeys,
       },
@@ -62,7 +62,7 @@ const CategoryTable = ({ intl }) => {
 
   // Handles addition of a category
   const handleSubmitAdd = async (values) => {
-    await axios.post(`api/option/category`, {
+    await axios.post(`option/category`, {
       en: values.addCategoryEn,
       fr: values.addCategoryFr,
     });
@@ -72,7 +72,7 @@ const CategoryTable = ({ intl }) => {
 
   // Handles the update/edit of a category
   const handleSubmitEdit = async (values, id) => {
-    await axios.put(`api/option/category`, {
+    await axios.put(`option/category`, {
       id,
       en: values.editCategoryEn,
       fr: values.editCategoryFr,

--- a/services/frontend/src/components/admin/competencyTable/CompetencyTable.jsx
+++ b/services/frontend/src/components/admin/competencyTable/CompetencyTable.jsx
@@ -30,7 +30,7 @@ const CompetencyTable = ({ intl }) => {
     try {
       dispatch(setAdminCompetenciesLoading(true));
 
-      const results = await axios.get(`api/option/competenciesAllLang`);
+      const results = await axios.get(`option/competenciesAllLang`);
 
       // Formats data from backend into viewable data for the table
       const formattedData = results.data.map((competency) => ({
@@ -65,7 +65,7 @@ const CompetencyTable = ({ intl }) => {
 
   // Handles addition of a competency
   const handleSubmitAdd = async (values) => {
-    await axios.post(`api/option/competency`, {
+    await axios.post(`option/competency`, {
       en: values.addCompetencyEn,
       fr: values.addCompetencyFr,
     });
@@ -75,7 +75,7 @@ const CompetencyTable = ({ intl }) => {
 
   // Handles the update/edit of a competency
   const handleSubmitEdit = async (values, id) => {
-    await axios.put(`api/option/competency`, {
+    await axios.put(`option/competency`, {
       id,
       en: values.editCompetencyEn,
       fr: values.editCompetencyFr,
@@ -86,7 +86,7 @@ const CompetencyTable = ({ intl }) => {
 
   // Handles the deletion of a competency
   const handleSubmitDelete = async () => {
-    await axios.delete(`api/option/competencies`, {
+    await axios.delete(`option/competencies`, {
       data: {
         ids: selectedRowKeys,
       },

--- a/services/frontend/src/components/admin/diplomaTable/DiplomaTable.jsx
+++ b/services/frontend/src/components/admin/diplomaTable/DiplomaTable.jsx
@@ -30,7 +30,7 @@ const DiplomaTable = ({ intl }) => {
     try {
       dispatch(setAdminDiplomasLoading(true));
 
-      const results = await axios.get(`api/option/diplomasAllLang`);
+      const results = await axios.get(`option/diplomasAllLang`);
 
       // Formats data from backend into viewable data for the table
       const formattedData = results.data.map((competency) => ({
@@ -65,7 +65,7 @@ const DiplomaTable = ({ intl }) => {
 
   // Handles addition of a diploma
   const handleSubmitAdd = async (values) => {
-    await axios.post(`api/option/diploma`, {
+    await axios.post(`option/diploma`, {
       en: values.addDiplomaEn,
       fr: values.addDiplomaFr,
     });
@@ -75,7 +75,7 @@ const DiplomaTable = ({ intl }) => {
 
   // Handles the update/edit of a diploma
   const handleSubmitEdit = async (values, id) => {
-    await axios.put(`api/option/diploma`, {
+    await axios.put(`option/diploma`, {
       id,
       en: values.editDiplomaEn,
       fr: values.editDiplomaFr,
@@ -86,7 +86,7 @@ const DiplomaTable = ({ intl }) => {
 
   // Handles the deletion of a diploma
   const handleSubmitDelete = async () => {
-    await axios.delete(`api/option/diplomas`, {
+    await axios.delete(`option/diplomas`, {
       data: {
         ids: selectedRowKeys,
       },

--- a/services/frontend/src/components/admin/schoolTable/SchoolTable.jsx
+++ b/services/frontend/src/components/admin/schoolTable/SchoolTable.jsx
@@ -30,7 +30,7 @@ const SchoolTable = ({ intl }) => {
     try {
       dispatch(setAdminSchoolsLoading(true));
 
-      const results = await axios.get(`api/option/schoolsAllLang`);
+      const results = await axios.get(`option/schoolsAllLang`);
 
       // Formats data from backend into viewable data for the table
       const formattedData = results.data.map((competency) => ({
@@ -65,7 +65,7 @@ const SchoolTable = ({ intl }) => {
 
   // Handles addition of a school
   const handleSubmitAdd = async (values) => {
-    await axios.post(`api/option/school`, {
+    await axios.post(`option/school`, {
       en: values.addSchoolEn,
       fr: values.addSchoolFr,
       abbrCountry: values.addSchoolCountry.toUpperCase(),
@@ -77,7 +77,7 @@ const SchoolTable = ({ intl }) => {
 
   // Handles the update/edit of a school
   const handleSubmitEdit = async (values, id) => {
-    await axios.put(`api/option/school`, {
+    await axios.put(`option/school`, {
       id,
       en: values.editSchoolEn,
       fr: values.editSchoolFr,
@@ -90,7 +90,7 @@ const SchoolTable = ({ intl }) => {
 
   // Handles the deletion of a school
   const handleSubmitDelete = async () => {
-    await axios.delete(`api/option/schools`, {
+    await axios.delete(`option/schools`, {
       data: {
         ids: selectedRowKeys,
       },

--- a/services/frontend/src/components/admin/skillTable/SkillTable.jsx
+++ b/services/frontend/src/components/admin/skillTable/SkillTable.jsx
@@ -31,8 +31,8 @@ const SkillTable = ({ intl }) => {
       dispatch(setAdminSkillsLoading(true));
       dispatch(setAdminCategoriesLoading(true));
       const [skill, categories] = await Promise.all([
-        axios.get(`api/option/skillsAllLang`),
-        axios.get(`api/option/categoriesAllLang`),
+        axios.get(`option/skillsAllLang`),
+        axios.get(`option/categoriesAllLang`),
       ]);
 
       dispatch(
@@ -71,7 +71,7 @@ const SkillTable = ({ intl }) => {
 
   // Handles addition of a skill
   const handleSubmitAdd = async (values) => {
-    await axios.post(`api/option/skill`, {
+    await axios.post(`option/skill`, {
       en: values.addSkillEn,
       fr: values.addSkillFr,
       categoryId: values.addSkillCategory,
@@ -81,7 +81,7 @@ const SkillTable = ({ intl }) => {
 
   // Handles the update/edit of a skill
   const handleSubmitEdit = async (values, id) => {
-    await axios.put(`api/option/skill`, {
+    await axios.put(`option/skill`, {
       id,
       en: values.editSkillEn,
       fr: values.editSkillFr,
@@ -92,7 +92,7 @@ const SkillTable = ({ intl }) => {
 
   // Handles the deletion of a skill
   const handleSubmitDelete = async () => {
-    await axios.delete(`api/option/skills`, {
+    await axios.delete(`option/skills`, {
       data: {
         ids: selectedRowKeys,
       },

--- a/services/frontend/src/components/admin/userTable/UserTable.jsx
+++ b/services/frontend/src/components/admin/userTable/UserTable.jsx
@@ -35,8 +35,8 @@ const UserTable = () => {
       dispatch(setAdminUsersLoading(true));
 
       const results = await Promise.all([
-        axios.get(`api/admin/users?language=${locale}`),
-        axios.get(`api/keycloak/users?language=${locale}`),
+        axios.get(`admin/users?language=${locale}`),
+        axios.get(`keycloak/users?language=${locale}`),
       ]);
 
       // Formats data from backend into viewable data for the table
@@ -66,7 +66,7 @@ const UserTable = () => {
 
   // Handles profile status change
   const handleApply = async () => {
-    const url = `api/admin/userStatuses`;
+    const url = `admin/userStatuses`;
 
     await axios.put(url, statuses);
 
@@ -128,7 +128,7 @@ const UserTable = () => {
 
   // Handles the deletion of a user
   const handleSubmitDelete = async (id) => {
-    await axios.delete(`api/user/${id}`);
+    await axios.delete(`user/${id}`);
 
     getUserInformation();
   };

--- a/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggle.jsx
+++ b/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggle.jsx
@@ -34,7 +34,7 @@ const CardVisibilityToggle = ({ visibleCards, cardName, type }) => {
     // eslint-disable-next-line no-param-reassign
     visibleCards[cardName] = value;
     await axios
-      .put(`api/profile/${urlID || userID}?language=${locale}`, {
+      .put(`profile/${urlID || userID}?language=${locale}`, {
         visibleCards,
       })
       .catch((error) => handleError(error, "message", history));

--- a/services/frontend/src/components/changeLanguage/ChangeLanguage.jsx
+++ b/services/frontend/src/components/changeLanguage/ChangeLanguage.jsx
@@ -19,7 +19,7 @@ const ChangeLanguage = ({ intl }) => {
     dispatch(setLocale(languageCode));
     if (userID) {
       await axios
-        .put(`api/profile/${userID}?language=${languageCode}`, {
+        .put(`profile/${userID}?language=${languageCode}`, {
           preferredLanguage: languageCode,
         })
         .catch((error) => handleError(error, "message", history));

--- a/services/frontend/src/components/layouts/settingsLayout/SettingsLayout.jsx
+++ b/services/frontend/src/components/layouts/settingsLayout/SettingsLayout.jsx
@@ -14,7 +14,7 @@ const SettingsLayout = () => {
 
   const deleteCurrentUser = async () => {
     try {
-      await axios.delete(`/api/user/${id}`);
+      await axios.delete(`user/${id}`);
       history.push("/logout");
     } catch (error) {
       handleError(error, "message", history);
@@ -24,7 +24,7 @@ const SettingsLayout = () => {
   const setProfileVisibility = async (visibility) => {
     try {
       const updatedState = visibility ? "ACTIVE" : "HIDDEN";
-      await axios.put(`/api/profile/${id}?language=${locale}`, {
+      await axios.put(`profile/${id}?language=${locale}`, {
         status: updatedState,
       });
 

--- a/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementForm.jsx
+++ b/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementForm.jsx
@@ -134,15 +134,15 @@ const CareerManagementForm = ({ formType }) => {
         getMatrixResultOptions,
         getClassificationOptions,
       ] = await Promise.all([
-        axios.get(`api/profile/private/${id}?language=${locale}`),
-        axios.get(`api/option/categories?language=${locale}`),
-        axios.get(`api/option/developmentalGoals?language=${locale}`),
-        axios.get(`api/option/cityLocations?language=${locale}`),
-        axios.get(`api/option/attachmentNames?language=${locale}&type=Dev`),
-        axios.get(`api/option/lookingJobs?language=${locale}`),
-        axios.get(`api/option/careerMobilities?language=${locale}`),
-        axios.get(`api/option/talentMatrixResults?language=${locale}`),
-        axios.get(`api/option/classifications?language=${locale}`),
+        axios.get(`profile/private/${id}?language=${locale}`),
+        axios.get(`option/categories?language=${locale}`),
+        axios.get(`option/developmentalGoals?language=${locale}`),
+        axios.get(`option/cityLocations?language=${locale}`),
+        axios.get(`option/attachmentNames?language=${locale}&type=Dev`),
+        axios.get(`option/lookingJobs?language=${locale}`),
+        axios.get(`option/careerMobilities?language=${locale}`),
+        axios.get(`option/talentMatrixResults?language=${locale}`),
+        axios.get(`option/classifications?language=${locale}`),
       ]);
 
       setProfileInfo(profile.data);

--- a/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
+++ b/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
@@ -121,7 +121,7 @@ const CareerManagementFormView = ({
       values.lookingForANewJobId = null;
     }
 
-    await axios.put(`api/profile/${userId}?language=${locale}`, values);
+    await axios.put(`profile/${userId}?language=${locale}`, values);
   };
   /**
    * Open Notification

--- a/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
+++ b/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataForm.jsx
@@ -34,10 +34,10 @@ const EmploymentDataForm = ({ formType }) => {
   const getBackendInfo = useCallback(async () => {
     try {
       const [tenures, classifications, clearance, profile] = await Promise.all([
-        axios.get(`api/option/tenures?language=${locale}`),
-        axios.get(`api/option/classifications?language=${locale}`),
-        axios.get(`api/option/securityClearances?language=${locale}`),
-        axios.get(`api/profile/private/${id}?language=${locale}`),
+        axios.get(`option/tenures?language=${locale}`),
+        axios.get(`option/classifications?language=${locale}`),
+        axios.get(`option/securityClearances?language=${locale}`),
+        axios.get(`profile/private/${id}?language=${locale}`),
       ]);
       setSubstantiveOptions(tenures.data);
       setClassificationOptions(classifications.data);

--- a/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -115,7 +115,7 @@ const EmploymentDataFormView = ({
       values.actingEndDate = null;
     }
 
-    await axios.put(`api/profile/${userId}?language=${locale}`, values);
+    await axios.put(`profile/${userId}?language=${locale}`, values);
   };
 
   /* toggle temporary role form */

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -35,7 +35,7 @@ const LangProficiencyForm = ({ formType }) => {
   // Get user profile for form drop down
   const getProfileInfo = useCallback(async () => {
     await axios
-      .get(`api/profile/private/${id}?language=${locale}`)
+      .get(`profile/private/${id}?language=${locale}`)
       .then((result) => {
         if (result.data && result.data.secondLangProfs) {
           const readingObj = result.data.secondLangProfs.find(

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -171,7 +171,7 @@ const LangProficiencyFormView = ({
       }
     }
 
-    await axios.put(`api/profile/${userId}?language=${locale}`, dbValues);
+    await axios.put(`profile/${userId}?language=${locale}`, dbValues);
   };
 
   /**

--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoForm.jsx
@@ -22,7 +22,7 @@ const PrimaryInfoForm = ({ formType }) => {
 
   // Get possible locations for form drop down
   const getLocations = useCallback(async () => {
-    const result = await axios.get(`api/option/locations?language=${locale}`);
+    const result = await axios.get(`option/locations?language=${locale}`);
     setLocationOptions(result.data ? result.data : []);
   }, [axios, locale]);
 
@@ -30,7 +30,7 @@ const PrimaryInfoForm = ({ formType }) => {
   const getProfileInfo = useCallback(async () => {
     if (id) {
       const result = await axios.get(
-        `api/profile/private/${id}?language=${locale}`
+        `profile/private/${id}?language=${locale}`
       );
       setProfileInfo(result.data);
     }

--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -218,7 +218,7 @@ const PrimaryInfoFormView = ({
     };
 
     delete dbValues.jobTitle;
-    await axios.put(`api/profile/${userId}?language=${locale}`, dbValues);
+    await axios.put(`profile/${userId}?language=${locale}`, dbValues);
     await login(keycloak, axios);
   };
 

--- a/services/frontend/src/components/profileForms/primaryInfoForm/gedsUpdateModal/GedsUpdateModal.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/gedsUpdateModal/GedsUpdateModal.jsx
@@ -16,7 +16,7 @@ const GedsUpdateModal = ({ visibility }) => {
     const dbValues = {
       ...formValues,
     };
-    await axios.put(`api/profile/${id}?language=${locale}`, dbValues);
+    await axios.put(`profile/${id}?language=${locale}`, dbValues);
   };
 
   return (

--- a/services/frontend/src/components/profileForms/primaryInfoForm/gedsUpdateModal/GedsUpdateModalView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/gedsUpdateModal/GedsUpdateModalView.jsx
@@ -114,11 +114,11 @@ const GedsUpdateModalView = ({ visibility, saveDataToDB }) => {
     try {
       // get saved user profile
       const profileResult = await axios.get(
-        `api/profile/private/${id}?language=${locale}`
+        `profile/private/${id}?language=${locale}`
       );
 
       // get profile form geds
-      const gedsResult = await axios.get(`api/profGen`, {
+      const gedsResult = await axios.get(`profGen`, {
         params: {
           email,
         },

--- a/services/frontend/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
+++ b/services/frontend/src/components/profileForms/qualificationsForm/QualificationsForm.jsx
@@ -29,11 +29,11 @@ const QualificationsForm = ({ formType }) => {
   const getBackendInfo = useCallback(async () => {
     try {
       return await Promise.all([
-        axios.get(`api/profile/private/${id}?language=${locale}`),
-        axios.get(`api/option/diplomas?language=${locale}`),
-        axios.get(`api/option/schools?language=${locale}`),
-        axios.get(`api/option/attachmentNames?language=${locale}&type=Edu`),
-        axios.get(`api/option/attachmentNames?language=${locale}&type=Exp`),
+        axios.get(`profile/private/${id}?language=${locale}`),
+        axios.get(`option/diplomas?language=${locale}`),
+        axios.get(`option/schools?language=${locale}`),
+        axios.get(`option/attachmentNames?language=${locale}&type=Edu`),
+        axios.get(`option/attachmentNames?language=${locale}&type=Exp`),
       ]);
     } catch (error) {
       setLoad(false);
@@ -43,7 +43,7 @@ const QualificationsForm = ({ formType }) => {
 
   const saveDataToDB = async (unalteredValues) => {
     const values = { ...unalteredValues };
-    await axios.put(`api/profile/${id}?language=${locale}`, values);
+    await axios.put(`profile/${id}?language=${locale}`, values);
   };
 
   useEffect(() => {

--- a/services/frontend/src/components/profileForms/talentForm/TalentForm.jsx
+++ b/services/frontend/src/components/profileForms/talentForm/TalentForm.jsx
@@ -33,7 +33,7 @@ const TalentForm = ({ formType }) => {
    */
   const getProfileInfo = useCallback(async () => {
     const result = await axios.get(
-      `api/profile/private/${id}?language=${locale}`
+      `profile/private/${id}?language=${locale}`
     );
     setProfileInfo(result.data);
   }, [axios, id, locale]);
@@ -45,7 +45,7 @@ const TalentForm = ({ formType }) => {
    */
   const getCompetencyOptions = useCallback(async () => {
     const result = await axios.get(
-      `api/option/competencies?language=${locale}`
+      `option/competencies?language=${locale}`
     );
 
     setCompetencyOptions(result.data);
@@ -58,8 +58,8 @@ const TalentForm = ({ formType }) => {
    */
   const getSkillOptions = useCallback(async () => {
     const [categoriesResult, skillsResults] = await Promise.all([
-      axios.get(`api/option/categories?language=${locale}`),
-      axios.get(`api/option/skills?language=${locale}`),
+      axios.get(`option/categories?language=${locale}`),
+      axios.get(`option/skills?language=${locale}`),
     ]);
 
     // Loop through all skill categories

--- a/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -96,7 +96,7 @@ const TalentFormView = ({
       values.mentorshipSkills = [];
     }
 
-    await axios.put(`api/profile/${userId}?language=${locale}`, values);
+    await axios.put(`profile/${userId}?language=${locale}`, values);
   };
 
   /**

--- a/services/frontend/src/components/profileForms/welcome/Welcome.jsx
+++ b/services/frontend/src/components/profileForms/welcome/Welcome.jsx
@@ -24,7 +24,7 @@ const Welcome = () => {
 
   const skipProfileCreation = async () => {
     try {
-      await axios.put(`/api/profile/${id}?language=${locale}`, {
+      await axios.put(`profile/${id}?language=${locale}`, {
         signupStep: 8,
         status: "HIDDEN",
       });
@@ -43,7 +43,7 @@ const Welcome = () => {
      */
     const getGedsProfiles = async () => {
       // Get info from GEDS
-      const result = await axios.get(`api/profGen`, {
+      const result = await axios.get(`profGen`, {
         params: {
           email,
         },

--- a/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
@@ -57,7 +57,7 @@ const WelcomeView = ({
       if (value) {
         // create profile
         await axios
-          .put(`${backendAddress}api/profile/${userId}?language=ENGLISH`, value)
+          .put(`${backendAddress}profile/${userId}?language=ENGLISH`, value)
           .then(() => history.push("/profile/create/step/2"))
           .catch((error) => handleError(error, "message", history));
       }

--- a/services/frontend/src/components/reportBug/ReportBug.jsx
+++ b/services/frontend/src/components/reportBug/ReportBug.jsx
@@ -5,7 +5,7 @@ const ReportBug = () => {
   const axios = useAxios();
 
   const saveDataToDB = async (values) => {
-    await axios.post("api/bugs", values);
+    await axios.post("bugs", values);
   };
 
   return <ReportBugView saveDataToDB={saveDataToDB} />;

--- a/services/frontend/src/components/resultsCard/ResultsCard.jsx
+++ b/services/frontend/src/components/resultsCard/ResultsCard.jsx
@@ -28,7 +28,7 @@ const ResultsCard = () => {
       const queryString = urlSections[1];
       const type = queryString.includes("searchValue") ? "fuzzy" : "filters";
       const result = await axios.get(
-        `api/search/${type}?${queryString}&language=${locale}`
+        `search/${type}?${queryString}&language=${locale}`
       );
 
       setResults(result.data);
@@ -44,7 +44,7 @@ const ResultsCard = () => {
    */
   const getConnections = useCallback(async () => {
     const result = await axios.get(
-      `api/profile/private/${id}?language=${locale}`
+      `profile/private/${id}?language=${locale}`
     );
 
     setConnections(map(result.data.connections, property("id")));
@@ -70,7 +70,7 @@ const ResultsCard = () => {
    */
   const addConnection = async (urlID) => {
     await axios
-      .post(`api/connections/${urlID}`)
+      .post(`connections/${urlID}`)
       .catch((error) => handleError(error, "message", history));
     getConnections();
   };
@@ -81,7 +81,7 @@ const ResultsCard = () => {
    */
   const removeConnection = async (urlID) => {
     await axios
-      .delete(`api/connections/${urlID}`)
+      .delete(`connections/${urlID}`)
       .catch((error) => handleError(error, "message", history));
     getConnections();
   };

--- a/services/frontend/src/components/searchBar/SearchBar.jsx
+++ b/services/frontend/src/components/searchBar/SearchBar.jsx
@@ -25,8 +25,8 @@ const SearchBar = () => {
    */
   const getSkills = useCallback(async () => {
     const [categoriesResult, skillsResults] = await Promise.all([
-      axios.get(`api/option/categories?language=${locale}`),
-      axios.get(`api/option/skills?language=${locale}`),
+      axios.get(`option/categories?language=${locale}`),
+      axios.get(`option/skills?language=${locale}`),
     ]);
 
     // Loop through all skill categories
@@ -58,19 +58,19 @@ const SearchBar = () => {
 
   // Fetches options for branches select field in advanced search
   const getBranch = useCallback(async () => {
-    const results = await axios.get(`api/option/branches?language=${locale}`);
+    const results = await axios.get(`option/branches?language=${locale}`);
     setBranchOptions(results.data);
   }, [axios, locale]);
 
   // Fetches options for locations select field in advanced search
   const getLocation = useCallback(async () => {
-    const results = await axios.get(`api/option/locations?language=${locale}`);
+    const results = await axios.get(`option/locations?language=${locale}`);
     setLocationOptions(results.data);
   }, [axios, locale]);
 
   // Fetches options for classifications select field in advanced search
   const getClassification = useCallback(async () => {
-    const results = await axios.get(`api/option/classifications`);
+    const results = await axios.get(`option/classifications`);
     setClassOptions(results.data);
   }, [axios]);
 

--- a/services/frontend/src/components/searchFilter/SearchFilter.jsx
+++ b/services/frontend/src/components/searchFilter/SearchFilter.jsx
@@ -77,11 +77,11 @@ const SearchFilter = () => {
         categoriesResult,
         skillsResults,
       ] = await Promise.all([
-        axios.get(`api/option/branches?language=${locale}`),
-        axios.get(`api/option/locations?language=${locale}`),
-        axios.get(`api/option/classifications`),
-        axios.get(`api/option/categories?language=${locale}`),
-        axios.get(`api/option/skills?language=${locale}`),
+        axios.get(`option/branches?language=${locale}`),
+        axios.get(`option/locations?language=${locale}`),
+        axios.get(`option/classifications`),
+        axios.get(`option/categories?language=${locale}`),
+        axios.get(`option/skills?language=${locale}`),
       ]);
       setBranchOptions(branch.data);
       setLocationOptions(location.data);

--- a/services/frontend/src/pages/Profile.jsx
+++ b/services/frontend/src/pages/Profile.jsx
@@ -29,13 +29,13 @@ const Profile = ({ history, match }) => {
     const apiCalls = [];
     const profile =
       id === userID
-        ? axios.get(`api/profile/private/${id}?language=${locale}`)
-        : axios.get(`api/profile/${id}?language=${locale}`);
+        ? axios.get(`profile/private/${id}?language=${locale}`)
+        : axios.get(`profile/${id}?language=${locale}`);
 
     apiCalls.push(profile);
 
     if (id !== userID) {
-      apiCalls.push(axios.get(`api/connections/${id}`));
+      apiCalls.push(axios.get(`connections/${id}`));
     }
 
     try {
@@ -89,12 +89,12 @@ const Profile = ({ history, match }) => {
   const changeConnection = async () => {
     if (connectionData) {
       await axios
-        .delete(`api/connections/${id}`)
+        .delete(`connections/${id}`)
         .catch((error) => handleError(error, "message", history));
       setConnectionData(false);
     } else {
       await axios
-        .post(`api/connections/${id}`)
+        .post(`connections/${id}`)
         .catch((error) => handleError(error, "message", history));
       setConnectionData(true);
     }

--- a/services/frontend/src/pages/ProfileCreate.jsx
+++ b/services/frontend/src/pages/ProfileCreate.jsx
@@ -20,7 +20,7 @@ const ProfileCreate = ({ match }) => {
     if (signupStep > highestStep) {
       dispatch(setUserSignupStep(signupStep));
 
-      axios.put(`api/profile/${id}?language=${locale}`, {
+      axios.put(`profile/${id}?language=${locale}`, {
         signupStep,
       });
     }

--- a/services/frontend/src/pages/Stats.jsx
+++ b/services/frontend/src/pages/Stats.jsx
@@ -28,9 +28,9 @@ const Stats = () => {
         topFiveSkills,
         topFiveDevelopmentalGoals,
       ] = await Promise.all([
-        axios.get(`api/stats/topFiveCompetencies?language=${locale}`),
-        axios.get(`api/stats/topFiveSkills?language=${locale}`),
-        axios.get(`api/stats/topFiveDevelopmentalGoals?language=${locale}`),
+        axios.get(`stats/topFiveCompetencies?language=${locale}`),
+        axios.get(`stats/topFiveSkills?language=${locale}`),
+        axios.get(`stats/topFiveDevelopmentalGoals?language=${locale}`),
       ]);
       dispatch(
         setTopFive({

--- a/services/frontend/src/pages/admin/AdminDashboard.jsx
+++ b/services/frontend/src/pages/admin/AdminDashboard.jsx
@@ -52,15 +52,15 @@ const AdminDashboard = ({ intl }) => {
         topFiveDevelopmentalGoals,
         topFiveSkills,
       ] = await Promise.all([
-        axios.get(`api/stats/count/users`),
-        axios.get(`api/stats/count/hiddenUsers`),
-        axios.get(`api/stats/count/inactiveUsers`),
-        axios.get(`api/stats/count/exFeederUsers`),
-        axios.get(`api/stats/growthRateByMonth`),
-        axios.get(`api/stats/growthRateByWeek`),
-        axios.get(`api/stats/topFiveCompetencies?language=${locale}`),
-        axios.get(`api/stats/topFiveDevelopmentalGoals?language=${locale}`),
-        axios.get(`api/stats/topFiveSkills?language=${locale}`),
+        axios.get(`stats/count/users`),
+        axios.get(`stats/count/hiddenUsers`),
+        axios.get(`stats/count/inactiveUsers`),
+        axios.get(`stats/count/exFeederUsers`),
+        axios.get(`stats/growthRateByMonth`),
+        axios.get(`stats/growthRateByWeek`),
+        axios.get(`stats/topFiveCompetencies?language=${locale}`),
+        axios.get(`stats/topFiveDevelopmentalGoals?language=${locale}`),
+        axios.get(`stats/topFiveSkills?language=${locale}`),
       ]);
       dispatch(
         setInitialAdminData({

--- a/services/frontend/src/utils/login.js
+++ b/services/frontend/src/utils/login.js
@@ -3,7 +3,7 @@ import { setLocale } from "../redux/slices/settingsSlice";
 import store from "../redux";
 
 const createUser = async (userInfo, axios) =>
-  axios.post("api/user", {
+  axios.post("user", {
     email: userInfo.email,
     name: userInfo.name,
     lastName: userInfo.family_name,
@@ -13,7 +13,7 @@ const createUser = async (userInfo, axios) =>
 const profileExist = async (userInfo, axios) => {
   let response;
   try {
-    response = await axios.get("api/user");
+    response = await axios.get("user");
 
     if (response.data === null) {
       response = await createUser(userInfo, axios);


### PR DESCRIPTION
#### Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
Since we use the same format to call the backend across the application it would be easier and more simplified to remove the /api from the code. This could also be helpful in case we decide to switch to a different url format.

#### Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->


#### Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. -->


#### Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] Has been tested on IE
- [ ] The modifications are tab friendly
- [ ] It is accessible
