### PR TITLE
[Fix] Improve a11y for official languages form

### DIFF
--- a/services/backend/src/core/profile/profile.js
+++ b/services/backend/src/core/profile/profile.js
@@ -14,7 +14,6 @@ async function updateProfile(request, response) {
 
   if (isKeycloakUser(request, id)) {
     await updateProfileInfo(request, id, language);
-
     response.sendStatus(204);
   } else {
     response.sendStatus(403);

--- a/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
+++ b/services/frontend/src/components/profileForms/employmentDataForm/EmploymentDataFormView.jsx
@@ -153,8 +153,9 @@ const EmploymentDataFormView = ({
 
   /**
    * Returns true if the values in the form have changed based on its initial values or the saved values
-   *
    * pickBy({}, identity) is used to omit falsely values from the object - https://stackoverflow.com/a/33432857
+   * @return {boolean} return true if any of the form inputs have changed
+   *
    */
   const checkIfFormValuesChanged = () => {
     const formValues = pickBy(form.getFieldsValue(), identity);
@@ -167,6 +168,10 @@ const EmploymentDataFormView = ({
     return !isEqual(formValues, dbValues);
   };
 
+  /**
+   * update state if form values have changed from the initial state
+   *
+   */
   const updateIfFormValuesChanged = () => {
     setFieldsChanged(checkIfFormValuesChanged());
   };

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyForm.jsx
@@ -91,53 +91,46 @@ const LangProficiencyForm = ({ formType }) => {
   useEffect(() => {
     // Set proficiency options
     setProficiencyOptions([
-      { key: "A", value: "A", text: "A" },
-      { key: "B", value: "B", text: "B" },
-      { key: "C", value: "C", text: "C" },
-      { key: "E", value: "E", text: "E" },
-      { key: "X", value: "X", text: "X" },
+      { value: "A", label: "A" },
+      { value: "B", label: "B" },
+      { value: "C", label: "C" },
+      { value: "E", label: "E" },
+      { value: "X", label: "X" },
       {
-        key: "NA",
         value: "NA",
-        text: intl.formatMessage({ id: "grade.not.applicable" }),
+        label: intl.formatMessage({ id: "grade.not.applicable" }),
       },
     ]);
 
     // Set substantive level options
     setLanguageOptions([
       {
-        key: "ENGLISH",
         value: "ENGLISH",
-        text: "English",
+        label: "English",
       },
       {
-        key: "FRENCH",
         value: "FRENCH",
-        text: "Français",
+        label: "Français",
       },
     ]);
 
     // Set status options:
     setStatusOptions([
       {
-        key: "EXPIRED",
         value: "EXPIRED",
-        text: intl.formatMessage({ id: "expired" }),
+        label: intl.formatMessage({ id: "expired" }),
       },
       {
-        key: "VALID",
         value: "VALID",
-        text: intl.formatMessage({ id: "valid" }),
+        label: intl.formatMessage({ id: "valid" }),
       },
       {
-        key: "UNKNOWN",
         value: "UNKNOWN",
-        text: intl.formatMessage({ id: "unknown" }),
+        label: intl.formatMessage({ id: "unknown" }),
       },
       {
-        key: "NA",
         value: "NA",
-        text: intl.formatMessage({ id: "grade.not.applicable" }),
+        label: intl.formatMessage({ id: "grade.not.applicable" }),
       },
     ]);
 

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -8,7 +8,6 @@ import {
   Form,
   Switch,
   notification,
-  Space,
 } from "antd";
 import { FormattedMessage, useIntl } from "react-intl";
 import { identity, pickBy } from "lodash";
@@ -21,6 +20,7 @@ import {
   HistoryPropType,
 } from "../../../utils/customPropTypes";
 import CustomDropdown from "../../formItems/CustomDropdown";
+import Fieldset from "../../fieldset/Fieldset";
 import handleError from "../../../functions/handleError";
 import CardVisibilityToggle from "../../cardVisibilityToggle/CardVisibilityToggle";
 import { setSavedFormContent } from "../../../redux/slices/stateSlice";
@@ -270,7 +270,7 @@ const LangProficiencyFormView = ({
   }, [displaySecondLangForm]);
 
   const getSecondLangRows = ({ name, label, statusName }) => (
-    <Row gutter={24} style={{ marginTop: "10px" }}>
+    <Row gutter={24}>
       <Col className="gutter-row" xs={24} md={24} lg={12} xl={12}>
         <Form.Item
           name={name}
@@ -304,7 +304,7 @@ const LangProficiencyFormView = ({
             placeholderText={<FormattedMessage id="select" />}
             initialValueId={
               getInitialValues({ profile: profileInfo })[statusName]
-            } // TODO: need to figure out how ot get value using "name"
+            }
             options={statusOptions}
             isSearchable={false}
             isRequired
@@ -327,12 +327,14 @@ const LangProficiencyFormView = ({
             label: "secondary.reading.proficiency",
             statusName: "secondaryReadingStatus",
           })}
+          <Divider className="my-2" />
           {/* Writing Proficiency */}
           {getSecondLangRows({
             name: "writingProficiency",
             label: "secondary.writing.proficiency",
             statusName: "secondaryWritingStatus",
           })}
+          <Divider className="my-2" />
           {/* Oral Proficiency */}
           {getSecondLangRows({
             name: "oralProficiency",
@@ -430,21 +432,25 @@ const LangProficiencyFormView = ({
             </Col>
           </Row>
           {/* Form Row Four: Temporary role */}
-          <Row className="lang-secondLangRow" gutter={24}>
-            <Col className="gutter-row" span={24}>
-              <Row>
-                <Space>
+          <Row className="lang-secondLangRow">
+            <Fieldset
+              title={
+                <>
                   <Text>
                     <FormattedMessage id="graded.on.second.language" />
                   </Text>
                   <Switch
                     checked={displaySecondLangForm}
                     onChange={toggleSecLangForm}
+                    className="ml-2 mb-1"
                   />
-                </Space>
-              </Row>
-              {getSecondLanguageForm(displaySecondLangForm)}
-            </Col>
+                </>
+              }
+            >
+              <Col span={24}>
+                {getSecondLanguageForm(displaySecondLangForm)}
+              </Col>
+            </Fieldset>
           </Row>
           {/* Form Row Five: Submit button */}
           <FormControlButton

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -280,7 +280,7 @@ const LangProficiencyFormView = ({
 
   const getSecondLangRows = ({ name, label, statusName }) => (
     <Row gutter={24}>
-      <Col className="gutter-row" xs={24} md={24} lg={12} xl={12}>
+      <Col className="gutter-row" xs={24} md={12} lg={12} xl={12}>
         <Form.Item
           name={name}
           label={<FormattedMessage id={label} />}
@@ -299,7 +299,7 @@ const LangProficiencyFormView = ({
           />
         </Form.Item>
       </Col>
-      <Col className="gutter-row" xs={24} md={24} lg={12} xl={12}>
+      <Col className="gutter-row" xs={24} md={12} lg={12} xl={12}>
         <Form.Item
           name={statusName}
           label={<FormattedMessage id="lang.status" />}
@@ -336,14 +336,14 @@ const LangProficiencyFormView = ({
             label: "secondary.reading.proficiency",
             statusName: "secondaryReadingStatus",
           })}
-          <Divider className="my-2" />
+          <Divider className="mt-0 mb-2" />
           {/* Writing Proficiency */}
           {getSecondLangRows({
             name: "writingProficiency",
             label: "secondary.writing.proficiency",
             statusName: "secondaryWritingStatus",
           })}
-          <Divider className="my-2" />
+          <Divider className="mt-0 mb-2" />
           {/* Oral Proficiency */}
           {getSecondLangRows({
             name: "oralProficiency",
@@ -372,7 +372,6 @@ const LangProficiencyFormView = ({
   /** **********************************
    ********* Render Component *********
    *********************************** */
-
   if (!load) {
     return (
       /* If form data is loading then wait */

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -88,7 +88,11 @@ const LangProficiencyFormView = ({
     }
   };
 
-  /* Get the initial values for the form */
+  /**
+   * extract the initial values from the profile
+   * @param {Object} profile - user profile
+   *
+   */
   const getInitialValues = ({ profile }) => {
     // Get default language from API and convert to dropdown key
     if (profile) {
@@ -114,18 +118,21 @@ const LangProficiencyFormView = ({
     return {};
   };
 
-  /* toggle temporary role form */
+  /**
+   * toggle second language form visibility
+   *
+   */
   const toggleSecLangForm = () => {
     setDisplaySecondLangForm((prev) => !prev);
   };
 
   /**
    * Returns true if the values in the form have changed based on its initial values or the saved values
-   *
    * pickBy({}, identity) is used to omit falsey values from the object - https://stackoverflow.com/a/33432857
+   * @return {boolean} return true if any of the form inputs have changed
+   *
    */
   const checkIfFormValuesChanged = () => {
-    console.log("changes saved:", form.getFieldsValue());
     const formValues = pickBy(form.getFieldsValue(), identity);
     const dbValues = pickBy(
       savedValues || getInitialValues({ profile: profileInfo }),
@@ -175,14 +182,18 @@ const LangProficiencyFormView = ({
     return false;
   };
 
+  /**
+   * update state if form values have changed from the initial state
+   *
+   */
   const updateIfFormValuesChanged = () => {
     setFieldsChanged(checkIfFormValuesChanged());
   };
 
   /*
    * Get All Validation Errors
-   *
    * Print out list of validation errors in a list for notification
+   *
    */
   const getAllValidationErrorMessages = () => (
     <div>
@@ -195,10 +206,10 @@ const LangProficiencyFormView = ({
     </div>
   );
 
-  /*
-   * Finish
+  /**
+   * Action to take "on finish".
+   * redirects to last page of profile forms
    *
-   * redirect to profile
    */
   const onFinish = () => {
     history.push(`/profile/edit/finish`);
@@ -214,7 +225,6 @@ const LangProficiencyFormView = ({
     form
       .validateFields()
       .then(async (values) => {
-        console.log("values", values);
         await saveDataToDB(values, displaySecondLangForm);
         setFieldsChanged(false);
         if (num === 1) {
@@ -232,7 +242,6 @@ const LangProficiencyFormView = ({
         }
       })
       .catch((error) => {
-        console.log("error", error);
         if (error.isAxiosError) {
           handleError(error, "message", history);
         } else {
@@ -244,10 +253,10 @@ const LangProficiencyFormView = ({
       });
   };
 
-  /*
-   * On Reset
-   *
+  /**
+   * Action to take "On Reset"
    * reset form fields to state when page was loaded
+   *
    */
   const onReset = () => {
     form.resetFields();

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -10,7 +10,7 @@ import {
   notification,
   Space,
 } from "antd";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { identity, pickBy } from "lodash";
 import PropTypes from "prop-types";
 import { useDispatch } from "react-redux";
@@ -18,7 +18,6 @@ import { Prompt } from "react-router";
 import {
   KeyTitleOptionsPropType,
   ProfileInfoPropType,
-  IntlPropType,
   HistoryPropType,
 } from "../../../utils/customPropTypes";
 import CustomDropdown from "../../formItems/CustomDropdown";
@@ -43,7 +42,6 @@ const LangProficiencyFormView = ({
   load,
   proficiencyOptions,
   profileInfo,
-  intl,
   history,
   saveDataToDB,
 }) => {
@@ -53,6 +51,7 @@ const LangProficiencyFormView = ({
   const [savedValues, setSavedValues] = useState(null);
   const [loadedData, setLoadedData] = useState(false);
   const dispatch = useDispatch();
+  const intl = useIntl();
 
   /* Component Rules for form fields */
   const Rules = {
@@ -471,7 +470,6 @@ LangProficiencyFormView.propTypes = {
   statusOptions: KeyTitleOptionsPropType,
   load: PropTypes.bool.isRequired,
   profileInfo: ProfileInfoPropType,
-  intl: IntlPropType,
   history: HistoryPropType.isRequired,
   saveDataToDB: PropTypes.func.isRequired,
 };
@@ -481,7 +479,6 @@ LangProficiencyFormView.defaultProps = {
   proficiencyOptions: [],
   statusOptions: [],
   profileInfo: null,
-  intl: null,
 };
 
-export default injectIntl(LangProficiencyFormView);
+export default LangProficiencyFormView;

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.jsx
@@ -307,9 +307,11 @@ const LangProficiencyFormView = ({
           aria-required="true"
         >
           <CustomDropdown
-            ariaLabel={intl.formatMessage({
+            ariaLabel={`${intl.formatMessage({
               id: label,
-            })}
+            })}: ${intl.formatMessage({
+              id: "lang.status",
+            })}`}
             placeholderText={<FormattedMessage id="select" />}
             initialValueId={
               getInitialValues({ profile: profileInfo })[statusName]

--- a/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.less
+++ b/services/frontend/src/components/profileForms/langProficiencyForm/LangProficiencyFormView.less
@@ -15,11 +15,9 @@
     margin: 15px 0 15px 0;
   }
   &-secondLangRow {
-    background-color: #dfe5e4;
-    padding-top: 15px;
-    padding-bottom: 15px;
-    margin-bottom: 20px;
-    margin-top: 10px;
+    background-color: @primary-color-2;
+    padding: 10px 20px 10px 20px;
+    margin: 10px 0px 20px 0px;
     border-radius: 5px;
   }
 }

--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -179,8 +179,8 @@ const PrimaryInfoFormView = ({
 
   /**
    * Returns true if the values in the form have changed based on its initial values or the saved values
+   * pickBy({}, identity) is used to omit falsey values from the object - https://stackoverflow.com/a/33432857
    *
-   * pickBy({}, identity) is used to omit false values from the object - https://stackoverflow.com/a/33432857
    */
   const checkIfFormValuesChanged = async () => {
     const formValues = pickBy(form.getFieldsValue(), identity);


### PR DESCRIPTION
#### ⭐ Changes introduced
- implemented react-select for the dropdown on the form
- utilized the fieldset to group the "second language results" on the form
- restyled the "second language results" form to be more compact

#### 🔗 Related issue(s)
address #1553 

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/127096346-38c89020-c439-4760-a019-b9e112cdf9ce.png)


#### ☑️ Checklist
If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
