### PR TITLE
[Fix] filter by branch bug when translating branch names

### DIFF
--- a/services/backend/src/core/options/util/branches.js
+++ b/services/backend/src/core/options/util/branches.js
@@ -9,8 +9,12 @@ async function getBranches(request, response) {
       language,
     },
     select: {
-      id: true,
       branch: true,
+      employmentInfo: {
+        select: {
+          id: true,
+        },
+      },
     },
     orderBy: {
       branch: "asc",
@@ -20,7 +24,7 @@ async function getBranches(request, response) {
   const branchesQueryUniq = _.sortedUniqBy(branchesQuery, "branch");
 
   const responseData = branchesQueryUniq.map((branch) => ({
-    value: branch.id,
+    value: branch.employmentInfo.id,
     label: branch.branch,
   }));
 

--- a/services/backend/src/core/search/search.js
+++ b/services/backend/src/core/search/search.js
@@ -41,7 +41,7 @@ async function filterSearch(request, response) {
   }
 
   if (branches) {
-    results = await utils.branchSearch(results, branches);
+    results = await utils.branchSearch(results, branches, language);
   }
 
   if (locations) {

--- a/services/backend/src/core/search/util/branchSearch.js
+++ b/services/backend/src/core/search/util/branchSearch.js
@@ -6,10 +6,9 @@ async function branchSearch(profiles, branchArray, language) {
     branchArray.map(async (employmentInfoId) => {
       const branchNameFound = await prisma.employmentInfo.findUnique({
         where: {
-          id: employmentInfoId,
+          id: "employmentInfoId",
         },
         select: {
-          id: true,
           translations: {
             where: {
               language,

--- a/services/backend/src/core/search/util/branchSearch.js
+++ b/services/backend/src/core/search/util/branchSearch.js
@@ -19,7 +19,6 @@ async function branchSearch(profiles, branchArray, language) {
           },
         },
       });
-      s;
       return branchNameFound && branchNameFound.translations[0].branch;
     })
   );

--- a/services/backend/src/core/search/util/branchSearch.js
+++ b/services/backend/src/core/search/util/branchSearch.js
@@ -6,7 +6,7 @@ async function branchSearch(profiles, branchArray, language) {
     branchArray.map(async (employmentInfoId) => {
       const branchNameFound = await prisma.employmentInfo.findUnique({
         where: {
-          id: "employmentInfoId",
+          id: employmentInfoId,
         },
         select: {
           translations: {
@@ -19,6 +19,7 @@ async function branchSearch(profiles, branchArray, language) {
           },
         },
       });
+      s;
       return branchNameFound && branchNameFound.translations[0].branch;
     })
   );

--- a/services/backend/src/core/search/util/branchSearch.js
+++ b/services/backend/src/core/search/util/branchSearch.js
@@ -1,6 +1,32 @@
-async function branchSearch(profiles, branchArray) {
+const prisma = require("../../../database");
+
+async function branchSearch(profiles, branchArray, language) {
+  // find the name of the branches in the DB based on the array of selected employmentInfo ID from frontend and language
+  const branchesFoundInDB = await Promise.all(
+    branchArray.map(async (employmentInfoId) => {
+      const branchNameFound = await prisma.employmentInfo.findUnique({
+        where: {
+          id: employmentInfoId,
+        },
+        select: {
+          id: true,
+          translations: {
+            where: {
+              language,
+            },
+            select: {
+              branch: true,
+            },
+          },
+        },
+      });
+      return branchNameFound && branchNameFound.translations[0].branch;
+    })
+  );
+
   return profiles.filter(
-    (profile) => profile.branch && branchArray.includes(profile.branch.name)
+    (profile) =>
+      profile.branch && branchesFoundInDB.includes(profile.branch.name)
   );
 }
 

--- a/services/backend/tests/src/api/options/branches.test.js
+++ b/services/backend/tests/src/api/options/branches.test.js
@@ -21,25 +21,55 @@ describe(`GET ${path}`, () => {
       [
         "ENGLISH",
         [
-          { branch: "Z Data" },
-          { branch: "Human Resources Branch" },
-          { branch: "Chief Information Office" },
-          { branch: "Human Resources Branch" },
+          {
+            branch: "Chief Information Office",
+          },
+          {
+            branch: "Human Resources Branch",
+          },
+          {
+            branch: "Human Resources Branch",
+          },
+          {
+            branch: "Z Data",
+          },
         ],
-        ["Chief Information Office", "Human Resources Branch", "Z Data"],
+        [
+          {
+            value: "Chief Information Office",
+            label: "Chief Information Office",
+          },
+          {
+            value: "Human Resources Branch",
+            label: "Human Resources Branch",
+          },
+          {
+            value: "Z Data",
+            label: "Z Data",
+          },
+        ],
       ],
       [
         "FRENCH",
         [
-          { branch: "Y Data" },
-          { branch: "Direction générale des ressources humaines" },
           { branch: "Bureau principal de l'information" },
           { branch: "Direction générale des ressources humaines" },
+          { branch: "Direction générale des ressources humaines" },
+          { branch: "Y Data" },
         ],
         [
-          "Bureau principal de l'information",
-          "Direction générale des ressources humaines",
-          "Y Data",
+          {
+            value: "Bureau principal de l'information",
+            label: "Bureau principal de l'information",
+          },
+          {
+            value: "Direction générale des ressources humaines",
+            label: "Direction générale des ressources humaines",
+          },
+          {
+            value: "Y Data",
+            label: "Y Data",
+          },
         ],
       ],
     ];
@@ -70,7 +100,6 @@ describe(`GET ${path}`, () => {
             language,
           },
           select: {
-            id: true,
             branch: true,
           },
           orderBy: {

--- a/services/backend/tests/src/api/options/branches.test.js
+++ b/services/backend/tests/src/api/options/branches.test.js
@@ -23,28 +23,46 @@ describe(`GET ${path}`, () => {
         [
           {
             branch: "Chief Information Office",
+            employmentInfo: {
+              id: "f412610e-0427-4e45-85ad-9eadc983ca83",
+            },
           },
           {
             branch: "Human Resources Branch",
+            employmentInfo: {
+              id: "2222222222222222222",
+            },
           },
           {
             branch: "Human Resources Branch",
+            employmentInfo: {
+              id: "2222222222222222222",
+            },
+          },
+          {
+            branch: "Human Resources Branch",
+            employmentInfo: {
+              id: "5555555555555555555555555",
+            },
           },
           {
             branch: "Z Data",
+            employmentInfo: {
+              id: "44444444444444444444444444",
+            },
           },
         ],
         [
           {
-            value: "Chief Information Office",
+            value: "f412610e-0427-4e45-85ad-9eadc983ca83",
             label: "Chief Information Office",
           },
           {
-            value: "Human Resources Branch",
+            value: "2222222222222222222",
             label: "Human Resources Branch",
           },
           {
-            value: "Z Data",
+            value: "44444444444444444444444444",
             label: "Z Data",
           },
         ],
@@ -52,22 +70,48 @@ describe(`GET ${path}`, () => {
       [
         "FRENCH",
         [
-          { branch: "Bureau principal de l'information" },
-          { branch: "Direction générale des ressources humaines" },
-          { branch: "Direction générale des ressources humaines" },
-          { branch: "Y Data" },
+          {
+            branch: "Bureau principal de l'information",
+            employmentInfo: {
+              id: "f412610e-0427-4e45-85ad-9eadc983ca83",
+            },
+          },
+          {
+            branch: "Direction générale des ressources humaines",
+            employmentInfo: {
+              id: "44444444444444444444444444",
+            },
+          },
+          {
+            branch: "Direction générale des ressources humaines",
+            employmentInfo: {
+              id: "44444444444444444444444444",
+            },
+          },
+          {
+            branch: "Direction générale des ressources humaines",
+            employmentInfo: {
+              id: "5555555555555555555555555",
+            },
+          },
+          {
+            branch: "Y Data",
+            employmentInfo: {
+              id: "1111111111111111111111111",
+            },
+          },
         ],
         [
           {
-            value: "Bureau principal de l'information",
+            value: "f412610e-0427-4e45-85ad-9eadc983ca83",
             label: "Bureau principal de l'information",
           },
           {
-            value: "Direction générale des ressources humaines",
+            value: "44444444444444444444444444",
             label: "Direction générale des ressources humaines",
           },
           {
-            value: "Y Data",
+            value: "1111111111111111111111111",
             label: "Y Data",
           },
         ],
@@ -101,6 +145,11 @@ describe(`GET ${path}`, () => {
           },
           select: {
             branch: true,
+            employmentInfo: {
+              select: {
+                id: true,
+              },
+            },
           },
           orderBy: {
             branch: "asc",

--- a/services/backend/tests/src/api/search/allProfileData.json
+++ b/services/backend/tests/src/api/search/allProfileData.json
@@ -74,6 +74,7 @@
         "name": "CS 03"
       },
       "employmentInfo": {
+        "id": "2222",
         "translations": [
           {
             "branch": "Chief Information Office",
@@ -398,9 +399,9 @@
       {
         "testTitle": "Filter Search Test: searching for Branch",
         "testDescription": "If 'branch' is set to a value then only the matching profile should be returned",
-        "testSearchTerm": "Human Resources Branch",
+        "testSearchTerm": "2222",
         "testResponseCode": 200,
-        "testResponseData": "[{\"id\":\"a041bceb-3873-4046-a475-a86dda954402\",\"avatarColor\":\"#ad4463\",\"firstName\":\"Mary\",\"lastName\":\"Doe\",\"isConnection\":false,\"jobTitle\":\"Manager\",\"branch\":\"Human Resources Branch\",\"officeLocation\":{\"id\":\"764be692-6bec-421e-a411-485477206fc8\",\"city\":\"Ottawa\",\"streetNumber\":160,\"province\":\"Ontario\",\"streetName\":\"Elgin St\",\"fullName\":\"160 Elgin St\"},\"skills\":[],\"totalSkillsCount\":0,\"groupLevel\":{\"id\":\"84cf48eb-38b4-4a33-9744-09a9da7923a3\",\"name\":\"CS 05\"},\"nameInitials\":\"MD\",\"status\":\"ACTIVE\"}]"
+        "testResponseData": "[{\"id\":\"25ba7914-1505-4806-97f9-e1c4b003ad92\",\"avatarColor\":\"#0bdaa3\",\"firstName\":\"John\",\"lastName\":\"Doe\",\"isConnection\":false,\"jobTitle\":\"Data Scientist\",\"branch\":\"Chief Information Office\",\"officeLocation\":{\"id\":\"282952e2-787a-4ee9-8b0e-234776f21673\",\"city\":\"Ottawa\",\"streetNumber\":235,\"province\":\"Ontario\",\"streetName\":\"Queen St\",\"fullName\":\"235 Queen St\"},\"skills\":[{\"id\":\"477d4291-fcbf-4c7a-b377-7fc160fafeff\",\"name\":\"CGI\"},{\"id\":\"7c72c804-0a69-4783-aa11-c39b37230b30\",\"name\":\"Linux\"},{\"id\":\"d5cb2222-1278-4ff0-b175-d4320f258fd2\",\"name\":\"Delegation\"}],\"totalSkillsCount\":4,\"groupLevel\":{\"id\":\"d78f0859-84af-4e46-884f-b15510e0b273\",\"name\":\"AS 04\"},\"nameInitials\":\"JD\",\"status\":\"ACTIVE\"}]"
       }
     ]
   }

--- a/services/backend/tests/src/api/search/filters.test.js
+++ b/services/backend/tests/src/api/search/filters.test.js
@@ -434,6 +434,8 @@ describe(`GET ${path}`, () => {
             .mockResolvedValueOnce(_testData.allProfilesInfo[0])
             .mockResolvedValueOnce(_testData.allProfilesInfo[1]);
 
+          prisma.employmentInfo.findUnique.mockResolvedValueOnce(null);
+
           let searchTerm = "zzzzzzzzzz";
 
           let res = await request(app)
@@ -451,6 +453,10 @@ describe(`GET ${path}`, () => {
           prisma.user.findUnique
             .mockResolvedValueOnce(_testData.allProfilesInfo[0])
             .mockResolvedValueOnce(_testData.allProfilesInfo[1]);
+
+          prisma.employmentInfo.findUnique.mockResolvedValueOnce({
+            translations: [{ branch: "Chief Information Office" }],
+          });
 
           let searchTerm = _testData.testParams.filterSearch[11].testSearchTerm;
 


### PR DESCRIPTION
#### ⭐ Changes introduced
- fix broken backend test
- branch filter now translates the selected options when the app language is changed by the user
- fix bug that occurred if the language was changed when the search was filtering by branch:
> because the "value" of the filter option was the string of the branch name and not a unique ID, when the language was changed when viewing the search results, the search results were not accurate because the backend was still filtering using the branch name in the previously selected language.


#### 🔗 Related issue(s)
closes #1574 

#### 📸 Screenshots (if applicable)
no UI chnages

#### ☑️ Checklist


Optional for now, since tests are not working correctly
- [x] Create tests for your changes
- [x] Make sure the tests are passing


