### PR TITLE
Updated gcconnex username placeholder

### DIFF
--- a/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
+++ b/services/frontend/src/components/profileForms/primaryInfoForm/PrimaryInfoFormView.jsx
@@ -556,7 +556,7 @@ const PrimaryInfoFormView = ({
                     aria-label={`${intl.formatMessage({
                       id: "gcconnex.username",
                     })} https://gcconnex.gc.ca/profile/`}
-                    placeholder={intl.formatMessage({ id: "username" })}
+                    placeholder={intl.formatMessage({ id: "gcconnex.username.placeholder" })}
                   />
                 </Form.Item>
               </Col>

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -156,6 +156,7 @@
   "from.gcdirectory": "from GCdirectory",
   "gcconnex": "GCconnex",
   "gcconnex.username": "GCconnex username",
+  "gcconnex.username.placeholder": "Example: first name.last name",
   "gcdirectory.sync": "GCdirectory Sync",
   "geds.edit.info": "If your GCdirectory information is not accurate, you can easily update your contact information through My User Profile. Instructions are available on My User Profile page. {instructionUrl} for instructions on updating your profile.",
   "geds.edit.info.link": "Update GCdirectory contact details form",

--- a/services/frontend/src/i18n/en_CA.json
+++ b/services/frontend/src/i18n/en_CA.json
@@ -156,7 +156,7 @@
   "from.gcdirectory": "from GCdirectory",
   "gcconnex": "GCconnex",
   "gcconnex.username": "GCconnex username",
-  "gcconnex.username.placeholder": "Example: first name.last name",
+  "gcconnex.username.placeholder": "Firstname.Lastname",
   "gcdirectory.sync": "GCdirectory Sync",
   "geds.edit.info": "If your GCdirectory information is not accurate, you can easily update your contact information through My User Profile. Instructions are available on My User Profile page. {instructionUrl} for instructions on updating your profile.",
   "geds.edit.info.link": "Update GCdirectory contact details form",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -156,7 +156,7 @@
   "from.gcdirectory": "de GCannuaire",
   "gcconnex": "GCconnex",
   "gcconnex.username": "Identifiant GCconnex",
-  "gcconnex.username.placeholder": "Example: first name.last name",
+  "gcconnex.username.placeholder": "Prénom.Nom",
   "gcdirectory.sync": "Synchroniser Gcconnex",
   "geds.edit.info": "Si vos renseignements figurant dans GCannuaire ne sont pas exacts, Mon profil d’utilisateur vous permet de mettre à jour vos coordonnées. Les instructions sont disponibles sur la page de Mon profil d’utilisateur. {instructionUrl} pour obtenir des instructions sur la mise à jour de votre profil.",
   "geds.edit.info.link": "Formulaire de mise à jour des coordonnées du GCannuaire",

--- a/services/frontend/src/i18n/fr_CA.json
+++ b/services/frontend/src/i18n/fr_CA.json
@@ -156,6 +156,7 @@
   "from.gcdirectory": "de GCannuaire",
   "gcconnex": "GCconnex",
   "gcconnex.username": "Identifiant GCconnex",
+  "gcconnex.username.placeholder": "Example: first name.last name",
   "gcdirectory.sync": "Synchroniser Gcconnex",
   "geds.edit.info": "Si vos renseignements figurant dans GCannuaire ne sont pas exacts, Mon profil d’utilisateur vous permet de mettre à jour vos coordonnées. Les instructions sont disponibles sur la page de Mon profil d’utilisateur. {instructionUrl} pour obtenir des instructions sur la mise à jour de votre profil.",
   "geds.edit.info.link": "Formulaire de mise à jour des coordonnées du GCannuaire",


### PR DESCRIPTION
#### ⭐ Changes introduced

Updated the placeholder for the gcconnex username input.

#### 🔗 Related issue(s)

closes #1704 

#### 📸 Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/46769064/141007073-1883b06b-61f0-4053-a560-c76f25958203.png)
![image](https://user-images.githubusercontent.com/46769064/141007176-ee9a3a93-5dd1-4a56-ba5e-7574823c37bd.png)

#### ☑️ Checklist

If the UI has been modified:

- [x] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [x] The modifications are tab friendly
- [x] It is accessible

If translations have been modified:

- [x] run `yarn i18n:validate" and clear errors
