### PR TITLE
[Fix] hide heading icons from screen reader

### DIFF
--- a/services/frontend/src/components/admin/bugsTable/BugsTableView.jsx
+++ b/services/frontend/src/components/admin/bugsTable/BugsTableView.jsx
@@ -265,12 +265,8 @@ const BugsTableView = ({ getBugs, saveDataToDB }) => {
   return (
     <>
       <Header
-        title={
-          <>
-            <DatabaseOutlined />
-            <FormattedMessage id="user.reported.bugs" />
-          </>
-        }
+        title={<FormattedMessage id="user.reported.bugs" />}
+        icon={<DatabaseOutlined />}
       />
       <Table
         size="large"

--- a/services/frontend/src/components/header/HeaderView.jsx
+++ b/services/frontend/src/components/header/HeaderView.jsx
@@ -12,7 +12,11 @@ const HeaderView = ({ title, icon, subtitle, extra, backBtn }) => {
       className="pageHeader"
       title={
         <>
-          {icon && <div className="headerIcon">{icon}</div>}
+          {icon && (
+            <div className="headerIcon" aria-hidden="true">
+              {icon}
+            </div>
+          )}
           <h1 id="headerTitle">{title}</h1>
         </>
       }


### PR DESCRIPTION
#### ⭐ Changes introduced
Hid icons in page heading to avoid verbose screen reader descriptions

#### 🔗 Related issue(s)
fixes #1499 

#### 📸 Screenshots (if applicable)
no UI changes
