### PR TITLE
[Fix] Husky causing build issue in Jenkins

### DIFF
--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -16,7 +16,7 @@
     "i18n:alphabetize": "node ./src/i18n/alphabetizeKeys",
     "i18n:export": "node ./src/i18n/exportTransToCSV",
     "analyze": "ANALYZE_BUILD=true yarn build",
-    "postinstall": "cd ../../ && husky install services/frontend/.husky"
+    "prepare": "cd ../../ && husky install services/frontend/.husky"
   },
   "dependencies": {
     "@ant-design/icons": "4.6.2",


### PR DESCRIPTION
#### ⭐ Changes introduced
<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
change from postinstall to prepare so that it only runs in dev.


#### 🔗 Related issue(s)
<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #1460

#### 📸 Screenshots (if applicable)
<!-- If you have made UI changes to the application, include a screenshot and if the change 
     involves movement, include a GIF. If the UI changes when the application is in mobile view, 
     show a mobile screenshot too. Include English and French versions for translation validation-->

#### ☑️ Checklist
If the database has been modified:
- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:
- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak 
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!-- 
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing 
-->

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:
- [ ] run `yarn i18n:validate" and clear errors 
