### PR TITLE
[Fix] Remove tool tip and translation

### DIFF
--- a/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
+++ b/services/frontend/src/components/profileForms/careerManagementForm/CareerManagementFormView.jsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   notification,
   Button,
-  // Typography,
 } from "antd";
 import { PlusOutlined } from "@ant-design/icons";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -36,10 +35,8 @@ import LinkAttachment from "../linkAttachment/LinkAttachment";
 import QualifiedPoolsForm from "./qualifiedPoolsForm/QualifiedPoolsForm";
 import FormTitle from "../formTitle/FormTitle";
 import FormSubTitle from "../formSubTitle/FormSubTitle";
-import config from "../../../utils/runtimeConfig";
 import Fieldset from "../../fieldset/Fieldset";
 
-// const { Title } = Typography;
 const { Option } = Select;
 const { SHOW_CHILD } = TreeSelect;
 const { TabPane } = Tabs;
@@ -80,7 +77,6 @@ const CareerManagementFormView = ({
   const [selectedTab, setSelectedTab] = useState(1);
   const [tabErrorsBool, setTabErrorsBool] = useState({});
   const axios = useAxios();
-  const { drupalSite } = config;
 
   const { locale } = useSelector((state) => state.settings);
   const dispatch = useDispatch();
@@ -438,25 +434,6 @@ const CareerManagementFormView = ({
             >
               <FormSubTitle
                 title={<FormattedMessage id="developmental.goals" />}
-                popoverMessage={
-                  <FormattedMessage
-                    id="tooltip.extra.info.help"
-                    values={{
-                      helpUrl: (
-                        <a
-                          className="link"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          href={`${drupalSite}${
-                            locale === "ENGLISH" ? "en" : "fr"
-                          }help`}
-                        >
-                          <FormattedMessage id="footer.contact.link" />
-                        </a>
-                      ),
-                    }}
-                  />
-                }
                 extra={
                   <CardVisibilityToggle
                     visibleCards={profileInfo.visibleCards}
@@ -596,27 +573,6 @@ const CareerManagementFormView = ({
             >
               <FormSubTitle
                 title={<FormattedMessage id="career.interests" />}
-                popoverMessage={
-                  <>
-                    <FormattedMessage
-                      id="tooltip.extra.info.help"
-                      values={{
-                        helpUrl: (
-                          <a
-                            className="link"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            href={`${drupalSite}${
-                              locale === "ENGLISH" ? "en" : "fr"
-                            }help`}
-                          >
-                            <FormattedMessage id="footer.contact.link" />
-                          </a>
-                        ),
-                      }}
-                    />
-                  </>
-                }
                 extra={
                   <CardVisibilityToggle
                     visibleCards={profileInfo.visibleCards}

--- a/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
+++ b/services/frontend/src/components/profileForms/talentForm/TalentFormView.jsx
@@ -29,7 +29,6 @@ import filterOption from "../../../functions/filterSelectInput";
 import FormControlButton from "../formControlButtons/FormControlButtons";
 import FormTitle from "../formTitle/FormTitle";
 import FormSubTitle from "../formSubTitle/FormSubTitle";
-import config from "../../../utils/runtimeConfig";
 
 import "./TalentFormView.less";
 
@@ -66,7 +65,6 @@ const TalentFormView = ({
   const [loadedData, setLoadedData] = useState(false);
   const [selectedTab, setSelectedTab] = useState(1);
   const [tabErrorsBool, setTabErrorsBool] = useState([]);
-  const { drupalSite } = config;
   const { locale } = useSelector((state) => state.settings);
   const dispatch = useDispatch();
 
@@ -608,27 +606,6 @@ const TalentFormView = ({
                 <Col className="gutter-row" xs={24} md={24} lg={24} xl={24}>
                   <FormSubTitle
                     title={<FormattedMessage id="skills" />}
-                    popoverMessage={
-                      <>
-                        <FormattedMessage
-                          id="tooltip.extra.info.help"
-                          values={{
-                            helpUrl: (
-                              <a
-                                className="link"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                href={`${drupalSite}${
-                                  locale === "ENGLISH" ? "en" : "fr"
-                                }help`}
-                              >
-                                <FormattedMessage id="footer.contact.link" />
-                              </a>
-                            ),
-                          }}
-                        />
-                      </>
-                    }
                     extra={
                       <CardVisibilityToggle
                         visibleCards={profileInfo.visibleCards}
@@ -668,27 +645,6 @@ const TalentFormView = ({
                 <Col className="gutter-row" span={24}>
                   <FormSubTitle
                     title={<FormattedMessage id="mentorship.skills" />}
-                    popoverMessage={
-                      <>
-                        <FormattedMessage
-                          id="tooltip.extra.info.help"
-                          values={{
-                            helpUrl: (
-                              <a
-                                className="link"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                href={`${drupalSite}${
-                                  locale === "ENGLISH" ? "en" : "fr"
-                                }help`}
-                              >
-                                <FormattedMessage id="footer.contact.link" />
-                              </a>
-                            ),
-                          }}
-                        />
-                      </>
-                    }
                     extra={
                       <CardVisibilityToggle
                         visibleCards={profileInfo.visibleCards}
@@ -725,27 +681,6 @@ const TalentFormView = ({
                 <Col className="gutter-row" xs={24} md={24} lg={24} xl={24}>
                   <FormSubTitle
                     title={<FormattedMessage id="competencies" />}
-                    popoverMessage={
-                      <>
-                        <FormattedMessage
-                          id="tooltip.extra.info.help"
-                          values={{
-                            helpUrl: (
-                              <a
-                                className="link"
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                href={`${drupalSite}${
-                                  locale === "ENGLISH" ? "en" : "fr"
-                                }help`}
-                              >
-                                <FormattedMessage id="footer.contact.link" />
-                              </a>
-                            ),
-                          }}
-                        />
-                      </>
-                    }
                     extra={
                       <CardVisibilityToggle
                         visibleCards={profileInfo.visibleCards}

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -337,7 +337,6 @@
   "talent.matrix.result": "Talent matrix result",
   "team": "Team",
   "tenure": "Tenure",
-  "tooltip.extra.info.help": "For more information, visit {helpUrl}.",
   "total.ex.feeders": "Total EX-Feeders",
   "type": "Type",
   "type.and.enter": "Type and press enter to add custom option",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -337,7 +337,6 @@
   "talent.matrix.result": "Résultat de la matrice de talents",
   "team": "Équipe",
   "tenure": "Mandat",
-  "tooltip.extra.info.help": "Pour plus d’informations, consultez Aide/Contactez-nous",
   "total.ex.feeders": "Nombre total de relève des EX",
   "type": "Type",
   "type.and.enter": "Tapez et appuyez sur Entrée pour ajouter une option personnalisée",


### PR DESCRIPTION
#### ⭐ Changes introduced

<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
I removed the tooltips that have contact/help us tool tip 


I am unsure if I should also remove this tool this 
![image](https://user-images.githubusercontent.com/21133129/129131188-bb0d1a90-1ebe-4511-aa9d-9aed9845900a.png)
Please let me know. It was mentioned here but it doesn't have contact/help us 
![image](https://user-images.githubusercontent.com/21133129/129131228-2b15f894-30e0-419a-bdef-6438788a72bb.png)

#### 🔗 Related issue(s)

<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->
closes #1601

#### 📸 Screenshots (if applicable)

<!-- If you have made UI changes to the application, include a screenshot and if the change
     involves movement, include a GIF. If the UI changes when the application is in mobile view,
     show a mobile screenshot too. Include English and French versions for translation validation-->

#### ☑️ Checklist

If the database has been modified:

- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:

- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!--
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing
-->

If the UI has been modified:

- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:

- [ ] run `yarn i18n:validate" and clear errors
