### PR TITLE
[Fix] Restyle Profile Org Chart

### DIFF
--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -226,9 +226,10 @@ const BasicInfoView = ({
               </>
             }
             visible={isModalVisible}
-            onOk={() => setIsModalVisible(false)}
+            closable={false}
+            cancelText={<FormattedMessage id="close" />}
             onCancel={() => setIsModalVisible(false)}
-            cancelButtonProps={{ style: { display: "none" } }}
+            okButtonProps={{ style: { display: "none" } }}
           >
             <OrgTree data={data} />
           </Modal>

--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -1,9 +1,9 @@
+import { useState } from "react";
 import { FormattedMessage } from "react-intl";
 import {
   MailOutlined,
   PhoneOutlined,
   MobileOutlined,
-  BranchesOutlined,
   EnvironmentOutlined,
   UserOutlined,
   DownOutlined,
@@ -11,6 +11,7 @@ import {
   UserDeleteOutlined,
   UserAddOutlined,
   InfoCircleOutlined,
+  ApartmentOutlined,
 } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import {
@@ -25,6 +26,7 @@ import {
   // Menu,
   Tag,
   Popover,
+  Modal,
 } from "antd";
 import { useParams } from "react-router";
 import { useSelector } from "react-redux";
@@ -49,6 +51,7 @@ const BasicInfoView = ({
   const { id } = useParams();
   const urlID = id;
   const userID = useSelector((state) => state.user.id);
+  const [isModalVisible, setIsModalVisible] = useState(false);
 
   /*
    * Generate Profile Header
@@ -205,21 +208,30 @@ const BasicInfoView = ({
    */
   const getWorkInfo = () => {
     const branch = {
-      icon: <BranchesOutlined />,
+      icon: <ApartmentOutlined />,
       title: <FormattedMessage id="profile.org.tree" />,
       description: data.branch ? (
         <>
-          <Popover
-            content={<OrgTree data={data} />}
-            title={<FormattedMessage id="profile.org.tree" />}
-            trigger="click"
-            placement="bottom"
+          <Button className="orgButton" onClick={() => setIsModalVisible(true)}>
+            <DownOutlined />
+            <span>{data.branch}</span>
+          </Button>
+          <Modal
+            title={
+              <>
+                <ApartmentOutlined />{" "}
+                <span>
+                  <FormattedMessage id="profile.org.tree" />
+                </span>
+              </>
+            }
+            visible={isModalVisible}
+            onOk={() => setIsModalVisible(false)}
+            onCancel={() => setIsModalVisible(false)}
+            cancelButtonProps={{ style: { display: "none" } }}
           >
-            <Button className="orgButton" type="link">
-              <DownOutlined />
-              <span className="leftSpacing">{data.branch}</span>
-            </Button>
-          </Popover>
+            <OrgTree data={data} />
+          </Modal>
         </>
       ) : (
         <FormattedMessage id="not.specified" />

--- a/services/frontend/src/components/basicInfo/BasicInfoView.jsx
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.jsx
@@ -17,12 +17,12 @@ import {
   Row,
   Col,
   Card,
-  Dropdown,
+  // Dropdown,
   Avatar,
   List,
   Typography,
   Button,
-  Menu,
+  // Menu,
   Tag,
   Popover,
 } from "antd";
@@ -208,19 +208,19 @@ const BasicInfoView = ({
       icon: <BranchesOutlined />,
       title: <FormattedMessage id="profile.org.tree" />,
       description: data.branch ? (
-        <Dropdown
-          overlay={
-            <Menu className="orgDropdown">
-              <OrgTree data={data} />
-            </Menu>
-          }
-          trigger={["click"]}
-        >
-          <Button className="orgButton" type="link">
-            <DownOutlined />
-            <span className="leftSpacing">{data.branch}</span>
-          </Button>
-        </Dropdown>
+        <>
+          <Popover
+            content={<OrgTree data={data} />}
+            title={<FormattedMessage id="profile.org.tree" />}
+            trigger="click"
+            placement="bottom"
+          >
+            <Button className="orgButton" type="link">
+              <DownOutlined />
+              <span className="leftSpacing">{data.branch}</span>
+            </Button>
+          </Popover>
+        </>
       ) : (
         <FormattedMessage id="not.specified" />
       ),

--- a/services/frontend/src/components/basicInfo/BasicInfoView.less
+++ b/services/frontend/src/components/basicInfo/BasicInfoView.less
@@ -26,11 +26,6 @@
   margin-right: -10px !important;
 }
 
-.leftSpacing {
-  padding-left: 0.5em;
-  white-space: normal;
-}
-
 .rowTopSplitter {
   border-top: 1px solid #f0f0f0;
 }

--- a/services/frontend/src/components/orgTree/OrgTreeView.jsx
+++ b/services/frontend/src/components/orgTree/OrgTreeView.jsx
@@ -1,5 +1,5 @@
 import { Tree, Typography } from "antd";
-import { BranchesOutlined, InfoCircleOutlined } from "@ant-design/icons";
+import { InfoCircleOutlined } from "@ant-design/icons";
 import { FormattedMessage } from "react-intl";
 import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
@@ -25,7 +25,6 @@ const OrgTreeView = ({ data }) => {
       const object = {
         title: titleString(val.title),
         key: val.id,
-        icon: <BranchesOutlined />,
       };
       if (retVal.length !== 0) {
         object.children = [retVal];

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -55,6 +55,7 @@
   "category": "Category",
   "classification": "Classification",
   "clear.changes": "Clear changes",
+  "close": "Close",
   "company.or.gov.branch.name": "Company or government branch name",
   "competencies": "Competencies",
   "competencies.empty": "no competencies provided",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -55,6 +55,7 @@
   "category": "Catégorie",
   "classification": "Classification",
   "clear.changes": "Effacer les modifications",
+  "close": "Fermer",
   "company.or.gov.branch.name": "Nom de la société ou de la branche gouvernementale",
   "competencies": "Compétences",
   "competencies.empty": "aucune compétence fournie",


### PR DESCRIPTION
#### ⭐ Changes introduced
- changed organization dropdown to a modal
- Modal is more screen reader-friendly than dropdown
- updated icons for the organization

#### 🔗 Related issue(s)
closes #1441 


#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/122251833-dd6a1580-ce98-11eb-944d-ceaac884b506.png)
![image](https://user-images.githubusercontent.com/11470442/122263607-a39f0c00-cea4-11eb-8283-95e26f005dab.png)

#### ☑️ Checklist

If the database has been modified:

- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:

- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!--
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing
-->

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
