### PR TITLE
[New] Add "skip to content" link

### DIFF
--- a/services/frontend/src/components/layouts/appLayout/AppLayoutView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/AppLayoutView.jsx
@@ -38,19 +38,16 @@ const AppLayoutView = ({
           loading={loading}
         />
         <Layout className="app-layout">
-          <div id="main">
-            <Content className="app-content">
-              {loading ? (
-                <Card>
-                  <Skeleton active />
-                </Card>
-              ) : (
-                children
-              )}
-            </Content>
-
-            {!loading && <Footer />}
-          </div>
+          <Content className="app-content" id="main">
+            {loading ? (
+              <Card>
+                <Skeleton active />
+              </Card>
+            ) : (
+              children
+            )}
+          </Content>
+          {!loading && <Footer />}
         </Layout>
       </Layout>
     </Layout>

--- a/services/frontend/src/components/layouts/appLayout/AppLayoutView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/AppLayoutView.jsx
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 import TopNav from "./topNav/TopNav";
 import Footer from "./footer/Footer";
 import SideNav from "./sideNav/SideNav";
+import SkipToContent from "./skipToContent/SkipToContent";
 import "./AppLayoutView.less";
 
 const { Content } = Layout;
@@ -24,6 +25,7 @@ const AppLayoutView = ({
       <Helmet>
         <html lang={locale === "ENGLISH" ? "en" : "fr"} />
       </Helmet>
+      <SkipToContent contentId="#main" />
       <TopNav
         loading={loading}
         displayLogo={displayLogo}
@@ -36,16 +38,19 @@ const AppLayoutView = ({
           loading={loading}
         />
         <Layout className="app-layout">
-          <Content className="app-content">
-            {loading ? (
-              <Card>
-                <Skeleton active />
-              </Card>
-            ) : (
-              children
-            )}
-          </Content>
-          {!loading && <Footer />}
+          <div id="main">
+            <Content className="app-content">
+              {loading ? (
+                <Card>
+                  <Skeleton active />
+                </Card>
+              ) : (
+                children
+              )}
+            </Content>
+
+            {!loading && <Footer />}
+          </div>
         </Layout>
       </Layout>
     </Layout>

--- a/services/frontend/src/components/layouts/appLayout/AppLayoutView.less
+++ b/services/frontend/src/components/layouts/appLayout/AppLayoutView.less
@@ -1,8 +1,8 @@
 .app {
   &-content {
-    padding: 20px 15px;
+    padding: 84px 15px;
     margin: 0;
-    margin-top: 64px;
+    // margin-top: 64px;
     height: 100%;
   }
 

--- a/services/frontend/src/components/layouts/appLayout/AppLayoutView.less
+++ b/services/frontend/src/components/layouts/appLayout/AppLayoutView.less
@@ -2,7 +2,6 @@
   &-content {
     padding: 84px 15px;
     margin: 0;
-    // margin-top: 64px;
     height: 100%;
   }
 

--- a/services/frontend/src/components/layouts/appLayout/sideNav/SideNavView.less
+++ b/services/frontend/src/components/layouts/appLayout/sideNav/SideNavView.less
@@ -3,7 +3,7 @@
   position: sticky;
   top: 0;
   left: 0;
-  z-index: 998 !important;
+  z-index: 997 !important;
 
   &-content {
     padding-top: 64px;

--- a/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContent.jsx
+++ b/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContent.jsx
@@ -1,0 +1,12 @@
+import PropTypes from "prop-types";
+import SkipToContentView from "./SkipToContentView";
+
+const SkipToContent = ({ contentId }) => (
+  <SkipToContentView contentId={contentId} />
+);
+
+SkipToContent.propTypes = {
+  contentId: PropTypes.string.isRequired,
+};
+
+export default SkipToContent;

--- a/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.jsx
@@ -1,0 +1,15 @@
+import { Button } from "antd";
+import PropTypes from "prop-types";
+import "./SkipToContentView.less";
+
+const SkipToContentView = ({ contentId }) => (
+  <Button className="skip-to-content-link" href={contentId} tabIndex="0">
+    Skip to content
+  </Button>
+);
+
+SkipToContentView.propTypes = {
+  contentId: PropTypes.string.isRequired,
+};
+
+export default SkipToContentView;

--- a/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.jsx
@@ -1,10 +1,11 @@
 import { Button } from "antd";
 import PropTypes from "prop-types";
+import { FormattedMessage } from "react-intl";
 import "./SkipToContentView.less";
 
 const SkipToContentView = ({ contentId }) => (
   <Button className="skip-to-content-link" href={contentId} tabIndex="0">
-    Skip to content
+    <FormattedMessage id="skip.to.content" />
   </Button>
 );
 

--- a/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.less
+++ b/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.less
@@ -2,7 +2,7 @@
   position: absolute;
   left: 50%;
   top: 10px;
-  transform: translateY(-120%);
+  transform: translateY(-130%);
   transition: transform 0.3s;
   z-index: 999 !important;
 }

--- a/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.less
+++ b/services/frontend/src/components/layouts/appLayout/skipToContent/SkipToContentView.less
@@ -1,0 +1,12 @@
+.skip-to-content-link {
+  position: absolute;
+  left: 50%;
+  top: 10px;
+  transform: translateY(-120%);
+  transition: transform 0.3s;
+  z-index: 999 !important;
+}
+
+.skip-to-content-link:focus {
+  transform: translateY(0%);
+}

--- a/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.jsx
+++ b/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { Layout, Dropdown, Menu, Button, Input, Row, Typography } from "antd";
 import {
   DownOutlined,
   EditOutlined,
@@ -13,7 +14,6 @@ import {
 } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import { useKeycloak } from "@react-keycloak/web";
-import { Layout, Dropdown, Menu, Button, Input, Row, Typography } from "antd";
 import { FormattedMessage, useIntl } from "react-intl";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router";
@@ -145,11 +145,7 @@ const TopNavView = ({ isAdmin, loading, displaySearch, displayLogo }) => {
             <Text id="nav-dropDownButton-name" ellipsis>
               {shortenName(firstName, lastName)}
             </Text>
-            <DownOutlined
-              className="dropDownArrow"
-              id="admin"
-              aria-hidden="true"
-            />
+            <DownOutlined className="dropDownArrow" aria-hidden="true" />
           </Button>
         </Dropdown>
       );

--- a/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.less
+++ b/services/frontend/src/components/layouts/appLayout/topNav/TopNavView.less
@@ -2,7 +2,7 @@
   padding: 0 !important;
   box-shadow: rgba(0, 0, 0, 0.05) 0px 0.1rem 0.1rem;
   position: fixed;
-  z-index: 999;
+  z-index: 998;
   width: 100%;
   border-bottom: 1px solid #f0f0f0;
 }

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -319,6 +319,7 @@
   "skills.and.talent.question": "Are you searching for employees with specific skills?",
   "skills.empty": "no skills provided",
   "skills.not.found": "No matching skills found",
+  "skip.to.content": "Skip to content",
   "something.went.wrong": "Something went wrong",
   "start.fresh": "start fresh",
   "statistics": "Statistics",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -319,6 +319,7 @@
   "skills.and.talent.question": "Cherchez-vous des employés avec des habiletés spécifiques ?",
   "skills.empty": "Aucune habileté fournie",
   "skills.not.found": "Aucune habileté correspondante trouvée",
+  "skip.to.content": "Aller au contenu",
   "something.went.wrong": "Quelque chose a mal tourné",
   "start.fresh": "débuter",
   "statistics": "Statistiques",


### PR DESCRIPTION
#### ⭐ Changes introduced
for accessibility reasons I created a button to allow "keyboard users"/"screen readers" to skip menus and jump to page content

#### 🔗 Related issue(s)
closes #1477 

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/122810271-28bb6400-d29d-11eb-9cbd-034e1b0b028f.png)


#### ☑️ Checklist

If the UI has been modified:

- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:

- [ ] run `yarn i18n:validate" and clear errors
