### PR TITLE
Null error fix when doing forEach on dataSource.secondLangProjs

### DIFF
--- a/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
+++ b/services/frontend/src/components/officialLanguage/OfficialLanguage.jsx
@@ -89,22 +89,24 @@ const OfficialLanguage = ({ data, editableCardBool }) => {
   const generateSecondLanguageInfo = (dataSource) => {
     const formattedLanguageInfo = [];
 
-    dataSource.secondLangProfs.forEach((item) => {
-      const formattedLangProficiencyItem = {};
-
-      formattedLangProficiencyItem.title = generateSecondLangProficiencyTitle(
-        item.proficiency
-      );
-      formattedLangProficiencyItem.level = generateSecondLangProficiencyLevel(
-        item.level
-      );
-      formattedLangProficiencyItem.status = generateSecondLangProficiencyStatus(
-        item.status
-      );
-
-      formattedLanguageInfo.push(formattedLangProficiencyItem);
-    });
-
+    if (dataSource.secondLangProfs) {
+      dataSource.secondLangProfs.forEach((item) => {
+        const formattedLangProficiencyItem = {};
+  
+        formattedLangProficiencyItem.title = generateSecondLangProficiencyTitle(
+          item.proficiency
+        );
+        formattedLangProficiencyItem.level = generateSecondLangProficiencyLevel(
+          item.level
+        );
+        formattedLangProficiencyItem.status = generateSecondLangProficiencyStatus(
+          item.status
+        );
+  
+        formattedLanguageInfo.push(formattedLangProficiencyItem);
+      });
+    }
+    
     return formattedLanguageInfo;
   };
 


### PR DESCRIPTION
#### ⭐ Changes introduced

Changes ensure that if `dataSource.secondLangProfs` is `null` or `undefined` instead of an array, the `forEach` method is not called on the variable which would result in a `Cannot read properties of null (reading 'forEach')` error.

#### 🔗 Related issue(s)

closes #1682 

#### 📸 Screenshots (if applicable)

No UI changes.

#### ☑️ Checklist