### PR TITLE
[Fix] react-select dropdown 'max selection' message not appearing

### DIFF
--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -212,10 +212,10 @@ const CustomDropdown = ({
     userSelectedOptions,
     isMultiSelect,
     maxSelectedLimit
-  ) => {
-    return isMultiSelect &&
-      maxSelectedLimit &&
-      userSelectedOptions.length >= maxSelectedLimit ? (
+  ) =>
+    isMultiSelect &&
+    maxSelectedLimit &&
+    userSelectedOptions.length >= maxSelectedLimit ? (
       <span role="alert">
         <InfoCircleOutlined aria-hidden="true" className="mr-1" />
         You have reached the max of {maxSelectedLimit} selected items
@@ -226,7 +226,6 @@ const CustomDropdown = ({
         No options available
       </span>
     );
-  };
   /**
    * Disable the selectable dropdown options when selected limit is reached
    *

--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -193,7 +193,7 @@ const CustomDropdown = ({
   ) =>
     isMultiSelect &&
     maxSelectedLimit &&
-    Array.isArray(maxSelectedLimit) &&
+    Array.isArray(userSelectedOptions) &&
     userSelectedOptions.length >= maxSelectedLimit
       ? []
       : providedOptions;
@@ -212,10 +212,10 @@ const CustomDropdown = ({
     userSelectedOptions,
     isMultiSelect,
     maxSelectedLimit
-  ) =>
-    isMultiSelect &&
-    maxSelectedLimit &&
-    userSelectedOptions.length >= maxSelectedLimit ? (
+  ) => {
+    return isMultiSelect &&
+      maxSelectedLimit &&
+      userSelectedOptions.length >= maxSelectedLimit ? (
       <span role="alert">
         <InfoCircleOutlined aria-hidden="true" className="mr-1" />
         You have reached the max of {maxSelectedLimit} selected items
@@ -226,7 +226,7 @@ const CustomDropdown = ({
         No options available
       </span>
     );
-
+  };
   /**
    * Disable the selectable dropdown options when selected limit is reached
    *


### PR DESCRIPTION
#### ⭐ Changes introduced
- fixed typo in variable name that prevented the 'max select' message from appearing in the the dropdown options.

#### 🔗 Related issue(s)
closes #1579 

#### 📸 Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/11470442/128038040-10abd733-2467-4a8c-adc5-6b9025a18fdc.png)

#### ☑️ Checklist

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
