### PR TITLE
[Fix] improve accessibility of privacy modal

### DIFF
--- a/services/frontend/src/components/changeLanguage/ChangeLanguage.jsx
+++ b/services/frontend/src/components/changeLanguage/ChangeLanguage.jsx
@@ -1,11 +1,12 @@
 import { useDispatch, useSelector } from "react-redux";
 import { useHistory } from "react-router";
+import PropTypes from "prop-types";
 import ChangeLanguageView from "./ChangeLanguageView";
 import { setLocale } from "../../redux/slices/settingsSlice";
 import useAxios from "../../utils/useAxios";
 import handleError from "../../functions/handleError";
 
-const ChangeLanguage = () => {
+const ChangeLanguage = ({ className }) => {
   const userID = useSelector((state) => state.user.id);
   const userLang = useSelector((state) => state.settings.locale);
   let languageCode = "ENGLISH";
@@ -28,7 +29,20 @@ const ChangeLanguage = () => {
     }
   };
 
-  return <ChangeLanguageView handleLanguageChange={handleLanguageChange} />;
+  return (
+    <ChangeLanguageView
+      handleLanguageChange={handleLanguageChange}
+      className={className}
+    />
+  );
+};
+
+ChangeLanguage.propTypes = {
+  className: PropTypes.string,
+};
+
+ChangeLanguage.defaultProps = {
+  className: "",
 };
 
 export default ChangeLanguage;

--- a/services/frontend/src/components/changeLanguage/ChangeLanguageView.jsx
+++ b/services/frontend/src/components/changeLanguage/ChangeLanguageView.jsx
@@ -3,7 +3,7 @@ import { GlobalOutlined } from "@ant-design/icons";
 import { Button } from "antd";
 import { FormattedMessage, useIntl } from "react-intl";
 
-const ChangeLanguageView = ({ handleLanguageChange }) => {
+const ChangeLanguageView = ({ className, handleLanguageChange }) => {
   const intl = useIntl();
 
   return (
@@ -18,6 +18,7 @@ const ChangeLanguageView = ({ handleLanguageChange }) => {
         borderColor: "#454545",
       }}
       aria-label={intl.formatMessage({ id: "language.change" })}
+      className={className}
     >
       <GlobalOutlined id="admin" className="mr-2" />
       <FormattedMessage
@@ -30,6 +31,7 @@ const ChangeLanguageView = ({ handleLanguageChange }) => {
 
 ChangeLanguageView.propTypes = {
   handleLanguageChange: PropTypes.func.isRequired,
+  className: PropTypes.string.isRequired,
 };
 
 export default ChangeLanguageView;

--- a/services/frontend/src/components/privacyModal/PrivacyModalView.jsx
+++ b/services/frontend/src/components/privacyModal/PrivacyModalView.jsx
@@ -1,5 +1,5 @@
 import PropTypes from "prop-types";
-import { Modal } from "antd";
+import { Modal, Button } from "antd";
 import { LockOutlined, CheckOutlined, CloseOutlined } from "@ant-design/icons";
 import { FormattedMessage } from "react-intl";
 import ChangeLanguage from "../changeLanguage/ChangeLanguage";
@@ -9,30 +9,41 @@ const PrivacyModalView = ({ handleOk, handleCancel, showModal, locale }) => (
   <Modal
     title={
       <>
-        <LockOutlined /> <FormattedMessage id="privacy.modal.header" />
-        <div className="privacyModalHeaderExtra">
-          <ChangeLanguage />
-        </div>
+        <LockOutlined aria-hidden="true" className="mr-1" />
+        <FormattedMessage id="privacy.modal.header" />
       </>
     }
     visible={showModal}
     closable={false}
     maskClosable={false}
-    okText={
-      <>
-        <CheckOutlined className="ModalbBtnIcon" />
-        <FormattedMessage id="privacy.modal.accept" />
-      </>
-    }
-    cancelText={
-      <>
-        <CloseOutlined className="ModalbBtnIcon" />
-        <FormattedMessage id="privacy.modal.decline" />
-      </>
-    }
+    // okText={
+    //   <>
+    //     <CheckOutlined className="ModalbBtnIcon" aria-hidden="true" />
+    //     <FormattedMessage id="privacy.modal.accept" />
+    //   </>
+    // }
+    // cancelText={
+    //   <>
+    //     <CloseOutlined className="ModalbBtnIcon" aria-hidden="true" />
+    //     <FormattedMessage id="privacy.modal.decline" />
+    //   </>
+    // }
     onOk={handleOk}
     onCancel={handleCancel}
     width={600}
+    footer={
+      <>
+        <ChangeLanguage className="privacyModalChangeLangBtn" />
+        <Button onClick={handleCancel}>
+          <CloseOutlined className="ModalbBtnIcon" aria-hidden="true" />
+          <FormattedMessage id="privacy.modal.decline" />
+        </Button>
+        <Button onClick={handleOk}>
+          <CheckOutlined className="ModalbBtnIcon" aria-hidden="true" />
+          <FormattedMessage id="privacy.modal.accept" />
+        </Button>
+      </>
+    }
   >
     <div className="privacyModalContent">
       {locale === "ENGLISH" ? (

--- a/services/frontend/src/components/privacyModal/PrivacyModalView.jsx
+++ b/services/frontend/src/components/privacyModal/PrivacyModalView.jsx
@@ -16,20 +16,6 @@ const PrivacyModalView = ({ handleOk, handleCancel, showModal, locale }) => (
     visible={showModal}
     closable={false}
     maskClosable={false}
-    // okText={
-    //   <>
-    //     <CheckOutlined className="ModalbBtnIcon" aria-hidden="true" />
-    //     <FormattedMessage id="privacy.modal.accept" />
-    //   </>
-    // }
-    // cancelText={
-    //   <>
-    //     <CloseOutlined className="ModalbBtnIcon" aria-hidden="true" />
-    //     <FormattedMessage id="privacy.modal.decline" />
-    //   </>
-    // }
-    onOk={handleOk}
-    onCancel={handleCancel}
     width={600}
     footer={
       <>

--- a/services/frontend/src/components/privacyModal/PrivacyModalView.less
+++ b/services/frontend/src/components/privacyModal/PrivacyModalView.less
@@ -1,7 +1,7 @@
-.privacyModalHeaderExtra {
+.privacyModalChangeLangBtn {
   position: absolute;
-  right: 25px;
-  top: 12px;
+  left: 25px;
+  bottom: 10px;
 }
 
 .ModalbBtnIcon {


### PR DESCRIPTION
#### ⭐ Changes introduced
- moved the "change language button" to footer of privacy modal to stop screen reader from reading it repeatedly when the modal opens
- hid all the icons in the modal from the screen reader

#### 🔗 Related issue(s)
closes #1484 

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/122790139-0407c200-d286-11eb-824a-bc7be4ff2ea7.png)

#### ☑️ Checklist

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
