### PR TITLE
[Fix] a11y for visibility toggle dropdowns

### DIFF
--- a/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggle.jsx
+++ b/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggle.jsx
@@ -1,11 +1,12 @@
 import PropTypes from "prop-types";
 import CardVisibilityToggleView from "./CardVisibilityToggleView";
 
-const CardVisibilityToggle = ({ visibleCards, cardName, type }) => (
+const CardVisibilityToggle = ({ visibleCards, cardName, type, ariaLabel }) => (
   <CardVisibilityToggleView
     cardName={cardName}
     type={type}
     visibleCards={visibleCards}
+    ariaLabel={ariaLabel}
   />
 );
 
@@ -15,10 +16,12 @@ CardVisibilityToggle.propTypes = {
   ).isRequired,
   cardName: PropTypes.string.isRequired,
   type: PropTypes.oneOf(["form", "card"]),
+  ariaLabel: PropTypes.string,
 };
 
 CardVisibilityToggle.defaultProps = {
   type: "card",
+  ariaLabel: "",
 };
 
 export default CardVisibilityToggle;

--- a/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggleView.jsx
+++ b/services/frontend/src/components/cardVisibilityToggle/CardVisibilityToggleView.jsx
@@ -15,7 +15,12 @@ import useAxios from "../../utils/useAxios";
 import handleError from "../../functions/handleError";
 import CustomDropdown from "../formItems/CustomDropdown";
 
-const CardVisibilityToggleView = ({ cardName, type, visibleCards }) => {
+const CardVisibilityToggleView = ({
+  cardName,
+  type,
+  visibleCards,
+  ariaLabel,
+}) => {
   const axios = useAxios();
   const intl = useIntl();
   const history = useHistory();
@@ -106,30 +111,18 @@ const CardVisibilityToggleView = ({ cardName, type, visibleCards }) => {
   const generateOptions = () => [
     {
       value: "PUBLIC",
-      label: (
-        <>
-          <EyeOutlined className="mr-1" aria-hidden="true" />
-          <FormattedMessage id="visibility.card.public" />
-        </>
-      ),
+      label: intl.formatMessage({ id: "visibility.card.public" }),
+      icon: <EyeOutlined className="mr-1" aria-hidden="true" />,
     },
     {
       value: "CONNECTIONS",
-      label: (
-        <>
-          <TeamOutlined className="mr-1" aria-hidden="true" />
-          <FormattedMessage id="connections" />
-        </>
-      ),
+      label: intl.formatMessage({ id: "connections" }),
+      icon: <TeamOutlined className="mr-1" aria-hidden="true" />,
     },
     {
       value: "PRIVATE",
-      label: (
-        <>
-          <EyeInvisibleOutlined className="mr-1" aria-hidden="true" />
-          <FormattedMessage id="visibility.card.private" />
-        </>
-      ),
+      label: intl.formatMessage({ id: "visibility.card.private" }),
+      icon: <EyeInvisibleOutlined className="mr-1" aria-hidden="true" />,
     },
   ];
 
@@ -141,7 +134,10 @@ const CardVisibilityToggleView = ({ cardName, type, visibleCards }) => {
         isClearable={false}
         options={generateOptions()}
         onChange={handleSelect}
-        ariaLabel={intl.formatMessage({ id: "visibility.selector" })}
+        ariaLabel={`${ariaLabel} ${intl.formatMessage({
+          id: "visibility.selector",
+        })}`}
+        isSearchable={false}
       />
       <AlertDialog
         title={<FormattedMessage id="visibility.card.title" />}
@@ -162,6 +158,7 @@ CardVisibilityToggleView.propTypes = {
   ).isRequired,
   cardName: PropTypes.string.isRequired,
   type: PropTypes.oneOf(["form", "card"]).isRequired,
+  ariaLabel: PropTypes.string.isRequired,
 };
 
 export default CardVisibilityToggleView;

--- a/services/frontend/src/components/careerInterests/CareerInterests.jsx
+++ b/services/frontend/src/components/careerInterests/CareerInterests.jsx
@@ -1,25 +1,30 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import CareerInterestsView from "./CareerInterestsView";
 import ProfileCards from "../profileCards/ProfileCards";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
-const CareerInterests = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="career.interests"
-    cardName="careerInterests"
-    id="card-profile-career-interests"
-    editUrl="/profile/edit/career-management?tab=career-interests"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.careerInterests}
-  >
-    <CareerInterestsView
-      lookingJob={data.lookingJob}
-      interestedInRemote={data.interestedInRemote}
-      relocationLocations={data.relocationLocations}
-    />
-  </ProfileCards>
-);
+const CareerInterests = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "career.interests" })}
+      cardName="careerInterests"
+      id="card-profile-career-interests"
+      editUrl="/profile/edit/career-management?tab=career-interests"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.careerInterests}
+    >
+      <CareerInterestsView
+        lookingJob={data.lookingJob}
+        interestedInRemote={data.interestedInRemote}
+        relocationLocations={data.relocationLocations}
+      />
+    </ProfileCards>
+  );
+};
 
 CareerInterests.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/competenciesCard/Competencies.jsx
+++ b/services/frontend/src/components/competenciesCard/Competencies.jsx
@@ -1,22 +1,27 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import ProfileCards from "../profileCards/ProfileCards";
 import CompetenciesView from "./CompetenciesView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
-const Competencies = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="competencies"
-    cardName="competencies"
-    id="card-profile-competency"
-    editUrl="/profile/edit/talent?tab=competencies"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.competencies}
-    lastUpdated={data.competenciesUpdatedAt}
-  >
-    <CompetenciesView competencies={data.competencies} />
-  </ProfileCards>
-);
+const Competencies = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "competencies" })}
+      cardName="competencies"
+      id="card-profile-competency"
+      editUrl="/profile/edit/talent?tab=competencies"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.competencies}
+      lastUpdated={data.competenciesUpdatedAt}
+    >
+      <CompetenciesView competencies={data.competencies} />
+    </ProfileCards>
+  );
+};
 
 Competencies.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/connections/Connections.jsx
+++ b/services/frontend/src/components/connections/Connections.jsx
@@ -1,20 +1,25 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import ConnectionsView from "./ConnectionsView";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const connections = ({ data }) => (
-  <ProfileCards
-    titleId="connections"
-    cardName="privateGroup"
-    id="card-profile-connections"
-    data={data}
-    editableCardBool={false}
-    displayExtraHeaderContent={false}
-    visibility="PUBLIC"
-  >
-    <ConnectionsView connections={data.connections} />
-  </ProfileCards>
-);
+const connections = ({ data }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "connections" })}
+      cardName="privateGroup"
+      id="card-profile-connections"
+      data={data}
+      editableCardBool={false}
+      displayExtraHeaderContent={false}
+      visibility="PUBLIC"
+    >
+      <ConnectionsView connections={data.connections} />
+    </ProfileCards>
+  );
+};
 
 connections.propTypes = {
   data: PropTypes.shape({

--- a/services/frontend/src/components/descriptionCard/DescriptionCard.jsx
+++ b/services/frontend/src/components/descriptionCard/DescriptionCard.jsx
@@ -1,21 +1,26 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import ProfileCards from "../profileCards/ProfileCards";
 import DescriptionCardView from "./DescriptionCardView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
-const DescriptionCard = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="about.me"
-    cardName="description"
-    id="card-profile-description"
-    editUrl="/profile/edit/employment"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.description}
-  >
-    <DescriptionCardView data={data.description} />
-  </ProfileCards>
-);
+const DescriptionCard = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "about.me" })}
+      cardName="description"
+      id="card-profile-description"
+      editUrl="/profile/edit/employment"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.description}
+    >
+      <DescriptionCardView data={data.description} />
+    </ProfileCards>
+  );
+};
 
 DescriptionCard.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/education/Education.jsx
+++ b/services/frontend/src/components/education/Education.jsx
@@ -7,6 +7,7 @@ import ProfileCards from "../profileCards/ProfileCards";
 
 const Education = ({ data, editableCardBool }) => {
   const intl = useIntl();
+
   const getEducationDuration = (startDate, endDate, ongoingDate) => {
     const formattedStartDate = dayjs(startDate).format("MMMM YYYY");
     const formattedEndDate = dayjs(endDate).format("MMMM YYYY");
@@ -67,7 +68,7 @@ const Education = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="education"
+      titleString={intl.formatMessage({ id: "education" })}
       cardName="education"
       id="card-profile-education"
       editUrl="/profile/edit/qualifications?tab=education"

--- a/services/frontend/src/components/employeeSummary/EmployeeSummary.jsx
+++ b/services/frontend/src/components/employeeSummary/EmployeeSummary.jsx
@@ -1,21 +1,26 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import EmployeeSummaryView from "./EmployeeSummaryView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const EmployeeSummary = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="employment.status"
-    cardName="info"
-    id="card-profile-employee-summary"
-    editUrl="/profile/edit/employment"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.info}
-  >
-    <EmployeeSummaryView data={data} />
-  </ProfileCards>
-);
+const EmployeeSummary = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "employment.status" })}
+      cardName="info"
+      id="card-profile-employee-summary"
+      editUrl="/profile/edit/employment"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.info}
+    >
+      <EmployeeSummaryView data={data} />
+    </ProfileCards>
+  );
+};
 
 EmployeeSummary.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/employmentEquity/EmploymentEquity.jsx
+++ b/services/frontend/src/components/employmentEquity/EmploymentEquity.jsx
@@ -36,7 +36,7 @@ const EmploymentEquity = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="employment.equity.groups"
+      titleString={intl.formatMessage({ id: "employment.equity.groups" })}
       cardName="employmentEquityGroup"
       id="card-profile-employment-equity"
       editUrl="/profile/edit/primary-info"

--- a/services/frontend/src/components/exFeeder/ExFeeder.jsx
+++ b/services/frontend/src/components/exFeeder/ExFeeder.jsx
@@ -1,19 +1,26 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import ExFeederView from "./ExFeederView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const ExFeeder = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId={<ExFeederView data={data} />}
-    cardName="exFeeder"
-    editUrl="/profile/edit/career-management?tab=ex-feeder"
-    id="card-profile-ex-feeder"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.exFeeder}
-  />
-);
+const ExFeeder = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "ex.feeder" })}
+      cardName="exFeeder"
+      editUrl="/profile/edit/career-management?tab=ex-feeder"
+      id="card-profile-ex-feeder"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.exFeeder}
+    >
+      <ExFeederView data={data} />
+    </ProfileCards>
+  );
+};
 
 ExFeeder.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/exFeeder/ExFeederView.jsx
+++ b/services/frontend/src/components/exFeeder/ExFeederView.jsx
@@ -1,23 +1,44 @@
 import { FormattedMessage } from "react-intl";
-import { CheckOutlined } from "@ant-design/icons";
+import {
+  CheckCircleOutlined,
+  WarningOutlined,
+  EyeInvisibleOutlined,
+} from "@ant-design/icons";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import "./ExFeederView.less";
 
 const ExFeederView = ({ data }) => {
   if (data.exFeeder) {
     return (
-      <>
-        <CheckOutlined />
-        <span className="exFeederTitleSpan">
-          <FormattedMessage id="profile.ex.feeder" />
-        </span>
-      </>
+      <div className="ex-feeder-success">
+        <CheckCircleOutlined
+          className="mr-2 ex-feeder-success-icon"
+          aria-hidden="true"
+        />
+        <FormattedMessage id="profile.ex.feeder" />
+      </div>
     );
   }
   if (data.exFeeder === false) {
-    return <FormattedMessage id="not.ex.feeder" />;
+    return (
+      <div className="ex-feeder-negative">
+        <WarningOutlined
+          className="mr-2 ex-feeder-negative-icon"
+          aria-hidden="true"
+        />
+        <FormattedMessage id="not.ex.feeder" />
+      </div>
+    );
   }
-  return <FormattedMessage id="private.ex.feeder" />;
+  return (
+    <div className="ex-feeder-negative">
+      <EyeInvisibleOutlined
+        className="mr-2 ex-feeder-negative-icon"
+        aria-hidden="true"
+      />
+      <FormattedMessage id="private.ex.feeder" />
+    </div>
+  );
 };
 
 ExFeederView.propTypes = {

--- a/services/frontend/src/components/exFeeder/ExFeederView.less
+++ b/services/frontend/src/components/exFeeder/ExFeederView.less
@@ -1,3 +1,17 @@
-.exFeederTitleSpan {
-  padding-left: 8px;
+.ex-feeder-success {
+  margin: 13px 0;
+
+  &-icon {
+    color: @primary-color;
+    font-size: 1.1rem;
+  }
+}
+
+.ex-feeder-negative {
+  margin: 13px 0;
+
+  &-icon {
+    color: @disabled-color;
+    font-size: 1.1rem;
+  }
 }

--- a/services/frontend/src/components/experience/Experience.jsx
+++ b/services/frontend/src/components/experience/Experience.jsx
@@ -7,6 +7,7 @@ import ProfileCards from "../profileCards/ProfileCards";
 
 const Experience = ({ data, editableCardBool }) => {
   const intl = useIntl();
+
   const getExperienceDuration = (startDate, endDate, ongoingDate) => {
     const formatedStartDate = dayjs(startDate).format("MMMM YYYY");
     const formatedEndDate = dayjs(endDate).format("MMMM YYYY");
@@ -73,7 +74,7 @@ const Experience = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="experience"
+      titleString={intl.formatMessage({ id: "experience" })}
       cardName="experience"
       id="card-profile-experience"
       editUrl="/profile/edit/qualifications?tab=experience"

--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -273,8 +273,23 @@ const CustomDropdown = ({
   };
 
   /**
+   * Disable the selectable dropdown options when selected limit is reached
+   *
+   * @param {object} option - object describing the dropdown options
+   * @param {string} option.label - label to be displayed to user
+   * @param {string} option.icon - optional icon to be displayed
+   *
+   */
+  const formatOptionLabel = ({ label, icon }) => (
+    <>
+      {icon} {label}
+    </>
+  );
+
+  /**
    * Custom styling for "react-select" based on the API provided in the documentation
    * @const {Object}
+   *
    */
   const customStyles = {
     control: (provided, state) => ({
@@ -334,6 +349,7 @@ const CustomDropdown = ({
   /**
    * Custom theming for "react-select" based on the API provided in the documentation
    * @const {Object}
+   *
    */
   const customTheme = (theme) => ({
     ...theme,
@@ -413,6 +429,8 @@ const CustomDropdown = ({
           styles={customStyles}
           theme={customTheme}
           className={className}
+          formatOptionLabel={formatOptionLabel}
+          menuPortalTarget={document.body}
         />
       )}
     </>

--- a/services/frontend/src/components/learningDevelopment/LearningDevelopment.jsx
+++ b/services/frontend/src/components/learningDevelopment/LearningDevelopment.jsx
@@ -1,25 +1,30 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 import LearningDevelopmentView from "./LearningDevelopmentView";
 
-const LearningDevelopment = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="learning.development"
-    cardName="developmentalGoals"
-    id="card-profile-learning-development"
-    editUrl="/profile/edit/career-management?tab=learning-development"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.developmentalGoals}
-    lastUpdated={data.developmentalGoalsUpdatedAt}
-  >
-    <LearningDevelopmentView
-      devGoals={data.developmentalGoals}
-      devAttachments={data.developmentalGoalsAttachments}
-    />
-  </ProfileCards>
-);
+const LearningDevelopment = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "learning.development" })}
+      cardName="developmentalGoals"
+      id="card-profile-learning-development"
+      editUrl="/profile/edit/career-management?tab=learning-development"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.developmentalGoals}
+      lastUpdated={data.developmentalGoalsUpdatedAt}
+    >
+      <LearningDevelopmentView
+        devGoals={data.developmentalGoals}
+        devAttachments={data.developmentalGoalsAttachments}
+      />
+    </ProfileCards>
+  );
+};
 
 LearningDevelopment.propTypes = {
   data: ProfileInfoPropType,

--- a/services/frontend/src/components/mentorshipCard/Mentorship.jsx
+++ b/services/frontend/src/components/mentorshipCard/Mentorship.jsx
@@ -1,9 +1,12 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import MentorshipView from "./MentorshipView";
 import ProfileCards from "../profileCards/ProfileCards";
 
 const Mentorship = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
   const formatData = (list) => {
     const categorizedList = {};
 
@@ -21,6 +24,7 @@ const Mentorship = ({ data, editableCardBool }) => {
 
     return categorizedList;
   };
+
   const setUpCategories = (list) => {
     const categorizedList = {};
     const categoriesTemp = {};
@@ -62,9 +66,10 @@ const Mentorship = ({ data, editableCardBool }) => {
 
     return mentorshipSkills;
   };
+
   return (
     <ProfileCards
-      titleId="mentorship.skills"
+      titleString={intl.formatMessage({ id: "mentorship.skills" })}
       cardName="mentorshipSkills"
       id="card-profile-mentorship-skills"
       editUrl="/profile/edit/talent?tab=mentorship"

--- a/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
@@ -59,7 +59,7 @@ const OfficialLanguage = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="official.languages"
+      titleString={intl.formatMessage({ id: "official.languages" })}
       cardName="officialLanguage"
       id="card-profile-official-language"
       editUrl="/profile/edit/language-proficiency"

--- a/services/frontend/src/components/profileCards/ProfileCards.jsx
+++ b/services/frontend/src/components/profileCards/ProfileCards.jsx
@@ -4,7 +4,7 @@ import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
 const ProfileCards = ({
   data,
-  titleId,
+  titleString,
   children,
   editUrl,
   cardName,
@@ -15,7 +15,7 @@ const ProfileCards = ({
   lastUpdated,
 }) => (
   <ProfileCardsView
-    titleId={titleId}
+    titleString={titleString}
     editUrl={editUrl}
     cardName={cardName}
     id={id}
@@ -31,7 +31,7 @@ const ProfileCards = ({
 
 ProfileCards.propTypes = {
   data: ProfileInfoPropType,
-  titleId: PropTypes.node.isRequired,
+  titleString: PropTypes.string.isRequired,
   children: PropTypes.element,
   editUrl: PropTypes.string,
   cardName: PropTypes.string.isRequired,

--- a/services/frontend/src/components/profileCards/ProfileCardsView.jsx
+++ b/services/frontend/src/components/profileCards/ProfileCardsView.jsx
@@ -12,7 +12,7 @@ const { Text } = Typography;
 
 const ProfileCardsView = ({
   editUrl,
-  titleId,
+  titleString,
   id,
   children,
   style,
@@ -26,19 +26,24 @@ const ProfileCardsView = ({
   /**
    * Generate Edit Menu with visibility toggle and edit button for profile in edit mode
    * @param {Object} visibilityOfAllCards - visibility status of all cards.
-   * @param {String} cardInfoName - name of the card.
-   * @param {String} editFormUrl - url to edit form.
+   * @param {string} cardInfoName - name of the card.
+   * @param {string} editFormUrl - url to edit form.
+   * @param {string} cardTitleString - url to edit form.
+   * @return {HTMLElement} generated element to display
+   *
    */
   const generateEditMenu = ({
     visibilityOfAllCards,
     cardInfoName,
     editFormUrl,
+    cardTitleString,
   }) => (
     <Row>
       <Col className="hide-for-print">
         <CardVisibilityToggle
           visibleCards={visibilityOfAllCards}
           cardName={cardInfoName}
+          ariaLabel={cardTitleString}
         />
       </Col>
       <Col style={{ marginLeft: 20 }} className="hide-for-print">
@@ -49,7 +54,9 @@ const ProfileCardsView = ({
 
   /**
    * Generate Visibility Status indicator for public profile (view only mode)
-   * @param {Bool} visibleCards - visibility status of this card.
+   * @param {boolean} visibleCards - visibility status of this card.
+   * @return {HTMLElement} generated element to display
+   *
    */
   const generateVisibilityStatusForPublic = (cardVisibilityStatus) => {
     let visibilityStatusSymbol;
@@ -83,6 +90,7 @@ const ProfileCardsView = ({
   /**
    * Generate Visibility Status indicator for profile being viewed by admin
    * @param {('PRIVATE'|'CONNECTIONS'|'PUBLIC')} cardVisibilityStatus - visibility status of card.
+   * @return {HTMLElement} generated element to display
    */
   const generateVisibilityStatusForAdmin = (cardVisibilityStatus) => (
     <CardVisibilityStatus visibilityStatus={cardVisibilityStatus} />
@@ -90,6 +98,7 @@ const ProfileCardsView = ({
 
   /**
    * Generate right menu in card header
+   * @return {HTMLElement} generated element to display
    */
   const generateExtraMenu = () => {
     let extraMenu;
@@ -100,6 +109,7 @@ const ProfileCardsView = ({
           visibilityOfAllCards: visibleCards,
           cardInfoName: cardName,
           editFormUrl: editUrl,
+          cardTitleString: titleString,
         });
       } else if (typeof visibility === "boolean") {
         extraMenu = generateVisibilityStatusForPublic(visibility);
@@ -119,11 +129,7 @@ const ProfileCardsView = ({
       <Card
         title={
           <>
-            {typeof titleId === "string" ? (
-              <FormattedMessage id={titleId} />
-            ) : (
-              titleId
-            )}
+            {titleString}
             {lastUpdated && (
               <Tooltip title={<FormattedMessage id="last.modified.date" />}>
                 <Text
@@ -152,7 +158,7 @@ const ProfileCardsView = ({
 
 ProfileCardsView.propTypes = {
   editUrl: PropTypes.string,
-  titleId: PropTypes.node.isRequired,
+  titleString: PropTypes.node.isRequired,
   id: PropTypes.string.isRequired,
   children: PropTypes.element,
   style: PropTypes.objectOf(PropTypes.string),

--- a/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
+++ b/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
@@ -462,6 +462,9 @@ const CareerManagementFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="developmentalGoals"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "developmental.goals",
+                    })}
                   />
                 }
               />
@@ -539,6 +542,9 @@ const CareerManagementFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="qualifiedPools"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "qualified.pools",
+                    })}
                   />
                 }
               />
@@ -616,6 +622,9 @@ const CareerManagementFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="careerInterests"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "career.interests",
+                    })}
                   />
                 }
               />
@@ -725,6 +734,9 @@ const CareerManagementFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="talentManagement"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "talent.management",
+                    })}
                   />
                 }
               />
@@ -787,6 +799,9 @@ const CareerManagementFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="exFeeder"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "ex.feeder",
+                    })}
                   />
                 }
               />

--- a/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -378,6 +378,9 @@ const EmploymentDataFormView = ({
                   visibleCards={profileInfo.visibleCards}
                   cardName="info"
                   type="form"
+                  ariaLabel={intl.formatMessage({
+                    id: "employment.status",
+                  })}
                 />
               </div>
             }
@@ -491,6 +494,9 @@ const EmploymentDataFormView = ({
                 visibleCards={profileInfo.visibleCards}
                 cardName="description"
                 type="form"
+                ariaLabel={intl.formatMessage({
+                  id: "about.me",
+                })}
               />
             }
           />

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -391,6 +391,9 @@ const LangProficiencyFormView = ({
                   visibleCards={profileInfo.visibleCards}
                   cardName="officialLanguage"
                   type="form"
+                  ariaLabel={intl.formatMessage({
+                    id: "official.languages",
+                  })}
                 />
               </div>
             }

--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -601,6 +601,9 @@ const PrimaryInfoFormView = ({
                 visibleCards={profileInfo.visibleCards}
                 cardName="employmentEquityGroup"
                 type="form"
+                ariaLabel={intl.formatMessage({
+                  id: "employment.equity.groups",
+                })}
               />
             }
           />

--- a/services/frontend/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
+++ b/services/frontend/src/components/profileForms/qualificationsForm/QualificationsFormView.jsx
@@ -380,6 +380,9 @@ const QualificationsFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="education"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "education",
+                    })}
                   />
                 }
               />
@@ -437,6 +440,9 @@ const QualificationsFormView = ({
                     visibleCards={profileInfo.visibleCards}
                     cardName="experience"
                     type="form"
+                    ariaLabel={intl.formatMessage({
+                      id: "experience",
+                    })}
                   />
                 }
               />

--- a/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -634,6 +634,9 @@ const TalentFormView = ({
                         visibleCards={profileInfo.visibleCards}
                         cardName="skills"
                         type="form"
+                        ariaLabel={intl.formatMessage({
+                          id: "skills",
+                        })}
                       />
                     }
                   />
@@ -691,6 +694,9 @@ const TalentFormView = ({
                         visibleCards={profileInfo.visibleCards}
                         cardName="mentorshipSkills"
                         type="form"
+                        ariaLabel={intl.formatMessage({
+                          id: "mentorship.skills",
+                        })}
                       />
                     }
                   />
@@ -745,6 +751,9 @@ const TalentFormView = ({
                         visibleCards={profileInfo.visibleCards}
                         cardName="competencies"
                         type="form"
+                        ariaLabel={intl.formatMessage({
+                          id: "competencies",
+                        })}
                       />
                     }
                   />

--- a/services/frontend/src/components/qualifiedPools/QualifiedPools.jsx
+++ b/services/frontend/src/components/qualifiedPools/QualifiedPools.jsx
@@ -1,9 +1,12 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import QualifiedPoolsView from "./QualifiedPoolsView";
 import ProfileCards from "../profileCards/ProfileCards";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 
 const QualifiedPools = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
   const getQualifiedPoolsInfo = (dataSource) => {
     if (!dataSource.qualifiedPools) {
       return [];
@@ -25,7 +28,7 @@ const QualifiedPools = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="qualified.pools"
+      titleString={intl.formatMessage({ id: "qualified.pools" })}
       cardName="qualifiedPools"
       id="card-profile-qualified-pools"
       editUrl="/profile/edit/career-management?tab=qualified-pools"

--- a/services/frontend/src/components/skillsCard/Skills.jsx
+++ b/services/frontend/src/components/skillsCard/Skills.jsx
@@ -1,9 +1,12 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import SkillsView from "./SkillsView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
 const Skills = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
   const formatData = (list) => {
     const categorizedList = {};
 
@@ -65,7 +68,7 @@ const Skills = ({ data, editableCardBool }) => {
 
   return (
     <ProfileCards
-      titleId="skills"
+      titleString={intl.formatMessage({ id: "skills" })}
       cardName="skills"
       id="card-profile-skills"
       editUrl="/profile/edit/talent?tab=skills"

--- a/services/frontend/src/components/talentManagement/TalentManagement.jsx
+++ b/services/frontend/src/components/talentManagement/TalentManagement.jsx
@@ -1,21 +1,26 @@
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 import TalentManagementView from "./TalentManagementView";
 import { ProfileInfoPropType } from "../../utils/customPropTypes";
 import ProfileCards from "../profileCards/ProfileCards";
 
-const TalentManagement = ({ data, editableCardBool }) => (
-  <ProfileCards
-    titleId="talent.management"
-    cardName="talentManagement"
-    id="card-profile-talent-management"
-    editUrl="/profile/edit/career-management?tab=talent-management"
-    data={data}
-    editableCardBool={editableCardBool}
-    visibility={data.visibleCards.talentManagement}
-  >
-    <TalentManagementView data={data} />
-  </ProfileCards>
-);
+const TalentManagement = ({ data, editableCardBool }) => {
+  const intl = useIntl();
+
+  return (
+    <ProfileCards
+      titleString={intl.formatMessage({ id: "talent.management" })}
+      cardName="talentManagement"
+      id="card-profile-talent-management"
+      editUrl="/profile/edit/career-management?tab=talent-management"
+      data={data}
+      editableCardBool={editableCardBool}
+      visibility={data.visibleCards.talentManagement}
+    >
+      <TalentManagementView data={data} />
+    </ProfileCards>
+  );
+};
 
 TalentManagement.propTypes = {
   data: ProfileInfoPropType,


### PR DESCRIPTION
#### ⭐ Changes introduced
- Screen reader was reading "Object Object" but with this fix will read the associated section title
- This affects all profile cards on the user's "view profile page"
- Restructured the EX-feeder cards to incorporate the accessible visibility toggle

#### 🔗 Related issue(s)
no related issues

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/126833582-747be2dc-f6e0-411d-b8bd-0772cc6bf57e.png)
![image](https://user-images.githubusercontent.com/11470442/126833616-c69617de-f957-4622-bc0e-826b90da5c68.png)
![image](https://user-images.githubusercontent.com/11470442/126833668-e1fda25b-e36f-4dcf-9b30-b3b1644cc201.png)

#### ☑️ Checklist

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
