### PR TITLE
[Fix] Fixed custom dropdown bug

### DIFF
--- a/services/frontend/src/components/formItems/CustomDropdown.jsx
+++ b/services/frontend/src/components/formItems/CustomDropdown.jsx
@@ -89,7 +89,7 @@ const CustomDropdown = ({
 
     return (
       FORMATTED_DROPDOWN_OPTIONS &&
-      savedValues &&
+      (savedValues || savedValues === false) &&
       FORMATTED_DROPDOWN_OPTIONS.find((option) => option.value === savedValues)
     );
   };


### PR DESCRIPTION
#### ⭐ Changes introduced

Fixed custom dropdown bug where if `savedValues` is the boolean `false` (representing the value "No"), then it returns the label and value.

#### 🔗 Related issue(s)

closes #1711 

#### 📸 Screenshots (if applicable)

No UI changes.

#### ☑️ Checklist
