### PR TITLE
[Fix] a11y for basic and advanced search on home page

### DIFF
--- a/services/backend/src/core/options/util/branches.js
+++ b/services/backend/src/core/options/util/branches.js
@@ -17,9 +17,14 @@ async function getBranches(request, response) {
     },
   });
 
-  const branches = _.sortBy(_.uniq(branchesQuery.map((i) => i.branch)));
+  const branchesQueryUniq = _.sortedUniqBy(branchesQuery, "branch");
 
-  response.status(200).json(branches);
+  const responseData = branchesQueryUniq.map((branch) => ({
+    value: branch.id,
+    label: branch.branch,
+  }));
+
+  response.status(200).json(responseData);
 }
 
 module.exports = {

--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -65,7 +65,7 @@ const CustomDropdown = ({
    *
    */
   const mapInitialValue = (dropdownOptions, savedValues) =>
-    isMulti
+    isMulti && savedValues
       ? savedValues.map((value) =>
           dropdownOptions.find((option) => option.value === value)
         )

--- a/services/frontend/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend/src/components/searchBar/SearchBarView.jsx
@@ -106,7 +106,7 @@ const SearchBarView = ({
     return (
       <div>
         <Row style={{ padding: "20px 5% 0px 5%" }}>
-          <Col span={24} style={{ padding: "0px 0" }}>
+          <Col span={24} className="p-0">
             <Title level={2} style={{ fontSize: "1.3em" }}>
               <SettingOutlined
                 style={{ marginRight: "4px", color: "#3CBAB3" }}

--- a/services/frontend/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend/src/components/searchBar/SearchBarView.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import PropTypes from "prop-types";
-import { injectIntl, FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import {
   Typography,
   Row,
@@ -9,7 +9,6 @@ import {
   Form,
   Input,
   Switch,
-  Select,
   Divider,
   Checkbox,
   TreeSelect,
@@ -19,18 +18,15 @@ import {
   SettingOutlined,
   DoubleRightOutlined,
 } from "@ant-design/icons";
+import CustomDropdown from "../formItems/CustomDropdown";
 import logo from "../../assets/I-talent-logo.png";
-import { IntlPropType } from "../../utils/customPropTypes";
-import filterOption from "../../functions/filterSelectInput";
 import "./SearchBarView.less";
 
 const { SHOW_CHILD } = TreeSelect;
-const { Option } = Select;
 const { Title } = Typography;
 
 const SearchBarView = ({
   anyMentorSkills,
-  intl,
   locationOptions,
   skillOptions,
   classOptions,
@@ -40,6 +36,7 @@ const SearchBarView = ({
 }) => {
   const [expandAdvancedSearch, setExpandAdvancedSearch] = useState(false);
   const [form] = Form.useForm();
+  const intl = useIntl();
 
   const searchLabel = intl.formatMessage({
     id: "search",
@@ -141,17 +138,16 @@ const SearchBarView = ({
               label={<FormattedMessage id="classification" />}
               name="classifications"
             >
-              <Select
-                style={{ width: "100%" }}
-                mode="multiple"
-                maxTagCount={3}
-                placeholder={searchLabel}
-                filterOption={filterOption}
-              >
-                {classOptions.map((value) => (
-                  <Option key={value.id}>{value.name}</Option>
-                ))}
-              </Select>
+              <CustomDropdown
+                ariaLabel={intl.formatMessage({
+                  id: "classification",
+                })}
+                placeholderText={<FormattedMessage id="type.to.search" />}
+                options={classOptions}
+                isSearchable
+                isMulti
+                maxSelectedOptions={3}
+              />
             </Form.Item>
           </Col>
 
@@ -162,34 +158,29 @@ const SearchBarView = ({
               label={<FormattedMessage id="location" />}
               name="locations"
             >
-              <Select
-                style={{ width: "100%" }}
-                mode="multiple"
-                placeholder={searchLabel}
-                maxTagCount={3}
-                filterOption={filterOption}
-              >
-                {locationOptions.map((value) => (
-                  <Option key={value.id}>
-                    {value.streetNumber} {value.streetName}, {value.city},{" "}
-                    {value.province}
-                  </Option>
-                ))}
-              </Select>
+              <CustomDropdown
+                ariaLabel={intl.formatMessage({
+                  id: "location",
+                })}
+                placeholderText={<FormattedMessage id="type.to.search" />}
+                options={locationOptions}
+                isSearchable
+                isMulti
+                maxSelectedOptions={3}
+              />
             </Form.Item>
             {/* branch field */}
             <Form.Item label={<FormattedMessage id="branch" />} name="branches">
-              <Select
-                style={{ width: "100%" }}
-                mode="multiple"
-                placeholder={searchLabel}
-                maxTagCount={3}
-                filterOption={filterOption}
-              >
-                {branchOptions.map((value) => (
-                  <Option key={value}>{value}</Option>
-                ))}
-              </Select>
+              <CustomDropdown
+                ariaLabel={intl.formatMessage({
+                  id: "branch",
+                })}
+                placeholderText={<FormattedMessage id="type.to.search" />}
+                options={branchOptions}
+                isSearchable
+                isMulti
+                maxSelectedOptions={3}
+              />
             </Form.Item>
           </Col>
         </Row>
@@ -392,13 +383,8 @@ SearchBarView.propTypes = {
     })
   ).isRequired,
   handleSearch: PropTypes.func.isRequired,
-  intl: IntlPropType,
   anyMentorSkills: PropTypes.bool.isRequired,
   handleAnyMentorSkillsChange: PropTypes.func.isRequired,
 };
 
-SearchBarView.defaultProps = {
-  intl: undefined,
-};
-
-export default injectIntl(SearchBarView);
+export default SearchBarView;

--- a/services/frontend/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend/src/components/searchBar/SearchBarView.jsx
@@ -19,6 +19,7 @@ import {
   DoubleRightOutlined,
 } from "@ant-design/icons";
 import CustomDropdown from "../formItems/CustomDropdown";
+import Fieldset from "../fieldset/Fieldset";
 import logo from "../../assets/I-talent-logo.png";
 import "./SearchBarView.less";
 
@@ -118,166 +119,138 @@ const SearchBarView = ({
         </Row>
 
         {/* General Info */}
-        <Row style={{ padding: "15px 5% 0px 5%" }}>
-          <Col span={24} style={{ padding: "0px 0" }}>
-            <Title level={3} style={{ fontSize: "1em" }}>
-              <FormattedMessage id="general.info" />
-            </Title>
-          </Col>
-        </Row>
-        <Row gutter={[48, 24]} style={{ padding: "0px 5%" }}>
-          {/* form column one */}
-          <Col span={12}>
-            {/* name field */}
-            <Form.Item label={<FormattedMessage id="name" />} name="name">
-              <Input style={{ width: "100%" }} placeholder={searchLabel} />
-            </Form.Item>
+        <Row style={{ padding: "15px 5%" }}>
+          <Fieldset title={<FormattedMessage id="general.info" />}>
+            {/* form column one */}
+            <Col span={24}>
+              {/* name field */}
+              <Form.Item label={<FormattedMessage id="name" />} name="name">
+                <Input style={{ width: "100%" }} placeholder={searchLabel} />
+              </Form.Item>
 
-            {/* classification field */}
-            <Form.Item
-              label={<FormattedMessage id="classification" />}
-              name="classifications"
-            >
-              <CustomDropdown
-                ariaLabel={intl.formatMessage({
-                  id: "classification",
-                })}
-                placeholderText={<FormattedMessage id="type.to.search" />}
-                options={classOptions}
-                isSearchable
-                isMulti
-                maxSelectedOptions={3}
-              />
-            </Form.Item>
-          </Col>
+              {/* Location field */}
+              <Form.Item
+                label={<FormattedMessage id="location" />}
+                name="locations"
+              >
+                <CustomDropdown
+                  ariaLabel={intl.formatMessage({
+                    id: "location",
+                  })}
+                  placeholderText={<FormattedMessage id="type.to.search" />}
+                  options={locationOptions}
+                  isSearchable
+                  isMulti
+                  maxSelectedOptions={3}
+                />
+              </Form.Item>
 
-          {/* form column three */}
-          <Col span={12}>
-            {/* Location field */}
-            <Form.Item
-              label={<FormattedMessage id="location" />}
-              name="locations"
-            >
-              <CustomDropdown
-                ariaLabel={intl.formatMessage({
-                  id: "location",
-                })}
-                placeholderText={<FormattedMessage id="type.to.search" />}
-                options={locationOptions}
-                isSearchable
-                isMulti
-                maxSelectedOptions={3}
-              />
-            </Form.Item>
-            {/* branch field */}
-            <Form.Item label={<FormattedMessage id="branch" />} name="branches">
-              <CustomDropdown
-                ariaLabel={intl.formatMessage({
-                  id: "branch",
-                })}
-                placeholderText={<FormattedMessage id="type.to.search" />}
-                options={branchOptions}
-                isSearchable
-                isMulti
-                maxSelectedOptions={3}
-              />
-            </Form.Item>
-          </Col>
+              {/* branch field */}
+              <Form.Item
+                label={<FormattedMessage id="branch" />}
+                name="branches"
+              >
+                <CustomDropdown
+                  ariaLabel={intl.formatMessage({
+                    id: "branch",
+                  })}
+                  placeholderText={<FormattedMessage id="type.to.search" />}
+                  options={branchOptions}
+                  isSearchable
+                  isMulti
+                  maxSelectedOptions={3}
+                />
+              </Form.Item>
+
+              {/* classification field */}
+              <Form.Item
+                label={<FormattedMessage id="classification" />}
+                name="classifications"
+              >
+                <CustomDropdown
+                  ariaLabel={intl.formatMessage({
+                    id: "classification",
+                  })}
+                  placeholderText={<FormattedMessage id="type.to.search" />}
+                  options={classOptions}
+                  isSearchable
+                  isMulti
+                  maxSelectedOptions={3}
+                />
+              </Form.Item>
+            </Col>
+          </Fieldset>
         </Row>
 
         {/* Skills section */}
-        <Row style={{ padding: "15px 5% 0px 5%" }}>
-          <Col span={24} style={{ padding: "0px 0" }}>
-            <Title level={3} style={{ fontSize: "1em" }}>
-              <FormattedMessage id="skills.and.talent.question" />
-            </Title>
-          </Col>
-        </Row>
-        <Row gutter={[48, 24]} style={{ padding: "0px 5%" }}>
-          {/* form column one */}
-          <Col span={24}>
-            {/* Skills field */}
-            <Form.Item label={<FormattedMessage id="skills" />} name="skills">
-              <TreeSelect
-                className="custom-bubble-select-style"
-                treeData={skillOptions}
-                treeCheckable
-                showCheckedStrategy={SHOW_CHILD}
-                placeholder={<FormattedMessage id="search" />}
-                treeNodeFilterProp="title"
-                showSearch
-                maxTagCount={15}
-              />
-            </Form.Item>
-          </Col>
+        <Row style={{ padding: "5px 5%" }}>
+          <Fieldset
+            title={<FormattedMessage id="skills.and.talent.question" />}
+          >
+            <Col span={24}>
+              <Form.Item label={<FormattedMessage id="skills" />} name="skills">
+                <TreeSelect
+                  className="custom-bubble-select-style"
+                  treeData={skillOptions}
+                  treeCheckable
+                  showCheckedStrategy={SHOW_CHILD}
+                  placeholder={<FormattedMessage id="search" />}
+                  treeNodeFilterProp="title"
+                  showSearch
+                  maxTagCount={15}
+                />
+              </Form.Item>
+            </Col>
+          </Fieldset>
         </Row>
 
         {/* Ex-Feeder section */}
-        <Row style={{ padding: "15px 5% 0px 5%" }}>
-          <Col span={24} style={{ padding: "0px 0" }}>
-            <Title level={3} style={{ fontSize: "1em" }}>
-              <FormattedMessage id="ex.feeder.question" />
-            </Title>
-          </Col>
-        </Row>
-        <Row gutter={[48, 24]} style={{ padding: "0px 5%" }}>
-          {/* form column one */}
-          <Col span={24}>
-            {/* exFeeder field */}
-            <Form.Item
-              label={<FormattedMessage id="ex.feeder" />}
-              name="exFeeder"
-              valuePropName="checked"
-              style={{ marginBottom: "5px" }}
-            >
-              <Switch />
-            </Form.Item>
-          </Col>
+        <Row style={{ padding: "5px 5%" }}>
+          <Fieldset title={<FormattedMessage id="ex.feeder.question" />}>
+            <Col span={24}>
+              <Form.Item
+                label={<FormattedMessage id="ex.feeder" />}
+                name="exFeeder"
+                valuePropName="checked"
+                style={{ marginBottom: "5px" }}
+              >
+                <Switch />
+              </Form.Item>
+            </Col>
+          </Fieldset>
         </Row>
 
         {/* Mentorship section */}
-        <Row style={{ margin: "15px 5% 0px 5%" }}>
-          <Col span={24} style={{ padding: "0px 0" }}>
-            <Title level={3} style={{ fontSize: "1em" }}>
-              <FormattedMessage id="looking.for.mentor" />
-            </Title>
-          </Col>
+        <Row style={{ padding: "5px 5%" }}>
+          <Fieldset title={<FormattedMessage id="looking.for.mentor" />}>
+            <Col span={24}>
+              {/* Mentorship Skills field */}
+              <Form.Item
+                label={<FormattedMessage id="mentorship.skills" />}
+                name="mentorSkills"
+                className="mb-0"
+              >
+                <TreeSelect
+                  className="custom-bubble-select-style"
+                  treeData={skillOptions}
+                  treeCheckable
+                  showCheckedStrategy={SHOW_CHILD}
+                  placeholder={<FormattedMessage id="search" />}
+                  treeNodeFilterProp="title"
+                  showSearch
+                  maxTagCount={15}
+                  disabled={anyMentorSkills}
+                />
+              </Form.Item>
+              <Form.Item name="anyMentorSkills" valuePropName="checked">
+                <Checkbox onChange={handleAnyMentorSkillsChange}>
+                  <FormattedMessage id="select.any.mentors" />
+                </Checkbox>
+              </Form.Item>
+            </Col>
+          </Fieldset>
         </Row>
-        <Row gutter={[48, 24]} style={{ padding: "0px 5% 40px 5%" }}>
-          {/* form column one */}
-          <Col span={24}>
-            {/* Mentorship Skills field */}
-            <Form.Item
-              label={<FormattedMessage id="mentorship.skills" />}
-              name="mentorSkills"
-              style={{ marginBottom: "0px" }}
-            >
-              <TreeSelect
-                className="custom-bubble-select-style"
-                treeData={skillOptions}
-                treeCheckable
-                showCheckedStrategy={SHOW_CHILD}
-                placeholder={<FormattedMessage id="search" />}
-                treeNodeFilterProp="title"
-                showSearch
-                maxTagCount={15}
-                disabled={anyMentorSkills}
-              />
-            </Form.Item>
-            <Form.Item name="anyMentorSkills" valuePropName="checked">
-              <Checkbox onChange={handleAnyMentorSkillsChange}>
-                <FormattedMessage id="select.any.mentors" />
-              </Checkbox>
-            </Form.Item>
-          </Col>
-        </Row>
-        <div
-          style={{
-            width: "100%",
-            textAlign: "center",
-            margin: "-40px 0 30px 0",
-          }}
-        >
+        <div className="search-advancedSearchBtns">
           <Button
             size="large"
             type="primary"
@@ -297,7 +270,7 @@ const SearchBarView = ({
             <FormattedMessage id="clear.changes" />
           </Button>
         </div>
-        <Divider />
+        <Divider className="my-2" />
       </div>
     );
   };
@@ -337,17 +310,13 @@ const SearchBarView = ({
               >
                 {expandAdvancedSearch ? (
                   <>
-                    <DoubleRightOutlined rotate="270" />
-                    <span>
-                      <FormattedMessage id="basic.search" />
-                    </span>
+                    <DoubleRightOutlined rotate="270" className="mr-2" />
+                    <FormattedMessage id="basic.search" />
                   </>
                 ) : (
                   <>
-                    <DoubleRightOutlined rotate="90" />
-                    <span>
-                      <FormattedMessage id="advanced.search" />
-                    </span>
+                    <DoubleRightOutlined rotate="90" className="mr-2" />
+                    <FormattedMessage id="advanced.search" />
                   </>
                 )}
               </Button>

--- a/services/frontend/src/components/searchBar/SearchBarView.jsx
+++ b/services/frontend/src/components/searchBar/SearchBarView.jsx
@@ -9,7 +9,6 @@ import {
   Form,
   Input,
   Switch,
-  Divider,
   Checkbox,
   TreeSelect,
 } from "antd";
@@ -80,7 +79,7 @@ const SearchBarView = ({
           size="large"
           type="primary"
           htmlType="submit"
-          icon={<SearchOutlined />}
+          icon={<SearchOutlined aria-hidden="true" />}
           className="search-submitBtn"
         >
           {searchLabel}
@@ -105,7 +104,7 @@ const SearchBarView = ({
       return null;
     }
     return (
-      <div style={{ marginBottom: "0" }}>
+      <div>
         <Row style={{ padding: "20px 5% 0px 5%" }}>
           <Col span={24} style={{ padding: "0px 0" }}>
             <Title level={2} style={{ fontSize: "1.3em" }}>
@@ -270,7 +269,6 @@ const SearchBarView = ({
             <FormattedMessage id="clear.changes" />
           </Button>
         </div>
-        <Divider className="my-2" />
       </div>
     );
   };
@@ -296,8 +294,6 @@ const SearchBarView = ({
           {getBasicSearchForm(!expandAdvancedSearch)}
         </div>
         <div className="search-advSearchCard">
-          {/* Gets fields for Advanced Search in collapse */}
-          {getAdvancedSearchForm(expandAdvancedSearch)}
           {/* expand advance search btn */}
           <Row>
             <Col span={24} className="search-advFieldPlacement">
@@ -307,21 +303,19 @@ const SearchBarView = ({
                 style={{ fontSize: 15 }}
                 tabIndex={0}
                 size="middle"
+                aria-expanded={expandAdvancedSearch}
               >
-                {expandAdvancedSearch ? (
-                  <>
-                    <DoubleRightOutlined rotate="270" className="mr-2" />
-                    <FormattedMessage id="basic.search" />
-                  </>
-                ) : (
-                  <>
-                    <DoubleRightOutlined rotate="90" className="mr-2" />
-                    <FormattedMessage id="advanced.search" />
-                  </>
-                )}
+                <DoubleRightOutlined
+                  rotate={expandAdvancedSearch ? "270" : "90"}
+                  className="mr-2"
+                  aria-hidden="true"
+                />
+                <FormattedMessage id="advanced.search" />
               </Button>
             </Col>
           </Row>
+          {/* Gets fields for Advanced Search in collapse */}
+          {getAdvancedSearchForm(expandAdvancedSearch)}
         </div>
       </div>
     </Form>

--- a/services/frontend/src/components/searchBar/SearchBarView.less
+++ b/services/frontend/src/components/searchBar/SearchBarView.less
@@ -28,10 +28,6 @@
     margin-left: 8px;
     margin-top: 10px;
   }
-  &-advFieldStyles {
-    text-align: center;
-    margin-top: 10px;
-  }
   &-advSearchCard {
     padding: 10px;
     background-color: #fff;

--- a/services/frontend/src/components/searchBar/SearchBarView.less
+++ b/services/frontend/src/components/searchBar/SearchBarView.less
@@ -1,49 +1,57 @@
-.search-outerForm {
-  width: 100%;
-  padding-top: 80px !important;
-}
-.search-outerDiv {
-  width: 90%;
-  max-width: 1100px;
-  margin: auto;
-  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
-}
-.search-mainSearchDiv {
-  background-color: rgb(25, 46, 47);
-  border-radius: 5px 5px 0 0;
-  padding: 50px 80px 40px 80px;
-  text-align: center;
-}
-.search-mainSearchField {
-  margin: 30px 10px 10px 10px;
-}
-.search-submitBtn {
-  margin-left: 8px;
-  width: 100%;
-  max-width: 200px;
-  margin-top: 10px;
-}
-.search-clearBtn {
-  margin-left: 8px;
-  margin-top: 10px;
-}
-.search-advFieldStyles {
-  text-align: center;
-  margin-top: 10px;
-}
-.search-advSearchCard {
-  padding: 10px;
-  background-color: #fff;
-  border-radius: 0 0 5px 5px;
-}
-.search-advFieldPlacement {
-  text-align: center;
-}
-.search-alert {
-  font-size: 14px;
-  text-align: center;
-  margin: 0 auto;
-  width: 300px;
+.search {
+  &-outerForm {
+    width: 100%;
+    padding-top: 80px !important;
+  }
+  &-outerDiv {
+    width: 90%;
+    max-width: 1100px;
+    margin: auto;
+    box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
+  }
+  &-mainSearchDiv {
+    background-color: rgb(25, 46, 47);
+    border-radius: 5px 5px 0 0;
+    padding: 50px 80px 40px 80px;
+    text-align: center;
+  }
+  &-mainSearchField {
+    margin: 30px 10px 10px 10px;
+  }
+  &-submitBtn {
+    margin-left: 8px;
+    width: 100%;
+    max-width: 200px;
+    margin-top: 10px;
+  }
+  &-clearBtn {
+    margin-left: 8px;
+    margin-top: 10px;
+  }
+  &-advFieldStyles {
+    text-align: center;
+    margin-top: 10px;
+  }
+  &-advSearchCard {
+    padding: 10px;
+    background-color: #fff;
+    border-radius: 0 0 5px 5px;
+  }
+  &-advFieldPlacement {
+    text-align: center;
+  }
+  &-alert {
+    font-size: 14px;
+    text-align: center;
+    margin: 0 auto;
+    width: 300px;
+  }
+
+  &-advancedSearchBtns {
+    width: 100%;
+    text-align: center;
+    margin: 0px 0 30px 0;
+  }
 }
 
 .searchValue {

--- a/services/frontend/src/components/searchBar/SearchBarView.less
+++ b/services/frontend/src/components/searchBar/SearchBarView.less
@@ -36,22 +36,11 @@
   &-advFieldPlacement {
     text-align: center;
   }
-  &-alert {
-    font-size: 14px;
-    text-align: center;
-    margin: 0 auto;
-    width: 300px;
-  }
-
   &-advancedSearchBtns {
     width: 100%;
     text-align: center;
     margin: 0px 0 30px 0;
   }
-}
-
-.searchValue {
-  width: 100%;
 }
 
 .searchLabel {


### PR DESCRIPTION
#### ⭐ Changes introduced
- reorganized advanced search form for better/easier tabbing 
- added "aria-expanded" when expanding advanced search
- removed unused styling
- implement "react-select" for dropdowns

#### 🔗 Related issue(s)
no related issues

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/127227840-ae27c16e-53ec-40ac-ad87-cbbc961489dd.png)

#### ☑️ Checklist

If the UI has been modified:
- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:
- [ ] run `yarn i18n:validate" and clear errors
