### PR TITLE
[Fix] Refine styling for react-select dropdowns

### DIFF
--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -281,8 +281,7 @@ const CustomDropdown = ({
       ...provided,
       background: "#fff",
       borderColor: state.isFocused || state.active ? "#087472" : "#d9d9d9",
-      minHeight: isMulti ? "36px" : "32px",
-      padding: isMulti ? "3px 0" : 0,
+      minHeight: "30px",
       boxShadow:
         state.isFocused || state.active
           ? "0px 0px 0px 2px rgb(8 116 114 / 50%)"
@@ -290,7 +289,7 @@ const CustomDropdown = ({
     }),
     valueContainer: (provided) => ({
       ...provided,
-      minHeight: "32px",
+      minHeight: "30px",
       padding: "0 11px",
     }),
     menu: (provided) => ({
@@ -301,9 +300,23 @@ const CustomDropdown = ({
       ...provided,
       margin: "0px",
     }),
+    placeholder: (provided) => ({
+      ...provided,
+      margin: "0px",
+    }),
     indicatorsContainer: (provided) => ({
       ...provided,
-      height: isMulti ? "auto" : "32px",
+      height: "auto",
+    }),
+    dropdownIndicator: (provided) => ({
+      ...provided,
+      paddingTop: 0,
+      paddingBottom: 0,
+    }),
+    clearIndicator: (provided) => ({
+      ...provided,
+      paddingTop: 0,
+      paddingBottom: 0,
     }),
     option: (provided) => ({
       ...provided,
@@ -320,10 +333,17 @@ const CustomDropdown = ({
       color: antdStyles["@primary-color"],
       borderWidth: "1px",
       borderRadius: "1rem",
-      padding: "0 5px",
+      padding: "0 0 0 5px",
       margin: "3px 6px 3px 0",
-      fontSize: "1rem",
-      lineHeight: "1.1rem",
+    }),
+    multiValueLabel: (provided) => ({
+      ...provided,
+      fontSize: "14px",
+      lineHeight: "15px",
+    }),
+    multiValueRemove: (provided) => ({
+      ...provided,
+      borderRadius: "0 1rem  1rem 0",
     }),
     noOptionsMessage: (provided) => ({
       ...provided,


### PR DESCRIPTION
#### ⭐ Changes introduced
- reduce the height of the input for multi select form items. This will make it easier to integrate with other antd form controls
- round the right side of the multiselect's bubble 'x' buttons
- reduce size of the multiselect bubbles

#### 🔗 Related issue(s)
no related issues

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/127220320-cb46c4aa-21ba-4b5f-94ff-6c66b69ca667.png)

#### ☑️ Checklist
If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
