### PR TITLE
[Fix] Clean up the display of empty second language results

### DIFF
--- a/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
@@ -44,9 +44,6 @@ const OfficialLanguage = ({ data, editableCardBool }) => {
         } else {
           nextData.level = info.level;
         }
-      } else {
-        nextData.level = "-";
-        nextData.status = "-";
       }
 
       languageInfo.push(nextData);

--- a/services/frontend/src/components/officialLanguage/OfficialLanguageView.jsx
+++ b/services/frontend/src/components/officialLanguage/OfficialLanguageView.jsx
@@ -24,9 +24,13 @@ const OfficialLanguageView = ({ firstLanguageInfo, secondLanguageInfo }) => {
           <List.Item.Meta
             title={<FormattedMessage id={i.titleId} />}
             description={
-              <>
-                {i.level} ({i.status})
-              </>
+              i.level ? (
+                <>
+                  {i.level} {i.status}
+                </>
+              ) : (
+                "-"
+              )
             }
           />
         </List.Item>

--- a/services/frontend/src/components/officialLanguage/OfficialLanguageView.jsx
+++ b/services/frontend/src/components/officialLanguage/OfficialLanguageView.jsx
@@ -26,7 +26,7 @@ const OfficialLanguageView = ({ firstLanguageInfo, secondLanguageInfo }) => {
             description={
               i.level ? (
                 <>
-                  {i.level} {i.status}
+                  {i.level} ({i.status})
                 </>
               ) : (
                 "-"


### PR DESCRIPTION
#### ⭐ Changes introduced
- clean up the logic to generate the reading results from the backend
- removed the extra brackets that were displayed if "result status" was empty

#### 🔗 Related issue(s)
closes #1442 

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/122284240-66924400-cebb-11eb-9466-ae2e5ea5f8be.png)
![image](https://user-images.githubusercontent.com/11470442/122284352-7f025e80-cebb-11eb-9dcd-f2b7d7a92aef.png)


#### ☑️ Checklist

If the database has been modified:

- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:

- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!--
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing
-->

If the UI has been modified:

- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:

- [ ] run `yarn i18n:validate" and clear errors
