### PR TITLE
Removed api/ prefix from the POST and DELETE requests inside ProfileActionRibbon

### DIFF
--- a/services/frontend/src/components/profileActionRibbon/ProfileActionRibbonView.jsx
+++ b/services/frontend/src/components/profileActionRibbon/ProfileActionRibbonView.jsx
@@ -34,12 +34,12 @@ const ProfileActionRibbonView = ({
   const changeConnection = async () => {
     if (isConnection) {
       await axios
-        .delete(`api/connections/${userId}`)
+        .delete(`connections/${userId}`)
         .catch((error) => handleError(error, "message", history));
       setIsConnection(false);
     } else {
       await axios
-        .post(`api/connections/${userId}`)
+        .post(`connections/${userId}`)
         .catch((error) => handleError(error, "message", history));
       setIsConnection(true);
     }


### PR DESCRIPTION
#### ⭐ Changes introduced

The POST and DELETE requests for adding/removing someone from your circle still had "api/" at the beginning of the addresses. I removed that prefix and the data now saves.

#### 🔗 Related issue(s)

closes #1679 

#### 📸 Screenshots (if applicable)

No UI changes.

#### ☑️ Checklist
