### PR TITLE
[Fix] GEDS error and ensured loading icon is not infinite

### DIFF
--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -111,7 +111,7 @@ async function getGedsSetup(request, response) {
     })),
   };
 
-  response.status(200).send(profile);
+  return response.status(200).send(profile);
 }
 
 module.exports = {

--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -37,6 +37,10 @@ async function getGedsSetup(request, response) {
     prisma.user.findUnique({ where: { id }, select: { email: true } }),
   ]);
 
+  if (!dataGEDSArray || !Array.isArray(dataGEDSArray)) {
+    return response.status(200).send({});
+  }
+
   const dataGEDS = dataGEDSArray.find(
     (element) => element.contactInformation.email === dataDBEmail
   );

--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -37,7 +37,11 @@ async function getGedsSetup(request, response) {
     prisma.user.findUnique({ where: { id }, select: { email: true } }),
   ]);
 
-  if (!dataGEDSArray || !Array.isArray(dataGEDSArray) || dataGEDSArray.length === 0) {
+  if (
+    !dataGEDSArray ||
+    !Array.isArray(dataGEDSArray) ||
+    dataGEDSArray.length === 0
+  ) {
     return response.status(200).send({});
   }
 

--- a/services/backend/src/core/geds/geds.js
+++ b/services/backend/src/core/geds/geds.js
@@ -37,7 +37,7 @@ async function getGedsSetup(request, response) {
     prisma.user.findUnique({ where: { id }, select: { email: true } }),
   ]);
 
-  if (!dataGEDSArray || !Array.isArray(dataGEDSArray)) {
+  if (!dataGEDSArray || !Array.isArray(dataGEDSArray) || dataGEDSArray.length === 0) {
     return response.status(200).send({});
   }
 

--- a/services/backend/tests/src/api/geds/geds.test.js
+++ b/services/backend/tests/src/api/geds/geds.test.js
@@ -185,7 +185,7 @@ describe(`GET ${path}`, () => {
       prisma.user.findUnique.mockReset();
     });
 
-    test("should trigger error if GEDS API returns an empty array - 500", async () => {
+    test("should return an empty object in res body if GEDS API returns an empty array", async () => {
       axios.mockResolvedValue({ data: [] });
       prisma.user.findUnique.mockResolvedValue({ email: "" });
 
@@ -193,9 +193,27 @@ describe(`GET ${path}`, () => {
         .get(`${path}?email=${faker.internet.email()}`)
         .set("Authorization", getBearerToken());
 
-      expect(res.statusCode).toBe(500);
-      expect(res.text).toBe("Internal Server Error");
-      expect(console.log).toHaveBeenCalled();
+      expect(res.body).toStrictEqual({});
+      expect(res.statusCode).toBe(200);
+      expect(console.log).not.toHaveBeenCalled();
+      expect(prisma.user.findUnique).toHaveBeenCalled();
+      expect(axios).toHaveBeenCalled();
+
+      axios.mockReset();
+      prisma.user.findUnique.mockReset();
+    });
+
+    test("should return an empty object in res body if GEDS API returns an empty string", async () => {
+      axios.mockResolvedValue({ data: "" });
+      prisma.user.findUnique.mockResolvedValue({ email: "" });
+
+      const res = await request(app)
+        .get(`${path}?email=${faker.internet.email()}`)
+        .set("Authorization", getBearerToken());
+
+      expect(res.body).toStrictEqual({});
+      expect(res.statusCode).toBe(200);
+      expect(console.log).not.toHaveBeenCalled();
       expect(prisma.user.findUnique).toHaveBeenCalled();
       expect(axios).toHaveBeenCalled();
 

--- a/services/frontend/src/components/profileForms/welcome/Welcome.jsx
+++ b/services/frontend/src/components/profileForms/welcome/Welcome.jsx
@@ -51,6 +51,7 @@ const Welcome = () => {
       });
       if (result.data) {
         setGedsProfiles(result.data);
+        setLoad(false);
       }
       return 1;
     };
@@ -58,8 +59,8 @@ const Welcome = () => {
     /* get all required data component */
     const getAllData = async () => {
       try {
-        await getGedsProfiles();
         setLoad(true);
+        await getGedsProfiles();
         return 1;
       } catch (error) {
         setLoad(false);

--- a/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
@@ -125,9 +125,9 @@ const WelcomeView = ({
       return (
         <div>
           {/* loading button */}
-          {generateProfileBtn({
+          {load && generateProfileBtn({
             firstTitle: intl.formatMessage({ id: "fetching.profiles" }),
-            icon: load ? <LoadingOutlined aria-hidden="true" /> : <ExclamationCircleOutlined aria-hidden="true" />,
+            icon: <LoadingOutlined aria-hidden="true" />,
             secondTitle: intl.formatMessage({
               id: "from.gcdirectory",
             }),

--- a/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
+++ b/services/frontend/src/components/profileForms/welcome/WelcomeView.jsx
@@ -121,13 +121,13 @@ const WelcomeView = ({
    */
   const generateGedsProfileList = () => {
     // check if GEDS profiles have loaded
-    if (!load || !gedsProfiles) {
+    if (!load || !gedsProfiles || Object.keys(gedsProfiles).length === 0) {
       return (
         <div>
           {/* loading button */}
           {generateProfileBtn({
             firstTitle: intl.formatMessage({ id: "fetching.profiles" }),
-            icon: <LoadingOutlined aria-hidden="true" />,
+            icon: load ? <LoadingOutlined aria-hidden="true" /> : <ExclamationCircleOutlined aria-hidden="true" />,
             secondTitle: intl.formatMessage({
               id: "from.gcdirectory",
             }),


### PR DESCRIPTION
#### ⭐ Changes introduced

I ensured that an empty object is returned if no geds profiles are found and the `Retrieving profiles` button disappears.

#### 🔗 Related issue(s)
closes #1684 
closes #1685 

<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->

#### 📸 Screenshots (if applicable)

Animation if no profiles are retrieved:
![24](https://user-images.githubusercontent.com/46769064/138325688-f7e27063-788a-4fc0-b962-98fe720b6a0f.gif)

#### ☑️ Checklist

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible