### PR TITLE
[Fix] changes to profile usernames were not detected in the form

### DIFF
--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -548,13 +548,10 @@ const PrimaryInfoFormView = ({
                 label={<FormattedMessage id="gcconnex.username" />}
                 rules={[Rules.maxChar100]}
               >
-                {/* accessibility related description for input */}
-                <span id="gcconnex-field-info" style={{ display: "none" }}>
-                  <FormattedMessage id="gcconnex.username" />
-                  https://gcconnex.gc.ca/profile/
-                </span>
                 <Input
-                  aria-describedby="gcconnex-field-info"
+                  aria-label={`${intl.formatMessage({
+                    id: "gcconnex.username",
+                  })} https://gcconnex.gc.ca/profile/`}
                   addonBefore="https://gcconnex.gc.ca/profile/"
                   placeholder={intl.formatMessage({ id: "username" })}
                 />
@@ -566,12 +563,10 @@ const PrimaryInfoFormView = ({
                 label={<FormattedMessage id="linkedin.username" />}
                 rules={[Rules.maxChar100]}
               >
-                {/* accessibility related description for input */}
-                <span id="linkedin-field-info" style={{ display: "none" }}>
-                  <FormattedMessage id="linkedin.username" />
-                  https://linkedin.com/in/
-                </span>
                 <Input
+                  aria-label={`${intl.formatMessage({
+                    id: "linkedin.username",
+                  })} https://linkedin.com/in/`}
                   addonBefore="https://linkedin.com/in/"
                   aria-describedby="linkedin-field-info"
                   placeholder={intl.formatMessage({ id: "username" })}
@@ -584,12 +579,10 @@ const PrimaryInfoFormView = ({
                 label={<FormattedMessage id="github.username" />}
                 rules={[Rules.maxChar100]}
               >
-                {/* accessibility related description for input */}
-                <span id="github-field-info" style={{ display: "none" }}>
-                  <FormattedMessage id="github.username" />
-                  https://github.com/
-                </span>
                 <Input
+                  aria-label={`${intl.formatMessage({
+                    id: "github.username",
+                  })} https://github.com/`}
                   addonBefore="https://github.com/"
                   aria-describedby="github-field-info"
                   placeholder={intl.formatMessage({ id: "username" })}


### PR DESCRIPTION
#### ⭐ Changes introduced
- when usernames to linkedin, github, or GCconnex were modified the change would not be detected and the save button would not become enabled.
- this fix keeps the accessibility but resolves the bug

#### 🔗 Related issue(s)
closes #1518 

#### 📸 Screenshots (if applicable)
no UI changes

#### ☑️ Checklist

If the database has been modified:

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
