### PR TITLE
[Fix] Remove middleware chaining from app.use()

### DIFF
--- a/services/backend/src/server.js
+++ b/services/backend/src/server.js
@@ -26,15 +26,15 @@ if (config.ENV === "development") {
   app.use("/api-docs", swaggerUi.serve, swaggerOptions);
 }
 
-app.use(
-  cors(),
-  helmet(),
-  sessionInstance,
-  timeout("5s"),
-  keycloak.middleware(),
-  bodyParser.urlencoded({ extended: true }),
-  bodyParser.json()
-);
+app.use(cors());
+app.use(helmet());
+app.use(sessionInstance);
+app.use(timeout("5s"));
+app.use(keycloak.middleware());
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+
+app.disable("x-powered-by");
 
 app.use("/api", router);
 app.use(keycloak.middleware({ logout: "/" }), errorHandler);


### PR DESCRIPTION
#### ⭐ Changes introduced

<!-- Explain briefly in a small paragraph or in bullet form the changes this PR brings to
     the application -->
This pr removes the middleware changing from the app.use in express in attempt to fix the security hotspots.
#### 🔗 Related issue(s)

<!-- If this PR fixes/closes an issue, please prepend that issue number with one of the github
     closing keywords (ex: `fixes`, `closes`, ...) -->

#### 📸 Screenshots (if applicable)

<!-- If you have made UI changes to the application, include a screenshot and if the change
     involves movement, include a GIF. If the UI changes when the application is in mobile view,
     show a mobile screenshot too. Include English and French versions for translation validation-->

#### ☑️ Checklist

If the database has been modified:

- [ ] Update database diagram <!-- Updated diagram located in the backend, at `./src/docs/I-Talent database.xml`, with draw.io and updated the png image at `./src/docs/I-Talent database.png` -->
- [ ] Create new migration <!-- Ran `yarn migrate:create` in backend docker container -->

If API endpoints has been modified:

- [ ] Update backend documentation <!-- Updated corresponding swagger documentation in the routers -->
- [ ] Create/Update validators for the API endpoints <!-- Restrict and sanitize user input in the routers with express-validator.github.io -->
- [ ] The API endpoints are properly secured with keycloak
<!-- Use the `keycloak.protect(roleName)` express middleware in the routes -->

<!--
Optional for now, since tests are not working correctly
- [ ] Create tests for your changes
- [ ] Make sure the tests are passing
-->

If the UI has been modified:

- [ ] It is translated in both language (with no hard coded text) <!-- To sort the keys and remove unused keys in the translation files, run `yarn i18n:cleanup` -->
- [ ] The modifications are tab friendly
- [ ] It is accessible

If translations have been modified:

- [ ] run `yarn i18n:validate" and clear errors
